### PR TITLE
Add updated path to examples

### DIFF
--- a/docs/_renderer.py
+++ b/docs/_renderer.py
@@ -66,9 +66,9 @@ class Renderer(MdRenderer):
         converted = convert_rst_link_to_md(rendered)
 
         if isinstance(el, dc.Alias) and "experimental" in el.target_path:
-            p_example_dir = SHINY_PATH / "experimental" / "examples" / el.name
+            p_example_dir = SHINY_PATH / "experimental" / "api-examples" / el.name
         else:
-            p_example_dir = SHINY_PATH / "examples" / el.name
+            p_example_dir = SHINY_PATH / "api-examples" / el.name
 
         if (p_example_dir / "app.py").exists():
             example = ""


### PR DESCRIPTION
This was a leftover task from #627 which didn't end up getting done. The result was that the function reference examples weren't showing up properly. 