### PR TITLE
Ensure `render.text()` returns a string

### DIFF
--- a/shiny/render/_render.py
+++ b/shiny/render/_render.py
@@ -82,7 +82,10 @@ class RenderText(RenderFunction):
         return _utils.run_coro_sync(self._run())
 
     async def _run(self) -> Union[str, None]:
-        return await self._fn()
+        res = await self._fn()
+        if res is None:
+            return None
+        return str(res)
 
 
 class RenderTextAsync(RenderText, RenderFunctionAsync):


### PR DESCRIPTION
Closes #200. This ensures that the wrapped function returned by `render.text()` will actually return a string.

For example, before this PR:

```py
import shiny
shiny.render.text()(lambda: ['1', 2])()
#> ['1', 2]
```


After:

```py
import shiny
shiny.render.text()(lambda: ['1', 2])()
#> "['1', 2]"
```