### PR TITLE
render_image() now renders no image (instead of erroring out) when receiving None

### DIFF
--- a/shiny/render/_render.py
+++ b/shiny/render/_render.py
@@ -279,6 +279,8 @@ class RenderImage(RenderFunction):
 
     async def _run(self) -> object:
         res: ImgData = await self._fn()
+        if res is None:
+            return None
         src: str = res.get("src")
         try:
             with open(src, "rb") as f:


### PR DESCRIPTION
Closes #176