### PR TITLE
Add static and run-time type checks for `@event`, `@render.*`, and `@output`

### DIFF
--- a/shiny/render/_try_render_plot.py
+++ b/shiny/render/_try_render_plot.py
@@ -70,12 +70,7 @@ class PlotnineFigure(Protocol):
         ...
 
 
-class PlotImgData(ImgData):
-    style: Union[str, float]
-    """The ``style`` attribute of the ``<img>`` tag."""
-
-
-TryPlotResult = Union[PlotImgData, None, Literal["TYPE_MISMATCH"]]
+TryPlotResult = Union[ImgData, None, Literal["TYPE_MISMATCH"]]
 
 
 # Try to render a matplotlib object. If `fig` is not a matplotlib object, return
@@ -115,13 +110,15 @@ def try_render_matplotlib(
         # N.B. matplotlib.tight_layout() causes the intrinsic file size can be different
         # from the requested size (i.e., the container size). So, scale the image to fit
         # in the container while preserving the aspect ratio.
-        res: PlotImgData = {
+        res: ImgData = {
             "src": "data:image/png;base64," + data_str,
             "width": "100%",
             "height": "100%",
             "style": "object-fit:contain",
-            "alt": alt,
         }
+
+        if alt is not None:
+            res["alt"] = alt
 
         return res
 
@@ -203,13 +200,15 @@ def try_render_pil(
             data = base64.b64encode(buf.read())
             data_str = data.decode("utf-8")
 
-        res: PlotImgData = {
+        res: ImgData = {
             "src": "data:image/png;base64," + data_str,
             "width": "100%",
             "height": "100%",
             "style": "object-fit:contain",
-            "alt": alt,
         }
+
+        if alt is not None:
+            res["alt"] = alt
 
         return res
 
@@ -254,13 +253,15 @@ def try_render_plotnine(
             data = base64.b64encode(buf.read())
             data_str = data.decode("utf-8")
 
-        res: PlotImgData = {
+        res: ImgData = {
             "src": "data:image/png;base64," + data_str,
             "width": "100%",
             "height": "100%",
             "style": "object-fit:contain",
-            "alt": alt,
         }
+
+        if alt is not None:
+            res["alt"] = alt
 
         return res
 

--- a/shiny/types.py
+++ b/shiny/types.py
@@ -86,8 +86,10 @@ class ImgData(TypedDict):
     """The ``width`` attribute of the ``<img>`` tag."""
     height: NotRequired[Union[str, float]]
     """The ``height`` attribute of the ``<img>`` tag."""
-    alt: NotRequired[Optional[str]]
+    alt: NotRequired[str]
     """The ``alt`` attribute of the ``<img>`` tag."""
+    style: NotRequired[str]
+    """The ``style`` attribute of the ``<img>`` tag."""
 
 
 @add_example()


### PR DESCRIPTION
This adds static types and run-time checks with `@reactive.event`, `@render.*`, `@output`, `@reactive.Calc`, and `@reactive.Effect`. The checks do the following

- `@event` must be applied _before_ any of the other decorators.
-  A `@output` _must_ take a `@render.*` function.
- The `@render.*` functions are more specific about the function types they take in, and the values they return. 

Misuse of most of these functions will result in errors displayed with a static type checker like pyright. However, there is one combination that does not result in a static error, but will result in a run-time error. It is when `@reactive.event` is applied to a `@render*` function:

```py
@output
@reactive.event(input.btn)
@render.text
def txt():
    ...
```

This results in the following run-time error message:

```
TypeError: `@reactive.event()` must be applied before `@render.xx` functions.
In other words, it goes on the line below `@render.xx`.
```

The correct way to use it is:

```py
@output
@render.text
@reactive.event(input.btn)
def txt():
    ...
```

The reason it doesn't result in an error with a static type checker is because `@event` accepts any kind of object and returns an object of the same type. For an error to show up, we would need to _exclude_ `RenderFunction` objects, but unfortunately, Python doesn't have a way to do that.
https://stackoverflow.com/questions/57854871/exclude-type-in-python-typing-annotation
https://github.com/python/typing/issues/256

It is possible that in the future, we will allow the first form, if we find a use case where the `@render.*` function takes some reactive arguments. For example, we might have something like this:

```py
@output
@reactive.event(input.btn)
@render.plot(width=input.width)
def plt():
    ...
```

(This assumes there's a parameter `width` which could accept a function.)

Currently the same effect could be achieved with the following, although it's a little clunky:

```py
@reactive.Calc
@reactive.event(input.btn)
def width:
    return input.width()

@render.text(width=width)
@reactive.event(input.btn)
def txt(): ...
```
