### PR TITLE
Better path handling for `shiny run`

### DIFF
--- a/shiny/_main.py
+++ b/shiny/_main.py
@@ -3,7 +3,7 @@ import importlib.util
 import os
 import sys
 import types
-from typing import Optional, Union
+from typing import Optional, Union, Tuple
 
 import click
 import uvicorn
@@ -197,7 +197,7 @@ def is_file(app: str) -> bool:
     return "/" in app or app.endswith(".py")
 
 
-def resolve_app(app: str, app_dir: Optional[str]) -> tuple[str, Optional[str]]:
+def resolve_app(app: str, app_dir: Optional[str]) -> Tuple[str, Optional[str]]:
     # The `app` parameter can be:
     #
     # - A module:attribute name


### PR DESCRIPTION
If "/" or ".py$" match the app parameter, we no longer try to form a relative
module path. Instead, we use the directory as app_dir, and the filename as
app, and pass through to uvicorn.

This gives us a couple of advantages:

1. The ability to say `shiny run ../myapp/app.py`, whereas previously you could only run apps in the current or child directories.
2. We set the same PYTHONPATH if you do `shiny run app.py`, versus `shiny run myapp/app.py` from the parent directory. This means that import statements in app.py will work consistently. This isn't/can't be the case if use modules (e.g. `shiny run app` versus `shiny run myapp.app` from the parent directory).