### PR TITLE
req() should clear outputs by default

### DIFF
--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -969,7 +969,7 @@ class Outputs:
                     {"recalculating": {"name": output_name, "status": "recalculating"}}
                 )
 
-                message: Dict[str, OT] = {}
+                message: Dict[str, Optional[OT]] = {}
                 try:
                     if _utils.is_async_callable(fn):
                         message[output_name] = await fn()
@@ -978,7 +978,7 @@ class Outputs:
                 except SilentCancelOutputException:
                     return
                 except SilentException:
-                    pass
+                    message[output_name] = None
                 except Exception as e:
                     # Print traceback to the console
                     traceback.print_exc()


### PR DESCRIPTION
Try checking and then unchecking an option in this test app. Before this fix, the previous output stays in place (i.e. "You chose blue"), which is incorrect; unless `cancel_output=True` is passed, `req()` should clear the output.

```python
from shiny import *

app_ui = ui.page_fluid(
    ui.input_checkbox_group(
        "colors",
        "Choose color(s):",
        {
            "red": ui.span("Red", style="color: #FF0000;"),
            "green": ui.span("Green", style="color: #00AA00;"),
            "blue": ui.span("Blue", style="color: #0000AA;"),
        },
    ),
    ui.output_ui("val"),
)


def server(input: Inputs, output: Outputs, session: Session):
    @output
    @render.ui
    def val():
        req(input.colors())
        return "You chose " + ", ".join(input.colors())


app = App(app_ui, server)
```