### PR TITLE
Use path to app as part of entrypoint for Express apps

### DIFF
--- a/shiny/_main.py
+++ b/shiny/_main.py
@@ -18,10 +18,11 @@ import uvicorn
 import uvicorn.config
 
 import shiny
-from shiny.express import is_express_app
 
 from . import _autoreload, _hostenv, _static, _utils
 from ._typing_extensions import NotRequired, TypedDict
+from .express import is_express_app
+from .express._utils import escape_to_var_name
 
 
 @click.group("main")
@@ -282,9 +283,9 @@ def run_app(
         app_no_suffix = re.sub(r":app$", "", app)
         if is_express_app(app_no_suffix, app_dir):
             app_path = Path(app_no_suffix).resolve()
-            # Set this so shiny.express.app.wrap_express_app() can find the app file.
-            os.environ["SHINY_EXPRESS_APP_FILE"] = str(app_path)
-            app = "shiny.express.app:app"
+            # If the file is "/path/to/app.py", our entrypoint with the escaped filename
+            # is "shiny.express.app:_2f_path_2f_to_2f_app_2e_py".
+            app = "shiny.express.app:" + escape_to_var_name(str(app_path))
             app_dir = str(app_path.parent)
         else:
             app, app_dir = resolve_app(app, app_dir)

--- a/shiny/express/_run.py
+++ b/shiny/express/_run.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import ast
-import os
 import sys
 from pathlib import Path
 from typing import cast
@@ -23,28 +22,19 @@ __all__ = ("wrap_express_app",)
 _DEFAULT_PAGE_FUNCTION = ui.page_fluid
 
 
-def wrap_express_app(file: Path | None = None) -> App:
-    """Wrap a Shiny express-mode app into a Shiny `App` object.
+def wrap_express_app(file: Path) -> App:
+    """Wrap a Shiny Express mode app into a Shiny `App` object.
 
     Parameters
     ----------
     file
-        The path to the file containing the Shiny express application. If `None`, the
-        `SHINY_EXPRESS_APP_FILE` environment variable is used.
+        The path to the file containing the Shiny express application.
 
     Returns
     -------
     :
         A `shiny.App` object.
     """
-    if file is None:
-        app_file = os.getenv("SHINY_EXPRESS_APP_FILE")
-        if app_file is None:
-            raise ValueError(
-                "No app file was specified and the SHINY_EXPRESS_APP_FILE environment variable "
-                "is not set."
-            )
-        file = Path(os.getcwd()) / app_file
 
     app_ui = run_express(file)
 

--- a/shiny/express/_utils.py
+++ b/shiny/express/_utils.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import re
+
+
+def escape_to_var_name(x: str) -> str:
+    """
+    Given a string, escape it to a valid Python variable name which contains
+    [a-zA-Z0-9_]. All other characters will be escaped to _<hex>_. Also, if the first
+    character is a digit, it will be escaped to _<hex>_, because Python variable names
+    can't begin with a digit.
+    """
+    encoded = ""
+    is_first = True
+
+    for char in x:
+        if is_first and char.isdigit():
+            encoded += f"_{ord(char):x}_"
+        elif char.isalnum():
+            encoded += char
+        else:
+            encoded += f"_{ord(char):x}_"
+
+        if is_first:
+            is_first = False
+
+    return encoded
+
+
+def unescape_from_var_name(x: str) -> str:
+    """
+    Given a string that was escaped to a Python variable name, unescape it -- that is,
+    convert it back to a regular string.
+    """
+
+    def replace_func(match: re.Match[str]) -> str:
+        return chr(int(match.group(1), 16))
+
+    decoded = re.sub("_([a-zA-Z0-9]+)_", replace_func, x)
+    return decoded

--- a/shiny/express/_utils.py
+++ b/shiny/express/_utils.py
@@ -14,9 +14,9 @@ def escape_to_var_name(x: str) -> str:
     is_first = True
 
     for char in x:
-        if is_first and char.isdigit():
+        if is_first and re.match("[0-9]", char):
             encoded += f"_{ord(char):x}_"
-        elif char.isalnum():
+        elif re.match("[a-zA-Z0-9]", char):
             encoded += char
         else:
             encoded += f"_{ord(char):x}_"

--- a/shiny/express/app.py
+++ b/shiny/express/app.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from .._app import App
+from pathlib import Path
+
 from ._run import wrap_express_app
+from ._utils import unescape_from_var_name
 
-app: App
 
-
+# If someone requests shiny.express.app:_2f_path_2f_to_2f_app_2e_py, then we will call
+# wrap_express_app(Path("/path/to/app.py")) and return the result.
 def __getattr__(name: str):
-    if name == "app":
-        return wrap_express_app()
-    raise AttributeError(f"Module 'shiny.express.app' has no attribute '{name}'")
+    name = unescape_from_var_name(name)
+    return wrap_express_app(Path(name))

--- a/tests/pytest/test_express_utils.py
+++ b/tests/pytest/test_express_utils.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from shiny.express._utils import escape_to_var_name, unescape_from_var_name
+
+
+def test_escape_var_name(tmp_path: Path):
+    x = "myapp.py"
+    y = escape_to_var_name(x)
+    assert y == "myapp_2e_py"
+    assert unescape_from_var_name(y) == x
+
+    x = "01myápp.py"
+    y = escape_to_var_name(x)
+    assert y == "_30_1my_e1_pp_2e_py"
+    assert unescape_from_var_name(y) == x
+
+    x = "path/to/your_🐍file.py"
+    y = escape_to_var_name(x)
+    assert y == "path_2f_to_2f_your_5f__1f40d_file_2e_py"
+    assert unescape_from_var_name(y) == x


### PR DESCRIPTION
For running Express apps, this PR makes it so that setting an environment variable is no longer needed for uvicorn to launch the app; instead, if the app path is:

```
path/to/app.py
```

then this sets the entrypoint to

```
shiny.express.app:path_2f_to_2f_app_2e_py
```

This will make it possible to deploy on shinyapps.io.

The escaping rule is this:
- For all characters that are _not_ numbers or letters escape them by replacing with `_<hex>_`, where `<hex>` is the hexadecimal representation of the character.
- In addition, if the first character is a number, escape it the same way. This is because variable names in Python can't start with a number. For example, `0app_2e_py` is not a valid name, and so can't be used as part of an entrypoint, as in  `shiny.express.app:0app_2e_py`.

In my testing, I found that uvicorn actually would accept other characters, like if you run:

```py
uvicorn shiny.express.app:path/to/app.py
```

However, `gunicorn` would error if you run:

```py
gunicorn shiny.express.app:path/to/app.py
```

because in `gunicorn` [tries to parse](https://github.com/benoitc/gunicorn/blob/02d3dd8b7ae28816a37623077388dbcfdbfd4379/gunicorn/util.py#L387-L393) the part after the `:` as an `ast.Name` or `ast.Call`, and `path/to/app.py` contains characters that are invalid for either of those types.

I decided to play it safe and make it general by escaping to valid Python variable names.