### PR TITLE
Make `req()` return `None`

### DIFF
--- a/shiny/_validation.py
+++ b/shiny/_validation.py
@@ -1,14 +1,10 @@
-from typing import TypeVar
 from .types import SilentException, SilentCancelOutputException
 
-T = TypeVar("T")
 
-
-def req(*args: T, cancel_output: bool = False) -> T:
+def req(*args: object, cancel_output: bool = False) -> None:
     for arg in args:
         if not arg:
             if cancel_output:
                 raise SilentCancelOutputException()
             else:
                 raise SilentException()
-    return args[0]


### PR DESCRIPTION
The current type signature for `req()` is this:

```py
def req(*args: T, cancel_output: bool = False) -> T:
```

The function returns the value of the first arg.

A problem with this is the return value is too broad when there are multiple args. For example, with the following code, it thinks that`x` is an `int | str`.

```py
x = req(123, "abc")
```

One way to solve this is to change the signature to following:

```py
def req(arg: T, *args: object, cancel_output: bool = False) -> T:
```

But in practice, I don't think I've seen code that uses the return value of `req()` like this:

```py
x = req(input.x())
```

It feels a bit weird to me that the function both checks all args for falsiness, and returns the first one. 

This PR simplifies `req()` so that it only does one thing: throw an exception if any inputs are falsy. If someone really wants to use a value, they can still do it like this:


```py
req(input.x())
x = input.x()
```
