### PR TITLE
Add 'shiny static' command for static deployment

### DIFF
--- a/shiny/_main.py
+++ b/shiny/_main.py
@@ -356,13 +356,13 @@ def static(
     appdir: str, destdir: str, overwrite: bool, subdir: str, verbose: bool
 ) -> None:
     try:
-        import shinylive
+        import shinylive  # pyright: reportMissingImports=false,reportUnknownVariableType=false
     except ImportError:
         sys.stderr.write(
             "Error: The 'shinylive' package must be installed to run the `shiny static` command.\n"
         )
         sys.exit(1)
 
-    shinylive.deploy(
+    shinylive.deploy(  # pyright: reportUnknownMemberType=false
         appdir, destdir, overwrite=overwrite, subdir=subdir, verbose=verbose
     )


### PR DESCRIPTION
This adds the `shiny static` command, which makes use of the shinylive package for creating a statically-deployable site.