### PR TITLE
Reorganize session utils

### DIFF
--- a/shiny/modules.py
+++ b/shiny/modules.py
@@ -11,8 +11,7 @@ from htmltools.core import TagChildArg
 
 from .reactive import Value
 from .render import RenderFunction
-from .session import Inputs, Outputs, Session
-from .session._utils import require_active_session
+from .session import Inputs, Outputs, Session, require_active_session
 
 
 class ModuleInputs(Inputs):

--- a/shiny/session/__init__.py
+++ b/shiny/session/__init__.py
@@ -3,5 +3,12 @@ Tools for working within a (user) session context.
 """
 
 from ._session import *
+from ._utils import *
 
-__all__ = ("Session", "Inputs", "Outputs", "get_current_session")
+__all__ = (
+    "Session",
+    "Inputs",
+    "Outputs",
+    "get_current_session",
+    "require_active_session",
+)

--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -1,4 +1,4 @@
-__all__ = ("Session", "Inputs", "Outputs", "get_current_session", "session_context")
+__all__ = ("Session", "Inputs", "Outputs")
 
 import functools
 import os
@@ -12,8 +12,6 @@ import typing
 import mimetypes
 import dataclasses
 import urllib.parse
-from contextvars import ContextVar, Token
-from contextlib import contextmanager
 from typing import (
     TYPE_CHECKING,
     AsyncIterable,
@@ -56,7 +54,7 @@ from .. import _utils
 from .._fileupload import FileInfo, FileUploadManager
 from ..input_handler import input_handlers
 from ..types import SafeException, SilentCancelOutputException, SilentException
-from ._utils import *
+from ._utils import RenderedDeps, read_thunk_opt, session_context
 
 # This cast is necessary because if the type checker thinks that if
 # "tag" isn't in `message`, then it's not a ClientMessage object.
@@ -688,24 +686,3 @@ class Outputs:
             return True
         else:
             return hidden
-
-
-# ==============================================================================
-# Context manager for current session (AKA current reactive domain)
-# ==============================================================================
-_current_session: ContextVar[Optional[Session]] = ContextVar(
-    "current_session", default=None
-)
-
-
-def get_current_session() -> Optional[Session]:
-    return _current_session.get()
-
-
-@contextmanager
-def session_context(session: Optional[Session]):
-    token: Token[Union[Session, None]] = _current_session.set(session)
-    try:
-        yield
-    finally:
-        _current_session.reset(token)

--- a/shiny/ui/_input_update.py
+++ b/shiny/ui/_input_update.py
@@ -31,8 +31,7 @@ from ._input_date import _as_date_attr
 from ._input_select import SelectChoicesArg, _normalize_choices, _render_choices
 from ._input_slider import SliderValueArg, SliderStepArg, _slider_type, _as_numeric
 from .._utils import drop_none
-from ..session import Session
-from ..session._utils import require_active_session
+from ..session import Session, require_active_session
 
 # -----------------------------------------------------------------------------
 # input_action_button.py

--- a/shiny/ui/_insert.py
+++ b/shiny/ui/_insert.py
@@ -10,8 +10,7 @@ else:
 
 from htmltools import TagChildArg
 
-from ..session import Session
-from ..session._utils import require_active_session
+from ..session import Session, require_active_session
 
 
 def insert_ui(

--- a/shiny/ui/_modal.py
+++ b/shiny/ui/_modal.py
@@ -16,8 +16,7 @@ else:
 from htmltools import tags, Tag, div, HTML, TagChildArg, TagAttrArg
 
 from .._utils import run_coro_sync
-from ..session import Session
-from ..session._utils import require_active_session
+from ..session import Session, require_active_session
 
 
 def modal_button(label: str, icon: TagChildArg = None, **kwargs: TagChildArg) -> Tag:

--- a/shiny/ui/_notification.py
+++ b/shiny/ui/_notification.py
@@ -11,8 +11,7 @@ else:
 from htmltools import TagList, TagChildArg
 
 from .._utils import run_coro_sync, rand_hex
-from ..session import Session
-from ..session._utils import require_active_session
+from ..session import Session, require_active_session
 
 
 def notification_show(

--- a/shiny/ui/_progress.py
+++ b/shiny/ui/_progress.py
@@ -3,8 +3,7 @@ __all__ = ("Progress",)
 from typing import Optional, Dict, Any
 from warnings import warn
 from .._utils import run_coro_sync, rand_hex
-from ..session import Session
-from ..session._utils import require_active_session
+from ..session import Session, require_active_session
 
 
 class Progress:


### PR DESCRIPTION
This PR moves some functions from `session._session` to `session_utils.` It makes it so that:

* `session._utils.require_active_session` doesn't require a run-time import from `._session`.
* Submodules outside of `session` don't need to explicitly import from `session._utils`