### PR TITLE
Keep version number to 3 components

### DIFF
--- a/shiny/__init__.py
+++ b/shiny/__init__.py
@@ -1,6 +1,6 @@
 """A package for building reactive web applications."""
 
-__version__ = "0.6.0.9000"
+__version__ = "0.6.1"
 
 from ._shinyenv import is_pyodide as _is_pyodide
 


### PR DESCRIPTION
Quarto uses semver rules to parse our version number, and chokes if it contains four elements