### PR TITLE
`render.plot()` now passes keyword arguments to the relevant save method

### DIFF
--- a/examples/static_plots/app.py
+++ b/examples/static_plots/app.py
@@ -5,8 +5,6 @@ import pandas as pd
 import seaborn as sns
 from plotnine.data import mtcars
 
-plt.tight_layout()
-
 nav = ui.navset_pill_list(
     ui.nav_control(ui.p("Choose a package", class_="lead text-center")),
     ui.nav(


### PR DESCRIPTION
and defaults to `bbox_inches='tight'`

Closes #216 
Closes #211