### PR TITLE
[idea] New layout for `input_file()`

### DIFF
--- a/shiny/ui/_input_file.py
+++ b/shiny/ui/_input_file.py
@@ -82,37 +82,52 @@ def input_file(
     if isinstance(accept, str):
         accept = [accept]
 
+    dom_id = resolve_id(id)
+    button_label_id = f"{dom_id}_label"
+
     btn_file = span(
+        {"class": "btn btn-default btn-file", "id": button_label_id},
         button_label,
         tags.input(
-            id=resolve_id(id),
-            name=id,
-            type="file",
-            multiple="multiple" if multiple else None,
-            accept=",".join(accept) if accept else None,
-            capture=capture,
-            # Don't use "display: none;" style, which causes keyboard accessibility issue; instead use the following workaround: https://css-tricks.com/places-its-tempting-to-use-display-none-but-dont/
-            style="position: absolute !important; top: -99999px !important; left: -99999px !important;",
+            {
+                "id": dom_id,
+                "name": id,
+                "type": "file",
+                "multiple": True if multiple else None,
+                "accept": ",".join(accept) if accept else None,
+                "capture": capture,
+                # Don't use "display: none;" style, which causes keyboard accessibility issue; instead use the following workaround: https://css-tricks.com/places-its-tempting-to-use-display-none-but-dont/
+                "style": "position: absolute !important; top: -99999px !important; left: -99999px !important;",
+            }
         ),
-        class_="btn btn-default btn-file",
     )
+
     return div(
+        {
+            "class_": "form-group shiny-input-container",
+            "style": css(width=width),
+        },
         shiny_input_label(id, label),
+        # btn_file,
         div(
-            tags.label(btn_file, class_="input-group-btn input-group-prepend"),
+            {"class": "input-group"},
+            btn_file,
             tags.input(
-                type="text",
-                class_="form-control",
-                placeholder=placeholder,
-                readonly="readonly",
+                {
+                    "type": "text",
+                    "class": "form-control",
+                    "placeholder": placeholder,
+                    "readonly": "readonly",
+                    "aria-label": button_label,
+                    "aria-describedby": button_label_id,
+                }
             ),
-            class_="input-group",
         ),
         div(
+            {
+                "id": id + "_progress",
+                "class": "progress active shiny-file-input-progress",
+            },
             div(class_="progress-bar"),
-            id=id + "_progress",
-            class_="progress active shiny-file-input-progress",
         ),
-        class_="form-group shiny-input-container",
-        style=css(width=width),
     )


### PR DESCRIPTION
The current `input_file()` displays with rounded corners at the transition of the button to the input text. Bootstrap has this natively covered and should be implemented.

####  Main branch
![Screenshot 2023-07-17 at 1 07 07 PM](https://github.com/rstudio/py-shiny/assets/93231/7e822009-d41d-4bf8-beab-1eeeed66eb32)

#### PR

![Screenshot 2023-07-17 at 1 06 37 PM](https://github.com/rstudio/py-shiny/assets/93231/388232f6-d5fd-4486-8ab1-e339c0f5e43c)

Related: https://getbootstrap.com/docs/5.3/forms/input-group/#custom-file-input

However, clicking on these elements do not work.

----------------------

TODO
- [ ] Get elements to click
- [ ] Drag / Drop
- [ ] Keyboard focus