### PR TITLE
Rename `calc()` -> `Calc()`; `effect()` -> `Effect()`

### DIFF
--- a/examples/bind_event/app.py
+++ b/examples/bind_event/app.py
@@ -29,19 +29,19 @@ app_ui = ui.page_fluid(
 def server(input: Inputs, output: Outputs, session: Session):
 
     # i.e., observeEvent(once=False)
-    @reactive.effect()
+    @reactive.Effect()
     @event(input.btn)
     def _():
         print("@effect() event: ", str(input.btn()))
 
     # i.e., eventReactive()
-    @reactive.calc()
+    @reactive.Calc()
     @event(input.btn)
-    def btn() -> int:
-        return input.btn()
+    async def btn() -> int:
+        return input.btn() + 2
 
-    @reactive.effect()
-    def _():
+    @reactive.Effect()
+    async def _():
         print("@calc() event: ", str(btn()))
 
     @output()
@@ -53,19 +53,19 @@ def server(input: Inputs, output: Outputs, session: Session):
     # -----------------------------------------------------------------------------
     # Async
     # -----------------------------------------------------------------------------
-    @reactive.effect()
+    @reactive.Effect()
     @event(input.btn_async)
     async def _():
         await asyncio.sleep(0)
         print("async @effect() event: ", str(input.btn_async()))
 
-    @reactive.calc()
+    @reactive.Calc()
     @event(input.btn_async)
     async def btn_async_r() -> int:
         await asyncio.sleep(0)
         return input.btn_async()
 
-    @reactive.effect()
+    @reactive.Effect()
     async def _():
         val = await btn_async_r()
         print("async @calc() event: ", str(val))

--- a/examples/inputs-update/app.py
+++ b/examples/inputs-update/app.py
@@ -89,7 +89,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.effect()
+    @reactive.Effect()
     def _():
         # We'll use these multiple times, so use short var names for
         # convenience.

--- a/examples/inputs/app.py
+++ b/examples/inputs/app.py
@@ -132,7 +132,7 @@ def server(input: Inputs, output: Outputs, session: Session):
         img: ImgData = {"src": str(dir / "rstudio-logo.png"), "width": "150px"}
         return img
 
-    @reactive.effect()
+    @reactive.Effect()
     def _():
         btn = input.btn()
         if btn and btn > 0:
@@ -144,7 +144,7 @@ def server(input: Inputs, output: Outputs, session: Session):
                 )
             )
 
-    @reactive.effect()
+    @reactive.Effect()
     def _():
         link = input.link()
         if link and link > 0:

--- a/examples/insert_ui/app.py
+++ b/examples/insert_ui/app.py
@@ -21,7 +21,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.calc()
+    @reactive.Calc()
     def r():
         if input.n() is None:
             return
@@ -50,7 +50,7 @@ def server(input: Inputs, output: Outputs, session: Session):
             "This slider is rendered via @render_ui()", "N", 0, 100, 20
         )
 
-    @reactive.effect()
+    @reactive.Effect()
     def _():
         btn = input.btn()
         if btn % 2 == 1:

--- a/examples/moduleapp/app.py
+++ b/examples/moduleapp/app.py
@@ -20,7 +20,7 @@ def counter_ui(
 def counter_server(input: ModuleInputs, output: ModuleOutputs, session: ModuleSession):
     count: reactive.Value[int] = reactive.Value(0)
 
-    @reactive.effect()
+    @reactive.Effect()
     @event(input.button)
     def _():
         count.set(count() + 1)

--- a/examples/myapp/app.py
+++ b/examples/myapp/app.py
@@ -23,7 +23,7 @@ shared_val = reactive.Value(None)
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.calc()
+    @reactive.Calc()
     def r():
         if input.n() is None:
             return
@@ -37,7 +37,7 @@ def server(input: Inputs, output: Outputs, session: Session):
 
     # This observer watches n, and changes shared_val, which is shared across
     # all running sessions.
-    @reactive.effect()
+    @reactive.Effect()
     def _():
         if input.n() is None:
             return

--- a/examples/req/app.py
+++ b/examples/req/app.py
@@ -15,7 +15,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.calc()
+    @reactive.Calc()
     def safe_click():
         req(input.safe())
         return input.safe()
@@ -31,7 +31,7 @@ def server(input: Inputs, output: Outputs, session: Session):
         req(input.unsafe())
         raise Exception(f"Super secret number of clicks: {str(input.unsafe())}")
 
-    @reactive.effect()
+    @reactive.Effect()
     def _():
         req(input.unsafe())
         print("unsafe clicks:", input.unsafe())

--- a/examples/simple/app.py
+++ b/examples/simple/app.py
@@ -10,7 +10,7 @@ shared_val = reactive.Value(None)
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.calc()
+    @reactive.Calc()
     def r():
         if input.n() is None:
             return

--- a/shiny/reactive/__init__.py
+++ b/shiny/reactive/__init__.py
@@ -5,8 +5,8 @@ __all__ = (
     "flush",
     "on_flushed",
     "Value",
-    "calc",
-    "effect",
+    "Calc",
+    "Effect",
     "isolate",
     "invalidate_later",
 )

--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -45,7 +45,7 @@ from htmltools import TagChildArg, TagList
 if TYPE_CHECKING:
     from .._app import App
 
-from ..reactive import Value, Effect, effect, isolate, flush
+from ..reactive import Value, Effect, Effect_, isolate, flush
 from ..reactive._core import lock
 from ..http_staticfiles import FileResponse
 from .._connmanager import Connection, ConnectionClosed
@@ -586,7 +586,7 @@ class Inputs:
 # ======================================================================================
 class Outputs:
     def __init__(self, session: Session) -> None:
-        self._effects: Dict[str, Effect] = {}
+        self._effects: Dict[str, Effect_] = {}
         self._suspend_when_hidden: Dict[str, bool] = {}
         self._session: Session = session
 
@@ -610,7 +610,7 @@ class Outputs:
 
             self._suspend_when_hidden[fn_name] = suspend_when_hidden
 
-            @effect(
+            @Effect(
                 suspended=suspend_when_hidden and self._is_hidden(fn_name),
                 priority=priority,
             )


### PR DESCRIPTION
This renames:
* `reactive.calc()` to `reactive.Calc()`
* `reactive.effect()` to `reactive.Effect()`

It also renames the corresponding classes so that they have a trailing underscore, as in `Calc_`, `CalcAsync_`, and `Effect_`. It removes the `EffectAsync` class because it turns out it's not necessary.

We also discussed renaming `Calc` to `Calculation`. I didn't do that here, but it would be straightforward to make that change.