### PR TITLE
Set a better default relative path to shinylive assets when building API docs

### DIFF
--- a/docs/sphinxext/pyshinyapp.py
+++ b/docs/sphinxext/pyshinyapp.py
@@ -31,7 +31,9 @@ from htmltools import css
 # This is only needed for the "self-contained" version of the API reference.
 # (in other words, you can set this to "" if you already have the shinylive/ directory
 # in your repo, just make sure to also point SHINYLIVE_DEST to the right place)
-shinylive_src = abspath(join(dirname(__file__), "../../../../build/shinylive"))
+shinylive_src = abspath(
+    join(dirname(__file__), "../../../py-shinylive/build/shinylive")
+)
 SHINYLIVE_SRC = os.getenv("SHINYLIVE_SRC", shinylive_src)
 
 # The location of the shinylive/ directory (relative to the output/root directory)


### PR DESCRIPTION
Closes #183

Should be merged after https://github.com/rstudio/py-shinylive/pull/4