### PR TITLE
Don't use `always()` in GitHub Actions workflow

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -66,10 +66,6 @@ jobs:
         run: |
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
-      - name: Boom
-        run: |
-          echo "stop boom"
-          exit 2
 
       - name: Install
         id: install


### PR DESCRIPTION
I learned that `always()` causes a step to run even if the workflow is cancelled. This changes to `success() || failure()`.

@schloerke I'd like these steps to run even if the previous check step fails. For example, if the unit test step fails, I still want it to do type checks with pyright, and similarly, if the type check step fails, I want it to build the API docs. However, I **don't** want it to run any of those checks if, say, the installation step fails. Will this PR make it work like that?