### PR TITLE
Give autoreload port an HTTP redirect to app port

### DIFF
--- a/shiny/_main.py
+++ b/shiny/_main.py
@@ -220,7 +220,7 @@ def run_app(
                 "Autoreload port is already being used by the app; disabling autoreload\n"
             )
         else:
-            setup_hot_reload(log_config, autoreload_port_num)
+            setup_hot_reload(log_config, autoreload_port_num, port)
 
     maybe_setup_rsw_proxying(log_config)
 
@@ -239,7 +239,9 @@ def run_app(
     )
 
 
-def setup_hot_reload(log_config: Dict[str, Any], port: int) -> None:
+def setup_hot_reload(
+    log_config: Dict[str, Any], autoreload_port: int, app_port: int
+) -> None:
     # The only way I've found to get notified when uvicorn decides to reload, is by
     # inserting a custom log handler.
     log_config["handlers"]["shiny_hot_reload"] = {
@@ -248,7 +250,7 @@ def setup_hot_reload(log_config: Dict[str, Any], port: int) -> None:
     }
     log_config["loggers"]["uvicorn.error"]["handlers"] = ["shiny_hot_reload"]
 
-    _autoreload.start_server(port)
+    _autoreload.start_server(autoreload_port, app_port)
 
 
 def maybe_setup_rsw_proxying(log_config: Dict[str, Any]) -> None:


### PR DESCRIPTION
This avoids the confusion that arises if someone visits the autoreload port in a browser. We don't advertise that port, but in RStudio Workbench's VS Code (and JupyterLab?) integrations, they sniff out what ports we're listening on and provide clickable HTTP links to each port. This has caused enough confusion in the past that I think it's worth detecting a non-WebSocket request, and redirecting to the app.

## Testing

* Run `shiny run --reload <app>` and then open http://127.0.0.1:8123 in a browser. It should redirect to http://127.0.0.1:8000
* Run `shiny run --port 8001 --reload <app>` and then open http://127.0.0.1:8124 in a browser. It should redirect to http://127.0.0.1:8001
* In RSW VSCode, run `shiny run --reload <app>` and then click on the proxy pane's link to port 8123. It should redirect to the running app.
