### PR TITLE
New `input_switch()` example

### DIFF
--- a/shiny/api-examples/input_switch/app.py
+++ b/shiny/api-examples/input_switch/app.py
@@ -2,8 +2,8 @@ from shiny import App, Inputs, Outputs, Session, render, ui
 
 app_ui = ui.page_fluid(
     ui.h2("Keyboard Settings"),
-    ui.input_switch("auto_capitalization", "Auto-Capitalization",  True),
-    ui.input_switch("auto_correction", "Auto-Correction",  True),
+    ui.input_switch("auto_capitalization", "Auto-Capitalization", True),
+    ui.input_switch("auto_correction", "Auto-Correction", True),
     ui.input_switch("check_spelling", "Check Spelling", True),
     ui.input_switch("smart_punctuation", "Smart Punctuation"),
     ui.output_text_verbatim("preview"),


### PR DESCRIPTION
Adds a slightly more involved `input_switch()` example. [Preview on shinylive](https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXGKAHVA6VBPMAaMAYwHsIAXOcpMAMwCdiYACAZwAsBLCbJjmVYnTJMAgujxMAkhFQBXMiwkB5eXIUSAynBYsOpCXUoATOHQmyOAHQjW0qAPoWmAXiYWsUAOZx7NADYWRgAU1kxhbhwYbABMIWAA0nDYAEbEUHRGTFpkZFyeLJZgAJR4oeHuXGr2LADuHGSEbHFQ8sT2hGj1UH4cAF5QuaSFEoUirQC0AMKdZN19A3o2+GEAKnSycCVlYRUy8tV1DU2FLWRtJHSGhINLI2BjZ1OCVzfDq+ubpRDhERiV+7V6o04o04IQANbVVBwPw9CCeN6FSZsMHgrLQ2F5N5rDZbb7lSL-MgHIHHMAsGDpYlyCDXWQLIbLQoaSlCJgABVktLI9NexS+P3cxFU+woAA9iQA3UzJBYwOKoQySjhwGqFPFFaxaiAmGisUzSuhBImIKR7dRMYVkNSmlTW+SKfU6RamrTO0hFRDbJgAAStam9PsMOtMGHFZG9uqYirgytVQU93p+hh5dG+NEKmYSSVS6Uy2Vy8IKEGcpbL5YrlYrtla7Rmc36N1NICJGFO53rPUbiwTAF8a2d2s8wU2mC3zW3axcXj2iv3aSiIVCYXDPM3W6ClywMau+9YKVT7DS6QyIOuJwehEeuSebnuwFntbZ0C5ROggnZHBwJCwDaZNRAYC9gAukAA).