### PR TITLE
Fix `input_radio_buttons(selected=[])`

### DIFF
--- a/shiny/ui/_input_check_radio.py
+++ b/shiny/ui/_input_check_radio.py
@@ -4,7 +4,7 @@ __all__ = (
     "input_radio_buttons",
 )
 
-from typing import Optional, Dict, Union, List, Tuple
+from typing import Optional, Dict, Union, List
 
 from htmltools import tags, Tag, div, span, css, TagChildArg
 
@@ -211,13 +211,28 @@ def _generate_options(
     choices: ChoicesArg,
     selected: Optional[Union[str, List[str]]],
     inline: bool,
-):
+) -> Tag:
     choicez = _normalize_choices(choices)
-    if type == "radio" and not selected:
-        selected = list(choicez.keys())[0]
+
+    if selected is None:
+        if type == "radio":
+            selected = list(choicez.keys())[0]
+        else:
+            selected = []
+
+    if not isinstance(selected, list):
+        selected = [selected]
+
     return div(
-        *[
-            _generate_option(id, type, choice, selected, inline)
+        [
+            _generate_option(
+                id,
+                type,
+                value=choice[0],
+                label=choice[1],
+                checked=choice[0] in selected,
+                inline=inline,
+            )
             for choice in choicez.items()
         ],
         class_="shiny-options-group",
@@ -227,15 +242,11 @@ def _generate_options(
 def _generate_option(
     id: str,
     type: str,
-    choice: Tuple[str, TagChildArg],
-    selected: Optional[Union[str, List[str]]],
+    value: str,
+    label: TagChildArg,
+    checked: bool,
     inline: bool,
-):
-    value, label = choice
-    if isinstance(selected, list):
-        checked = value in selected
-    else:
-        checked = value == selected
+) -> Tag:
     input = tags.input(
         type=type,
         name=id,


### PR DESCRIPTION
Previously, it was not possible to have radio buttons with no items selected. For example:

```py
from shiny import ui
ui.input_radio_buttons("x", "X", {"a": "A", "b": "B"}, selected = [])
#> <div id="x" class="form-group shiny-input-radiogroup shiny-input-container" role="radi ogroup" aria-labelledby="x-label">
#>   <label class="control-label" id="x-label" for="x">X</label>
#>   <div class="shiny-options-group">
#>     <div class="radio">
#>       <label>
#>         <input type="radio" name="x" value="a" checked="checked"/>
#>         <span>A</span>
#>       </label>
#>     </div>
#>     <div class="radio">
#>       <label>
#>         <input type="radio" name="x" value="b"/>
#>         <span>B</span>
#>       </label>
#>     </div>
#>   </div>
#> </div>
```

Note the `checked="checked"`.

After this fix:

```py
from shiny import *
ui.input_radio_buttons("x", "X", {"a": "A", "b": "B"}, selected = [])
#> <div id="x" class="form-group shiny-input-radiogroup shiny-input-container" role="radiogroup" aria-labelledby="x-label">
#>   <label class="control-label" id="x-label" for="x">X</label>
#>   <div class="shiny-options-group">
#>     <div class="radio">
#>       <label>
#>         <input type="radio" name="x" value="a"/>
#>         <span>A</span>
#>       </label>
#>     </div>
#>     <div class="radio">
#>       <label>
#>         <input type="radio" name="x" value="b"/>
#>         <span>B</span>
#>       </label>
#>     </div>
#>   </div>
#> </div>
```

The problem before was with a falsy test: `if type == "radio" and not selected`. The `not selected` was true for `[]`, `""`, and `None`, but we only really wanted to capture the `None` case. So now we have an explicit `if selected is None`.

A second thing this PR does is move some complexity out of `_generate_option()` (singular). The main change here is that in `_generate_options()` (plural) the `selected` object gets normalized to a list of strings, which then makes it easy to check if each choice is in that list.