### PR TITLE
reactive.Value -> reactive.value

### DIFF
--- a/examples/moduleapp/app.py
+++ b/examples/moduleapp/app.py
@@ -18,7 +18,7 @@ def counter_ui(
 
 
 def counter_server(input: ModuleInputs, output: ModuleOutputs, session: ModuleSession):
-    count: reactive.Value[int] = reactive.Value(0)
+    count: reactive.value[int] = reactive.value(0)
 
     @reactive.effect()
     @event(input.button)

--- a/examples/myapp/app.py
+++ b/examples/myapp/app.py
@@ -19,7 +19,7 @@ app_ui = ui.page_fluid(
 )
 
 # A ReactiveVal which is shared across all sessions.
-shared_val = reactive.Value(None)
+shared_val = reactive.value(None)
 
 
 def server(input: Inputs, output: Outputs, session: Session):

--- a/examples/simple/app.py
+++ b/examples/simple/app.py
@@ -5,8 +5,8 @@ app_ui = ui.page_fluid(
     ui.output_text_verbatim("txt", placeholder=True),
 )
 
-# A reactive.Value which is exists outside of the session.
-shared_val = reactive.Value(None)
+# A reactive.value which is exists outside of the session.
+shared_val = reactive.value(None)
 
 
 def server(input: Inputs, output: Outputs, session: Session):

--- a/shiny/modules.py
+++ b/shiny/modules.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Optional
 
 from htmltools.core import TagChildArg
 
-from .reactive import Value
+from .reactive import value
 from .render import RenderFunction
 from .session import Inputs, Outputs, Session
 from .session._utils import require_active_session
@@ -23,24 +23,24 @@ class ModuleInputs(Inputs):
     def _ns_key(self, key: str) -> str:
         return self._ns + "-" + key
 
-    def __setitem__(self, key: str, value: Value[Any]) -> None:
+    def __setitem__(self, key: str, value: value[Any]) -> None:
         self._values[self._ns_key(key)].set(value)
 
-    def __getitem__(self, key: str) -> Value[Any]:
+    def __getitem__(self, key: str) -> value[Any]:
         return self._values[self._ns_key(key)]
 
     def __delitem__(self, key: str) -> None:
         del self._values[self._ns_key(key)]
 
     # Allow access of values as attributes.
-    def __setattr__(self, attr: str, value: Value[Any]) -> None:
+    def __setattr__(self, attr: str, value: value[Any]) -> None:
         if attr in ("_values", "_ns", "_ns_key"):
             object.__setattr__(self, attr, value)
             return
         else:
             self.__setitem__(attr, value)
 
-    def __getattr__(self, attr: str) -> Value[Any]:
+    def __getattr__(self, attr: str) -> value[Any]:
         if attr in ("_values", "_ns", "_ns_key"):
             return object.__getattribute__(self, attr)
         else:

--- a/shiny/reactive/__init__.py
+++ b/shiny/reactive/__init__.py
@@ -4,7 +4,7 @@ from ._reactives import *
 __all__ = (
     "flush",
     "on_flushed",
-    "Value",
+    "value",
     "calc",
     "effect",
     "isolate",

--- a/shiny/reactive/_reactives.py
+++ b/shiny/reactive/_reactives.py
@@ -1,6 +1,6 @@
 """Reactive components"""
 
-__all__ = ("Value", "Calc", "CalcAsync", "calc", "Effect", "EffectAsync", "effect")
+__all__ = ("value", "Calc", "CalcAsync", "calc", "Effect", "EffectAsync", "effect")
 
 import traceback
 from typing import (
@@ -25,9 +25,9 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 # ==============================================================================
-# Value
+# value
 # ==============================================================================
-class Value(Generic[T]):
+class value(Generic[T]):
     def __init__(self, value: T, *, _read_only: bool = False) -> None:
         self._value: T = value
         self._read_only: bool = _read_only
@@ -45,12 +45,12 @@ class Value(Generic[T]):
     def set(self, value: T) -> bool:
         if self._read_only:
             raise RuntimeError(
-                "Can't set read-only Value. If you are trying to set an input value, use `update_xxx()` instead."
+                "Can't set read-only reactive.value. If you are trying to set an input value, use `update_xxx()` instead."
             )
         return self._set(value)
 
-    # The ._set() method allows setting read-only Value objects. This is used when the
-    # Value is part of a session.Inputs object, and the session wants to set it.
+    # The ._set() method allows setting read-only value objects. This is used when the
+    # value is part of a session.Inputs object, and the session wants to set it.
     def _set(self, value: T) -> bool:
         if self._value is value:
             return False

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1,12 +1,12 @@
 """Tests for `Module`."""
 
 import pytest
+from htmltools import TagChildArg
 
 from shiny import *
-from shiny.modules import *
 from shiny._utils import Callable
-from shiny.reactive import isolate
-from htmltools import TagChildArg
+from shiny.modules import *
+from shiny.reactive import isolate, effect
 
 
 def mod_ui(ns: Callable[[str], str]) -> TagChildArg:
@@ -18,7 +18,7 @@ def mod_ui(ns: Callable[[str], str]) -> TagChildArg:
 
 # Note: We currently can't test Session; this is just here for future use.
 def mod_server(input: ModuleInputs, output: ModuleOutputs, session: ModuleSession):
-    count: Value[int] = Value(0)
+    count: reactive.value[int] = reactive.value(0)
 
     @effect()
     @event(session.input.button)

--- a/tests/test_reactives.py
+++ b/tests/test_reactives.py
@@ -20,8 +20,8 @@ async def test_flush_runs_newly_invalidated():
     flush.
     """
 
-    v1 = Value(1)
-    v2 = Value(2)
+    v1 = value(1)
+    v2 = value(2)
 
     v2_result = None
 
@@ -49,8 +49,8 @@ async def test_flush_runs_newly_invalidated_async():
     flush. (Same as previous test, but async.)
     """
 
-    v1 = Value(1)
-    v2 = Value(2)
+    v1 = value(1)
+    v2 = value(2)
 
     v2_result = None
 
@@ -72,11 +72,11 @@ async def test_flush_runs_newly_invalidated_async():
 
 
 # ======================================================================
-# Setting Value to same value doesn't invalidate downstream
+# Setting reactive.value to same value doesn't invalidate downstream
 # ======================================================================
 @pytest.mark.asyncio
 async def test_reactive_value_same_no_invalidate():
-    v = Value(1)
+    v = value(1)
 
     @effect()
     def o():
@@ -95,7 +95,7 @@ async def test_reactive_value_same_no_invalidate():
 # ======================================================================
 @pytest.mark.asyncio
 async def test_recursive_calc():
-    v = Value(5)
+    v = value(5)
 
     @calc()
     def r():
@@ -117,7 +117,7 @@ async def test_recursive_calc():
 
 @pytest.mark.asyncio
 async def test_recursive_async_calc():
-    v = Value(5)
+    v = value(5)
 
     @calc()
     async def r():
@@ -144,7 +144,7 @@ async def test_recursive_async_calc():
 
 @pytest.mark.asyncio
 async def test_async_sequential():
-    x: Value[int] = Value(1)
+    x: value[int] = value(1)
     results: list[int] = []
     exec_order: list[str] = []
 
@@ -192,8 +192,8 @@ async def test_async_sequential():
 # ======================================================================
 @pytest.mark.asyncio
 async def test_isolate_basic_without_context():
-    # isolate() works with calc and Value; allows executing without a reactive context.
-    v = Value(1)
+    # isolate() works with calc and value; allows executing without a reactive context.
+    v = value(1)
 
     @calc()
     def r():
@@ -212,13 +212,13 @@ async def test_isolate_basic_without_context():
 
 @pytest.mark.asyncio
 async def test_isolate_prevents_dependency():
-    v = Value(1)
+    v = value(1)
 
     @calc()
     def r():
         return v() + 10
 
-    v_dep = Value(1)  # Use this only for invalidating the effect
+    v_dep = value(1)  # Use this only for invalidating the effect
     o_val = None
 
     @effect()
@@ -258,9 +258,9 @@ async def test_isolate_async_basic_value():
 
 @pytest.mark.asyncio
 async def test_isolate_async_basic_without_context():
-    # async isolate works with calc and Value; allows executing without a reactive
+    # async isolate works with calc and value; allows executing without a reactive
     # context.
-    v = Value(1)
+    v = value(1)
 
     @calc()
     async def r():
@@ -276,13 +276,13 @@ async def test_isolate_async_basic_without_context():
 
 @pytest.mark.asyncio
 async def test_isolate_async_prevents_dependency():
-    v = Value(1)
+    v = value(1)
 
     @calc()
     async def r():
         return v() + 10
 
-    v_dep = Value(1)  # Use this only for invalidating the effect
+    v_dep = value(1)  # Use this only for invalidating the effect
     o_val = None
 
     @effect()
@@ -313,7 +313,7 @@ async def test_isolate_async_prevents_dependency():
 # ======================================================================
 @pytest.mark.asyncio
 async def test_effect_priority():
-    v = Value(1)
+    v = value(1)
     results: list[int] = []
 
     @effect(priority=1)
@@ -364,7 +364,7 @@ async def test_effect_priority():
 # Same as previous, but with async
 @pytest.mark.asyncio
 async def test_async_effect_priority():
-    v = Value(1)
+    v = value(1)
     results: list[int] = []
 
     @effect(priority=1)
@@ -417,7 +417,7 @@ async def test_async_effect_priority():
 # ======================================================================
 @pytest.mark.asyncio
 async def test_effect_destroy():
-    v = Value(1)
+    v = value(1)
     results: list[int] = []
 
     @effect()
@@ -435,7 +435,7 @@ async def test_effect_destroy():
     assert results == [1]
 
     # Same as above, but destroy before running first time
-    v = Value(1)
+    v = value(1)
     results: list[int] = []
 
     @effect()
@@ -503,7 +503,7 @@ async def test_error_handling():
 async def test_calc_error_rethrow():
     # Make sure calcs re-throw errors.
     vals: List[str] = []
-    v = Value(1)
+    v = value(1)
 
     @calc()
     def r():
@@ -540,8 +540,8 @@ async def test_calc_error_rethrow():
 # For https://github.com/rstudio/prism/issues/26
 @pytest.mark.asyncio
 async def test_dependent_invalidation():
-    trigger = Value(0)
-    v = Value(0)
+    trigger = value(0)
+    v = value(0)
     error_occurred = False
 
     @effect()
@@ -665,7 +665,7 @@ async def test_invalidate_later():
 async def test_invalidate_later_invalidation():
     mock_time = MockTime()
     with mock_time():
-        rv = Value(0)
+        rv = value(0)
 
         @effect()
         def obs1():
@@ -750,7 +750,7 @@ async def test_event_decorator():
     assert n_times == 2
 
     # Is invalidated properly by reactive values
-    v = Value(1)
+    v = value(1)
 
     @effect()
     @event(v)
@@ -770,7 +770,7 @@ async def test_event_decorator():
     assert n_times == 4
 
     # Doesn't run on init
-    v = Value(1)
+    v = value(1)
 
     @effect()
     @event(v, ignore_init=True)
@@ -786,8 +786,8 @@ async def test_event_decorator():
     assert n_times == 5
 
     # Isolates properly
-    v = Value(1)
-    v2 = Value(1)
+    v = value(1)
+    v2 = value(1)
 
     @effect()
     @event(v)
@@ -803,7 +803,7 @@ async def test_event_decorator():
     assert n_times == 6
 
     # works with @calc()
-    v2 = Value(1)
+    v2 = value(1)
 
     @calc()
     @event(lambda: v2(), ignore_init=True)
@@ -861,7 +861,7 @@ async def test_event_async_decorator():
     assert n_times == 2
 
     # Is invalidated properly by reactive values
-    v = Value(1)
+    v = value(1)
 
     @effect()
     @event(v)
@@ -881,7 +881,7 @@ async def test_event_async_decorator():
     assert n_times == 4
 
     # Doesn't run on init
-    v = Value(1)
+    v = value(1)
 
     @effect()
     @event(v, ignore_init=True)
@@ -897,8 +897,8 @@ async def test_event_async_decorator():
     assert n_times == 5
 
     # Isolates properly
-    v = Value(1)
-    v2 = Value(1)
+    v = value(1)
+    v2 = value(1)
 
     @effect()
     @event(v)
@@ -914,7 +914,7 @@ async def test_event_async_decorator():
     assert n_times == 6
 
     # works with @calc()
-    v2 = Value(1)
+    v2 = value(1)
 
     @calc()
     async def r_a():
@@ -946,7 +946,7 @@ async def test_event_async_decorator():
 # ------------------------------------------------------------
 @pytest.mark.asyncio
 async def test_effect_pausing():
-    a = Value(float(1))
+    a = value(float(1))
 
     @calc()
     def funcA():
@@ -1028,7 +1028,7 @@ async def test_effect_pausing():
 # ------------------------------------------------------------
 @pytest.mark.asyncio
 async def test_effect_async_pausing():
-    a = Value(float(1))
+    a = value(float(1))
 
     @calc()
     async def funcA():
@@ -1108,7 +1108,7 @@ async def test_effect_async_pausing():
 @pytest.mark.asyncio
 async def test_observer_async_suspended_resumed_observers_run_at_most_once():
 
-    a = Value(1)
+    a = value(1)
 
     @effect()
     async def obs():


### PR DESCRIPTION
(Don't merge until we've discussed this.) This PR renames `reactive.Value` to `reactive.value`. Although it is a class, it is the only thing in `reactive` that starts with a capital letter and so it feels a little weird.