### PR TITLE
Remove output from template app

### DIFF
--- a/shiny/api-examples/template/app.py
+++ b/shiny/api-examples/template/app.py
@@ -1,14 +1,13 @@
 from shiny import App, render, ui
 
 app_ui = ui.page_fluid(
-    ui.h2("Hello Shiny!"),
+    ui.panel_title("Hello Shiny!"),
     ui.input_slider("n", "N", 0, 100, 20),
     ui.output_text_verbatim("txt"),
 )
 
 
 def server(input, output, session):
-    @output
     @render.text
     def txt():
         return f"n*2 is {input.n() * 2}"


### PR DESCRIPTION
So we don't forget to remove the `@output` from the default app before the next release. I also added a `panel_title` instead of an `h2` so that the app shows up in the browser tab. 