### PR TITLE
Run tests on Python 3.12

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         # "3.10" must be a string; otherwise it is interpreted as 3.1.
-        python-version: ["3.11", "3.10", "3.9", "3.8"]
+        python-version: ["3.12", "3.11", "3.10", "3.9", "3.8"]
         os: [ubuntu-latest, windows-latest, macOS-latest]
       fail-fast: false
 


### PR DESCRIPTION
This change makes tests run on Python 3.12 on GitHub Actions.

My earlier attempt at this resulted in failures due to a problems building a package that shiny's tests depend on; this PR is here so that we can wait until that package is fixed and then merge.