### PR TITLE
bug(sidebar): Revert sidebar icon back to chevron

### DIFF
--- a/shiny/ui/_sidebar.py
+++ b/shiny/ui/_sidebar.py
@@ -555,7 +555,7 @@ _sidebar_func = sidebar
 
 def _collapse_icon() -> TagChild:
     return HTML(
-        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="bi bi-arrow-bar-left collapse-icon" style="fill:currentColor;" aria-hidden="true" role="img" ><path fill-rule="evenodd" d="M12.5 15a.5.5 0 0 1-.5-.5v-13a.5.5 0 0 1 1 0v13a.5.5 0 0 1-.5.5ZM10 8a.5.5 0 0 1-.5.5H3.707l2.147 2.146a.5.5 0 0 1-.708.708l-3-3a.5.5 0 0 1 0-.708l3-3a.5.5 0 1 1 .708.708L3.707 7.5H9.5a.5.5 0 0 1 .5.5Z"></path></svg>'
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="bi bi-chevron-left collapse-icon" style="fill:currentColor;" aria-hidden="true" role="img" ><path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z"></path></svg>'
     )
 
 


### PR DESCRIPTION
Related: https://github.com/rstudio/bslib/pull/841/files#diff-363b351490c118118d1a95c0ee882a23303d7353746351a8cc63e0f2a1855d59

cc @wch 
