### PR TITLE
Bump uvicorn min version to 0.16

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ exclude = docs
 
 [options]
 install_requires =
-  uvicorn>=0.14.0
+  uvicorn>=0.16.0
   matplotlib>=3.4.2
   fastapi>=0.70.0
   contextvars>=2.4


### PR DESCRIPTION
Since we now use the app-dir parameter in run_app() https://github.com/encode/uvicorn/blob/master/CHANGELOG.md\#0160---2021-12-08