### PR TITLE
Remove warnings from external packages when testing shiny examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,9 +91,8 @@ e2e-examples: ## end-to-end tests on examples with playwright
 	playwright install --with-deps
 	pytest $(FILE) -m "examples"
 
-coverage: ## check code coverage quickly with the default Python
-	coverage run --source shiny -m pytest
-	coverage report -m
+coverage: ## check combined code coverage (must run e2e last)
+	pytest --cov-report term-missing --cov=shiny tests/pytest/ tests/e2e/ -m "not examples"
 	coverage html
 	$(BROWSER) htmlcov/index.html
 

--- a/examples/static_plots/app.py
+++ b/examples/static_plots/app.py
@@ -141,12 +141,19 @@ def server(input: Inputs, output: Outputs, session: Session):
     @output
     @render.plot
     def missingno():
+        import matplotlib.pyplot as plt
         import missingno as msno
 
         collisions = pd.read_csv(
             "https://raw.githubusercontent.com/ResidentMario/missingno-data/master/nyc_collision_factors.csv"
         )
-        return msno.matrix(collisions.sample(250))
+        ret = msno.matrix(
+            collisions.sample(250),
+            fontsize=8,
+            label_rotation=45,
+        )
+        plt.subplots_adjust(top=0.6)
+        return ret
 
 
 app = App(app_ui, server)

--- a/examples/static_plots/app.py
+++ b/examples/static_plots/app.py
@@ -118,7 +118,6 @@ def server(input: Inputs, output: Outputs, session: Session):
     @output
     @render.plot
     def xarray():
-        # `pooch` module required to download `open_dataset`
         import xarray as xr
 
         airtemps = xr.tutorial.open_dataset("air_temperature")
@@ -130,9 +129,10 @@ def server(input: Inputs, output: Outputs, session: Session):
     @output
     @render.plot
     def geopandas():
+        import geodatasets
         import geopandas
 
-        nybb_path = geopandas.datasets.get_path("nybb")
+        nybb_path = geodatasets.get_path("nybb")
         boros = geopandas.read_file(nybb_path)
         boros.set_index("BoroCode", inplace=True)
         boros.sort_index(inplace=True)

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,8 @@ test =
     pytest-xdist
     pytest-timeout
     pytest-rerunfailures
+    pytest-cov
+    coverage
     # For snapshot testing
     syrupy
     psutil

--- a/setup.cfg
+++ b/setup.cfg
@@ -78,8 +78,8 @@ test =
     bokeh
     xarray
     geopandas
+    geodatasets
     missingno
-    pooch
 
 dev =
     black>=23.1.0

--- a/shiny/render/_try_render_plot.py
+++ b/shiny/render/_try_render_plot.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import io
+import warnings
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple, cast
 
 from ..types import ImgData, PlotnineFigure
@@ -33,12 +34,12 @@ def try_render_matplotlib(
         return (False, None)
 
     try:
-        import matplotlib.pyplot as plt
+        import matplotlib.pyplot as plt  # pyright: ignore[reportUnusedImport] # noqa: F401
 
         fig.set_size_inches(width / ppi, height / ppi)
         fig.set_dpi(ppi * pixelratio)
 
-        plt.tight_layout()  # pyright: ignore[reportUnknownMemberType]
+        plt_tight_layout()
         coordmap = get_coordmap(fig)
 
         with io.BytesIO() as buf:
@@ -70,6 +71,14 @@ def try_render_matplotlib(
         import matplotlib.pyplot
 
         matplotlib.pyplot.close(fig)  # pyright: ignore[reportUnknownMemberType]
+
+
+# Function to suppress the message `UserWarning: The figure layout has changed to tight`
+def plt_tight_layout() -> None:
+    import matplotlib.pyplot as plt
+
+    warnings.simplefilter("ignore", UserWarning)
+    plt.tight_layout()  # pyright: ignore[reportUnknownMemberType]
 
 
 def get_matplotlib_figure(

--- a/shiny/render/_try_render_plot.py
+++ b/shiny/render/_try_render_plot.py
@@ -39,7 +39,15 @@ def try_render_matplotlib(
         fig.set_size_inches(width / ppi, height / ppi)
         fig.set_dpi(ppi * pixelratio)
 
-        plt_tight_layout()
+        # Suppress the message `UserWarning: The figure layout has changed to tight`
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                action="ignore",
+                category=UserWarning,
+                message="The figure layout has changed to tight",
+            )
+            plt.tight_layout()  # pyright: ignore[reportUnknownMemberType]
+
         coordmap = get_coordmap(fig)
 
         with io.BytesIO() as buf:
@@ -71,14 +79,6 @@ def try_render_matplotlib(
         import matplotlib.pyplot
 
         matplotlib.pyplot.close(fig)  # pyright: ignore[reportUnknownMemberType]
-
-
-# Function to suppress the message `UserWarning: The figure layout has changed to tight`
-def plt_tight_layout() -> None:
-    import matplotlib.pyplot as plt
-
-    warnings.simplefilter("ignore", UserWarning)
-    plt.tight_layout()  # pyright: ignore[reportUnknownMemberType]
 
 
 def get_matplotlib_figure(

--- a/tests/e2e/examples/test_examples.py
+++ b/tests/e2e/examples/test_examples.py
@@ -73,9 +73,9 @@ app_allow_external_errors: typing.List[str] = [
     # mizani: https://github.com/has2k1/mizani/issues/34
     # seaborn: https://github.com/mwaskom/seaborn/issues/3457
     "FutureWarning: is_categorical_dtype is deprecated",
+    "if pd.api.types.is_categorical_dtype(vector",
     # plotnine: https://github.com/has2k1/plotnine/issues/713#issuecomment-1701363058
     "FutureWarning: The default of observed=False is deprecated",
-    # "if pd.api.types.is_categorical_dtype(vector"
     # seaborn: https://github.com/mwaskom/seaborn/pull/3355
     "FutureWarning: use_inf_as_na option is deprecated",
     "pd.option_context('mode.use_inf_as_na",  # continutation of line above

--- a/tests/e2e/examples/test_examples.py
+++ b/tests/e2e/examples/test_examples.py
@@ -44,36 +44,18 @@ app_allow_shiny_errors: typing.Dict[
     "SafeException": True,
     "global_pyplot": True,
     "static_plots": [
-        # acceptable warnings!
+        # acceptable warning
         "PlotnineWarning: Smoothing requires 2 or more points",
-        # acceptable warnings!
         "RuntimeWarning: divide by zero encountered",
         "UserWarning: This figure includes Axes that are not compatible with tight_layout",
-        # # https://github.com/has2k1/plotnine/issues/713
-        # # https://github.com/mwaskom/seaborn/issues/3457
-        # "FutureWarning: is_categorical_dtype",
-        # "is_categorical_dtype",
-        # "FutureWarning: use_inf_as_na",
-        # "pd.option_context('mode.use_inf_as_na",
-        # "FutureWarning: The default of observed=False",
     ],
-    # "annotation-export": [
-    #     "FutureWarning: is_categorical_dtype",
-    #     "is_categorical_dtype",
-    #     "FutureWarning: use_inf_as_na",
-    #     "pd.option_context('mode.use_inf_as_na",
-    # ],
-    # # https://github.com/posit-dev/py-shiny/issues/611#issuecomment-1632866419
-    # "penguins": [
-    #     "UserWarning:",
-    # ],
 }
 app_allow_external_errors: typing.List[str] = [
     # plotnine: https://github.com/has2k1/plotnine/issues/713
     # mizani: https://github.com/has2k1/mizani/issues/34
     # seaborn: https://github.com/mwaskom/seaborn/issues/3457
     "FutureWarning: is_categorical_dtype is deprecated",
-    "if pd.api.types.is_categorical_dtype(vector",
+    "if pd.api.types.is_categorical_dtype(vector",  # continutation of line above
     # plotnine: https://github.com/has2k1/plotnine/issues/713#issuecomment-1701363058
     "FutureWarning: The default of observed=False is deprecated",
     # seaborn: https://github.com/mwaskom/seaborn/pull/3355

--- a/tests/e2e/examples/test_examples.py
+++ b/tests/e2e/examples/test_examples.py
@@ -1,6 +1,8 @@
 import os
+import sys
 import typing
 from pathlib import PurePath
+from typing import Literal
 
 import pytest
 from conftest import run_shiny_app
@@ -8,6 +10,9 @@ from playwright.sync_api import ConsoleMessage, Page
 
 here_tests_e2e_examples = PurePath(__file__).parent
 here_root = here_tests_e2e_examples.parent.parent.parent
+
+is_interactive = hasattr(sys, "ps1")
+reruns = 1 if is_interactive else 3
 
 
 def get_apps(path: str) -> typing.List[str]:
@@ -33,13 +38,48 @@ app_hard_wait: typing.Dict[str, int] = {
     "brownian": 250,
     "ui-func": 250,
 }
-app_allow_shiny_errors: typing.Dict[str, typing.Union[bool, typing.List[str]]] = {
+app_allow_shiny_errors: typing.Dict[
+    str, typing.Union[Literal[True], typing.List[str]]
+] = {
     "SafeException": True,
     "global_pyplot": True,
-    "static_plots": ["PlotnineWarning", "RuntimeWarning"],
-    # https://github.com/posit-dev/py-shiny/issues/611#issuecomment-1632866419
-    "penguins": ["UserWarning", "plt.tight_layout"],
+    "static_plots": [
+        # acceptable warnings!
+        "PlotnineWarning: Smoothing requires 2 or more points",
+        # acceptable warnings!
+        "RuntimeWarning: divide by zero encountered",
+        "UserWarning: This figure includes Axes that are not compatible with tight_layout",
+        # # https://github.com/has2k1/plotnine/issues/713
+        # # https://github.com/mwaskom/seaborn/issues/3457
+        # "FutureWarning: is_categorical_dtype",
+        # "is_categorical_dtype",
+        # "FutureWarning: use_inf_as_na",
+        # "pd.option_context('mode.use_inf_as_na",
+        # "FutureWarning: The default of observed=False",
+    ],
+    # "annotation-export": [
+    #     "FutureWarning: is_categorical_dtype",
+    #     "is_categorical_dtype",
+    #     "FutureWarning: use_inf_as_na",
+    #     "pd.option_context('mode.use_inf_as_na",
+    # ],
+    # # https://github.com/posit-dev/py-shiny/issues/611#issuecomment-1632866419
+    # "penguins": [
+    #     "UserWarning:",
+    # ],
 }
+app_allow_external_errors: typing.List[str] = [
+    # plotnine: https://github.com/has2k1/plotnine/issues/713
+    # mizani: https://github.com/has2k1/mizani/issues/34
+    # seaborn: https://github.com/mwaskom/seaborn/issues/3457
+    "FutureWarning: is_categorical_dtype is deprecated",
+    # plotnine: https://github.com/has2k1/plotnine/issues/713#issuecomment-1701363058
+    "FutureWarning: The default of observed=False is deprecated",
+    # "if pd.api.types.is_categorical_dtype(vector"
+    # seaborn: https://github.com/mwaskom/seaborn/pull/3355
+    "FutureWarning: use_inf_as_na option is deprecated",
+    "pd.option_context('mode.use_inf_as_na",  # continutation of line above
+]
 app_allow_js_errors: typing.Dict[str, typing.List[str]] = {
     "brownian": ["Failed to acquire camera feed:"],
 }
@@ -106,7 +146,7 @@ def wait_for_idle_app(
 # Run this test for each example app
 @pytest.mark.examples
 @pytest.mark.parametrize("ex_app_path", example_apps)
-@pytest.mark.flaky(reruns=3, reruns_delay=1)
+@pytest.mark.flaky(reruns=reruns, reruns_delay=1)
 def test_examples(page: Page, ex_app_path: str) -> None:
     app = run_shiny_app(here_root / ex_app_path, wait_for_start=True)
 
@@ -138,25 +178,39 @@ def test_examples(page: Page, ex_app_path: str) -> None:
 
         # Check for py-shiny errors
         error_lines = str(app.stderr).splitlines()
+
+        # Remove any errors that are allowed
+        error_lines = [
+            line
+            for line in error_lines
+            if not any([error_txt in line for error_txt in app_allow_external_errors])
+        ]
+
+        # Remove any app specific errors that are allowed
         if app_name in app_allow_shiny_errors:
             app_allowable_errors = app_allow_shiny_errors[app_name]
         else:
-            app_allowable_errors = False
+            app_allowable_errors = []
 
         # If all errors are not allowed, check for unexpected errors
-        if not (app_allowable_errors is True):
-            # Remove ^INFO lines
-            error_lines = [line for line in error_lines if not line.startswith("INFO:")]
+        if isinstance(app_allowable_errors, list):
+            app_allowable_errors = (
+                # Remove ^INFO lines
+                ["INFO:"]
+                # Remove any known errors caused by external packages
+                + app_allow_external_errors
+                # Remove any known errors allowed by the app
+                + app_allowable_errors
+            )
+
             # If there is an array of allowable errors, remove them from errors. Ex: `PlotnineWarning`
-            if isinstance(app_allowable_errors, list):
-                error_lines = [
-                    line
-                    for line in error_lines
-                    if not any(
-                        [error_txt in line for error_txt in app_allowable_errors]
-                    )
-                ]
-                app_allowable_errors = False
+            error_lines = [
+                line
+                for line in error_lines
+                if not any([error_txt in line for error_txt in app_allowable_errors])
+            ]
+            if len(error_lines) > 0:
+                print("\n".join(error_lines))
             assert len(error_lines) == 0
 
         # Check for JavaScript errors


### PR DESCRIPTION
Merged in contents of #725 