### PR TITLE
`Dependents`: don't register unnecessary `on_invalidate` callbacks

### DIFF
--- a/shiny/reactive/_core.py
+++ b/shiny/reactive/_core.py
@@ -81,8 +81,12 @@ class Dependents:
 
     def register(self) -> None:
         ctx: Context = get_current_context()
-        if ctx.id not in self._dependents:
-            self._dependents[ctx.id] = ctx
+
+        if ctx.id in self._dependents:
+            # This context is already registered; no need to register it.
+            return
+
+        self._dependents[ctx.id] = ctx
 
         def on_invalidate_cb() -> None:
             if ctx.id in self._dependents:


### PR DESCRIPTION
Previously, registering a dependent context N times would only add one entry `self._dependents`, but it would register N `on_invalidate` callbacks to remove the context from `self_dependents`. This change makes it so that only registers one `on_invalidate` callback.

