### PR TITLE
Add lowercase `reactive.value`, `calc`, `effect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New features
 
+* Closed #814: The classes `reactive.Value`, `reactive.Calc`, and `reactive.Effect` have been changed to have lowercase names: `reactive.value`, `reactive.calc`, and `reactive.effect`. The old capitalized names are now aliases to the new lowercase names, so existing code will continue to work. The examples have not been changed yet, but will be changed in a future release. (#822)
+
 ### Bug fixes
 
 * Fix support for `shiny.ui.accordion(multiple=)` (#799).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New features
 
-* Closed #814: The classes `reactive.Value`, `reactive.Calc`, and `reactive.Effect` have been changed to have lowercase names: `reactive.value`, `reactive.calc`, and `reactive.effect`. The old capitalized names are now aliases to the new lowercase names, so existing code will continue to work. The examples have not been changed yet, but will be changed in a future release. (#822)
+* Closed #814: The functions `reactive.Calc` and `reactive.Effect` have been changed to have lowercase names: `reactive.calc`, and `reactive.effect`. The old capitalized names are now aliases to the new lowercase names, so existing code will continue to work. Similarly, the class `reactive.Value` has a new alias, `reactive.value`, but in this case, since the original was a class, it keeps the original capitalized name as the primary name. The examples have not been changed yet, but will be changed in a future release. (#822)
 
 ### Bug fixes
 

--- a/docs/_quartodoc.yml
+++ b/docs/_quartodoc.yml
@@ -186,6 +186,9 @@ quartodoc:
     - title: Reactive programming
       desc: ""
       contents:
+        - reactive.calc
+        - reactive.effect
+        - reactive.value
         - reactive.Calc
         - reactive.Effect
         - reactive.Value

--- a/shiny/reactive/__init__.py
+++ b/shiny/reactive/__init__.py
@@ -8,10 +8,13 @@ from ._core import (  # noqa: F401
 )
 from ._poll import poll, file_reader
 from ._reactives import (  # noqa: F401
+    value,
     Value,
+    calc,
     Calc,
     Calc_,  # pyright: ignore[reportUnusedImport]
     CalcAsync_,  # pyright: ignore[reportUnusedImport]
+    effect,
     Effect,
     Effect_,  # pyright: ignore[reportUnusedImport]
     event,
@@ -26,8 +29,11 @@ __all__ = (
     "on_flushed",
     "poll",
     "file_reader",
+    "value",
     "Value",
+    "calc",
     "Calc",
+    "effect",
     "Effect",
     "event",
 )

--- a/shiny/reactive/_poll.py
+++ b/shiny/reactive/_poll.py
@@ -96,10 +96,10 @@ def poll(
     """
 
     with reactive.isolate():
-        last_value: reactive.Value[Any] = reactive.Value(poll_func())
-        last_error: reactive.Value[Optional[Exception]] = reactive.Value(None)
+        last_value: reactive.value[Any] = reactive.value(poll_func())
+        last_error: reactive.value[Optional[Exception]] = reactive.value(None)
 
-    @reactive.Effect(priority=priority, session=session)
+    @reactive.effect(priority=priority, session=session)
     async def _():
         try:
             if _utils.is_async_callable(poll_func):
@@ -159,7 +159,7 @@ def poll(
     def wrapper(fn: Callable[[], T]) -> Callable[[], T]:
         if _utils.is_async_callable(fn):
 
-            @reactive.Calc(session=session)
+            @reactive.calc(session=session)
             @functools.wraps(fn)
             async def result_async() -> T:
                 # If an error occurred, raise it
@@ -182,7 +182,7 @@ def poll(
 
         else:
 
-            @reactive.Calc(session=session)
+            @reactive.calc(session=session)
             @functools.wraps(fn)
             def result_sync() -> T:
                 # If an error occurred, raise it

--- a/shiny/reactive/_poll.py
+++ b/shiny/reactive/_poll.py
@@ -96,8 +96,8 @@ def poll(
     """
 
     with reactive.isolate():
-        last_value: reactive.value[Any] = reactive.value(poll_func())
-        last_error: reactive.value[Optional[Exception]] = reactive.value(None)
+        last_value: reactive.Value[Any] = reactive.Value(poll_func())
+        last_error: reactive.Value[Optional[Exception]] = reactive.Value(None)
 
     @reactive.effect(priority=priority, session=session)
     async def _():

--- a/shiny/reactive/_reactives.py
+++ b/shiny/reactive/_reactives.py
@@ -46,7 +46,7 @@ T = TypeVar("T")
 # Value
 # ==============================================================================
 @add_example()
-class value(Generic[T]):
+class Value(Generic[T]):
     """
     Create a reactive value.
 
@@ -215,8 +215,7 @@ class value(Generic[T]):
         self._value = MISSING
 
 
-# Alias for backward compatibility
-Value = value
+value = Value
 
 # ==============================================================================
 # Calc

--- a/shiny/reactive/_reactives.py
+++ b/shiny/reactive/_reactives.py
@@ -2,7 +2,18 @@
 
 from __future__ import annotations
 
-__all__ = ("Value", "Calc", "Calc_", "CalcAsync_", "Effect", "Effect_", "event")
+__all__ = (
+    "value",
+    "Value",
+    "calc",
+    "Calc",
+    "Calc_",
+    "CalcAsync_",
+    "effect",
+    "Effect",
+    "Effect_",
+    "event",
+)
 
 import functools
 import traceback
@@ -35,7 +46,7 @@ T = TypeVar("T")
 # Value
 # ==============================================================================
 @add_example()
-class Value(Generic[T]):
+class value(Generic[T]):
     """
     Create a reactive value.
 
@@ -204,6 +215,9 @@ class Value(Generic[T]):
         self._value = MISSING
 
 
+# Alias for backward compatibility
+Value = value
+
 # ==============================================================================
 # Calc
 # ==============================================================================
@@ -343,12 +357,12 @@ class CalcAsync_(Calc_[T]):
 
 
 @overload
-def Calc(fn: CalcFunctionAsync[T]) -> CalcAsync_[T]:
+def calc(fn: CalcFunctionAsync[T]) -> CalcAsync_[T]:
     ...
 
 
 @overload
-def Calc(fn: CalcFunction[T]) -> Calc_[T]:
+def calc(fn: CalcFunction[T]) -> Calc_[T]:
     ...
 
 
@@ -373,14 +387,14 @@ def Calc(fn: CalcFunction[T]) -> Calc_[T]:
 # __call__ method) or CalcAsync object (which has an async __call__ method), and it
 # works out.
 @overload
-def Calc(
+def calc(
     *, session: "MISSING_TYPE | Session | None" = MISSING
 ) -> Callable[[CalcFunction[T]], Calc_[T]]:
     ...
 
 
 @add_example()
-def Calc(
+def calc(
     fn: Optional[CalcFunction[T] | CalcFunctionAsync[T]] = None,
     *,
     session: "MISSING_TYPE | Session | None" = MISSING,
@@ -433,6 +447,9 @@ def Calc(
     else:
         return create_calc(fn)
 
+
+# Alias for backward compatibility
+Calc = calc
 
 # ==============================================================================
 # Effect
@@ -630,12 +647,12 @@ class Effect_:
 
 
 @overload
-def Effect(fn: EffectFunction | EffectFunctionAsync) -> Effect_:
+def effect(fn: EffectFunction | EffectFunctionAsync) -> Effect_:
     ...
 
 
 @overload
-def Effect(
+def effect(
     *,
     suspended: bool = False,
     priority: int = 0,
@@ -645,7 +662,7 @@ def Effect(
 
 
 @add_example()
-def Effect(
+def effect(
     fn: Optional[EffectFunction | EffectFunctionAsync] = None,
     *,
     suspended: bool = False,
@@ -704,6 +721,9 @@ def Effect(
         return create_effect
     else:
         return create_effect(fn)
+
+
+Effect = effect
 
 
 # ==============================================================================

--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -46,7 +46,7 @@ from .._typing_extensions import TypedDict
 from .._utils import wrap_async
 from ..http_staticfiles import FileResponse
 from ..input_handler import input_handlers
-from ..reactive import Effect_, effect, flush, isolate, value
+from ..reactive import Effect_, Value, effect, flush, isolate
 from ..reactive._core import lock, on_flushed
 from ..render.transformer import OutputRenderer
 from ..types import SafeException, SilentCancelOutputException, SilentException
@@ -345,7 +345,7 @@ class Session(object, metaclass=SessionMeta):
             # id; make that explicit by wrapping it in ResolvedId, otherwise self.input
             # will throw an id validation error.
             hidden_value_obj = cast(
-                value[bool], self.input[ResolvedId(f".clientdata_output_{name}_hidden")]
+                Value[bool], self.input[ResolvedId(f".clientdata_output_{name}_hidden")]
             )
             if not hidden_value_obj.is_set():
                 return True
@@ -898,24 +898,24 @@ class Inputs:
     """
 
     def __init__(
-        self, values: dict[str, value[Any]], ns: Callable[[str], str] = Root
+        self, values: dict[str, Value[Any]], ns: Callable[[str], str] = Root
     ) -> None:
         self._map = values
         self._ns = ns
 
-    def __setitem__(self, key: str, value: value[Any]) -> None:
-        if not isinstance(value, reactive.value):
+    def __setitem__(self, key: str, value: Value[Any]) -> None:
+        if not isinstance(value, reactive.Value):
             raise TypeError("`value` must be a reactive.Value object.")
 
         self._map[self._ns(key)] = value
 
-    def __getitem__(self, key: str) -> value[Any]:
+    def __getitem__(self, key: str) -> Value[Any]:
         key = self._ns(key)
         # Auto-populate key if accessed but not yet set. Needed to take reactive
         # dependencies on input values that haven't been received from client
         # yet.
         if key not in self._map:
-            self._map[key] = value[Any](read_only=True)
+            self._map[key] = Value[Any](read_only=True)
 
         return self._map[key]
 
@@ -923,14 +923,14 @@ class Inputs:
         del self._map[self._ns(key)]
 
     # Allow access of values as attributes.
-    def __setattr__(self, attr: str, value: value[Any]) -> None:
+    def __setattr__(self, attr: str, value: Value[Any]) -> None:
         if attr in ("_map", "_ns"):
             super().__setattr__(attr, value)
             return
 
         self.__setitem__(attr, value)
 
-    def __getattr__(self, attr: str) -> value[Any]:
+    def __getattr__(self, attr: str) -> Value[Any]:
         if attr in ("_map", "_ns"):
             return object.__getattribute__(self, attr)
         return self.__getitem__(attr)

--- a/tests/deploys/apps/plotly_app/app.py
+++ b/tests/deploys/apps/plotly_app/app.py
@@ -61,7 +61,7 @@ def server(input, output, session):
             height="100%",
         )
 
-    @reactive.Calc
+    @reactive.calc
     def filtered_df():
         selected_idx = list(req(input.summary_data_selected_rows()))
         countries = summary_df["country"][selected_idx]
@@ -116,7 +116,7 @@ def synchronize_size(output_id):
     def wrapper(func):
         input = session.get_current_session().input
 
-        @reactive.Effect
+        @reactive.effect
         def size_updater():
             func(
                 input[f".clientdata_output_{output_id}_width"](),

--- a/tests/e2e/TODO/sidebar/app.py
+++ b/tests/e2e/TODO/sidebar/app.py
@@ -62,24 +62,24 @@ def server(input: Inputs, output: Outputs, session: Session) -> None:
     def ui_content():
         return f"Hello, {input.adjective()} {input.animal()}!"
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.open_all)
     def _():
         ui.update_sidebar("sidebar_inner", show=True)
         ui.update_sidebar("sidebar_outer", show=True)
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.close_all)
     def _():
         ui.update_sidebar("sidebar_inner", show=False)
         ui.update_sidebar("sidebar_outer", show=False)
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.toggle_inner)
     def _():
         ui.update_sidebar("sidebar_inner", show=not input.sidebar_inner())
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.toggle_outer)
     def _():
         ui.update_sidebar("sidebar_outer", show=not input.sidebar_outer())

--- a/tests/e2e/TODO/update_popover/app.py
+++ b/tests/e2e/TODO/update_popover/app.py
@@ -14,12 +14,12 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Effect
+    @reactive.effect
     def _():
         # Immediately display popover
         ui.update_popover("popover_id", show=True)
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.btn_update)
     def _():
         content = (
@@ -33,7 +33,7 @@ def server(input: Inputs, output: Outputs, session: Session):
             #   show=True
         )
 
-    @reactive.Effect
+    @reactive.effect
     def _():
         req(input.btn_w_popover())
         ui.notification_show("Button clicked!", duration=3, type="message")

--- a/tests/e2e/async/app.py
+++ b/tests/e2e/async/app.py
@@ -31,7 +31,7 @@ def server(input: s.Inputs, output: s.Outputs, session: s.Session):
         content = await hash_result()
         return content
 
-    @reactive.Calc()
+    @reactive.calc()
     async def hash_result() -> str:
         with ui.Progress() as p:
             p.set(message="Calculating...")

--- a/tests/e2e/bugs/0648-update-slider-datetime-value/app.py
+++ b/tests/e2e/bugs/0648-update-slider-datetime-value/app.py
@@ -51,7 +51,7 @@ def slider_with_reset_server(
         else:
             return input.times()
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.reset)
     def reset_time():
         ui.update_slider("times", min=min, max=max, value=value)

--- a/tests/e2e/bugs/0696-resolve-id/app.py
+++ b/tests/e2e/bugs/0696-resolve-id/app.py
@@ -217,7 +217,7 @@ def mod_x_server(
 ):
     session_dict[session.ns] = session
 
-    @reactive.Calc
+    @reactive.calc
     def n():
         return int(letters.index(input.input_radio_buttons()))
 
@@ -394,7 +394,7 @@ def server(input: Inputs, output: Outputs, session: Session):
         ui.update_popover("explanation", show=True)
 
         # On button clicks, hide the explanation popover
-        @reactive.Effect(suspended=True)
+        @reactive.effect(suspended=True)
         def _():
             input.reset()
             input.update_global()
@@ -482,7 +482,7 @@ def server(input: Inputs, output: Outputs, session: Session):
     for _input_key, session_key in module_keys:
         offsets[session_key] = 0
 
-    @reactive.Effect
+    @reactive.effect
     def _():
         # trigger reactivity
         input.reset()
@@ -492,7 +492,7 @@ def server(input: Inputs, output: Outputs, session: Session):
                 update_session(session_dict[session_key], count=0)
 
     def update_session_effect(*, input_key: str, session_key: str) -> None:
-        @reactive.Effect
+        @reactive.effect
         @reactive.event(input[input_key])
         def _():
             update_session(

--- a/tests/e2e/inputs/input_file/app.py
+++ b/tests/e2e/inputs/input_file/app.py
@@ -20,7 +20,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Calc
+    @reactive.calc
     def parsed_file():
         file: typing.Union[typing.List["FileInfo"], None] = input.file1()
         if file is None:

--- a/tests/e2e/navs/navset_hidden/app.py
+++ b/tests/e2e/navs/navset_hidden/app.py
@@ -20,7 +20,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.controller)
     def _():
         ui.update_navs("hidden_tabs", selected="panel" + str(input.controller()))

--- a/tests/e2e/session/flush/app.py
+++ b/tests/e2e/session/flush/app.py
@@ -81,12 +81,12 @@ def server(input: Inputs, output: Outputs, session: Session):
     session.on_ended(on_ended_async("session ended - async - test3"))
     session.on_ended(on_ended_sync("session ended - sync - test4"))
 
-    all_vals: reactive.value[tuple[str, ...]] = reactive.value(())
-    flush_vals: reactive.value[tuple[str, ...]] = reactive.value(())
-    flushed_vals: reactive.value[tuple[str, ...]] = reactive.value(())
+    all_vals: reactive.Value[tuple[str, ...]] = reactive.Value(())
+    flush_vals: reactive.Value[tuple[str, ...]] = reactive.Value(())
+    flushed_vals: reactive.Value[tuple[str, ...]] = reactive.Value(())
 
     def call_a(
-        vals: reactive.value[tuple[str, ...]],
+        vals: reactive.Value[tuple[str, ...]],
         suffix: str,
     ):
         def _():
@@ -97,7 +97,7 @@ def server(input: Inputs, output: Outputs, session: Session):
         return _
 
     def call_b(
-        vals: reactive.value[tuple[str, ...]],
+        vals: reactive.Value[tuple[str, ...]],
         suffix: str,
     ):
         async def _():
@@ -112,7 +112,7 @@ def server(input: Inputs, output: Outputs, session: Session):
         return _
 
     def call_c(
-        vals: reactive.value[tuple[str, ...]],
+        vals: reactive.Value[tuple[str, ...]],
         suffix: str,
     ):
         def _():

--- a/tests/e2e/session/flush/app.py
+++ b/tests/e2e/session/flush/app.py
@@ -81,12 +81,12 @@ def server(input: Inputs, output: Outputs, session: Session):
     session.on_ended(on_ended_async("session ended - async - test3"))
     session.on_ended(on_ended_sync("session ended - sync - test4"))
 
-    all_vals: reactive.Value[tuple[str, ...]] = reactive.Value(())
-    flush_vals: reactive.Value[tuple[str, ...]] = reactive.Value(())
-    flushed_vals: reactive.Value[tuple[str, ...]] = reactive.Value(())
+    all_vals: reactive.value[tuple[str, ...]] = reactive.value(())
+    flush_vals: reactive.value[tuple[str, ...]] = reactive.value(())
+    flushed_vals: reactive.value[tuple[str, ...]] = reactive.value(())
 
     def call_a(
-        vals: reactive.Value[tuple[str, ...]],
+        vals: reactive.value[tuple[str, ...]],
         suffix: str,
     ):
         def _():
@@ -97,7 +97,7 @@ def server(input: Inputs, output: Outputs, session: Session):
         return _
 
     def call_b(
-        vals: reactive.Value[tuple[str, ...]],
+        vals: reactive.value[tuple[str, ...]],
         suffix: str,
     ):
         async def _():
@@ -112,7 +112,7 @@ def server(input: Inputs, output: Outputs, session: Session):
         return _
 
     def call_c(
-        vals: reactive.Value[tuple[str, ...]],
+        vals: reactive.value[tuple[str, ...]],
         suffix: str,
     ):
         def _():
@@ -125,11 +125,11 @@ def server(input: Inputs, output: Outputs, session: Session):
     # Continuously trigger the reactive graph to ensure that the flush / flushed
     # callbacks are called. If this Effect is not called, then the click counter will
     # always be one higher than the flush/flushed values displayed.
-    @reactive.Effect
+    @reactive.effect
     def _():
         reactive.invalidate_later(0.25)
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.btn)
     def _():
         btn_count = input.btn()

--- a/tests/e2e/ui/accordion/app.py
+++ b/tests/e2e/ui/accordion/app.py
@@ -29,14 +29,14 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session) -> None:
-    @reactive.Calc
+    @reactive.calc
     def acc() -> list[str]:
         acc_val: list[str] | None = input.acc()
         if acc_val is None:
             acc_val = []
         return acc_val
 
-    @reactive.Effect
+    @reactive.effect
     def _():
         req(input.toggle_b())
 
@@ -46,12 +46,12 @@ def server(input: Inputs, output: Outputs, session: Session) -> None:
             else:
                 ui.update_accordion_panel("acc", "Section B", show=True)
 
-    @reactive.Effect
+    @reactive.effect
     def _():
         req(input.open_all())
         ui.update_accordion("acc", show=True)
 
-    @reactive.Effect
+    @reactive.effect
     def _():
         req(input.close_all())
         ui.update_accordion("acc", show=False)
@@ -60,7 +60,7 @@ def server(input: Inputs, output: Outputs, session: Session) -> None:
     has_alternate = True
     has_updates = False
 
-    @reactive.Effect
+    @reactive.effect
     def _():
         req(input.alternate())
 
@@ -79,7 +79,7 @@ def server(input: Inputs, output: Outputs, session: Session) -> None:
         ui.update_accordion("acc", show=sections)
         has_alternate = not has_alternate
 
-    @reactive.Effect
+    @reactive.effect
     def _():
         req(input.toggle_efg())
 
@@ -93,7 +93,7 @@ def server(input: Inputs, output: Outputs, session: Session) -> None:
 
         has_efg = not has_efg
 
-    @reactive.Effect
+    @reactive.effect
     def _():
         req(input.toggle_updates())
 

--- a/tests/e2e/ui/popover/app.py
+++ b/tests/e2e/ui/popover/app.py
@@ -15,19 +15,19 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Effect
+    @reactive.effect
     def _():
         req(input.btn_show())
 
         ui.update_popover("popover_id", show=True)
 
-    @reactive.Effect
+    @reactive.effect
     def _():
         req(input.btn_close())
 
         ui.update_popover("popover_id", show=False)
 
-    @reactive.Effect
+    @reactive.effect
     def _():
         req(input.btn_w_popover())
         ui.notification_show("Button clicked!", duration=3, type="message")

--- a/tests/e2e/ui/tooltip/app.py
+++ b/tests/e2e/ui/tooltip/app.py
@@ -15,19 +15,19 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Effect
+    @reactive.effect
     def _():
         req(input.btn_show())
 
         ui.update_tooltip("tooltip_id", show=True)
 
-    @reactive.Effect
+    @reactive.effect
     def _():
         req(input.btn_close())
 
         ui.update_tooltip("tooltip_id", show=False)
 
-    @reactive.Effect
+    @reactive.effect
     def _():
         req(input.btn_w_tooltip())
         ui.notification_show("Button clicked!", duration=3, type="message")

--- a/tests/pytest/test_modules.py
+++ b/tests/pytest/test_modules.py
@@ -45,11 +45,11 @@ async def test_session_scoping():
 
     @module.server
     def inner_server(input: Inputs, output: Outputs, session: Session):
-        @reactive.Calc
+        @reactive.calc
         def out():
             return get_current_session()
 
-        @reactive.Effect
+        @reactive.effect
         def _():
             sessions["inner"] = session
             sessions["inner_current"] = get_current_session()
@@ -59,11 +59,11 @@ async def test_session_scoping():
 
     @module.server
     def outer_server(input: Inputs, output: Outputs, session: Session):
-        @reactive.Calc
+        @reactive.calc
         def out():
             return get_current_session()
 
-        @reactive.Effect
+        @reactive.effect
         def _():
             inner_server("mod_inner")
             sessions["outer"] = session
@@ -75,11 +75,11 @@ async def test_session_scoping():
     def server(input: Inputs, output: Outputs, session: Session):
         outer_server("mod_outer")
 
-        @reactive.Calc
+        @reactive.calc
         def out():
             return get_current_session()
 
-        @reactive.Effect
+        @reactive.effect
         def _():
             sessions["top"] = session
             sessions["top_current"] = get_current_session()

--- a/tests/pytest/test_poll.py
+++ b/tests/pytest/test_poll.py
@@ -11,7 +11,7 @@ import pytest
 
 from shiny import Session, _utils, session
 from shiny._namespaces import Root
-from shiny.reactive import effect, file_reader, flush, isolate, poll, value
+from shiny.reactive import Value, effect, file_reader, flush, isolate, poll
 
 from .mocktime import MockTime
 
@@ -57,9 +57,9 @@ async def test_poll():
     async with OnEndedSessionCallbacks():
         poll_invocations = 0
         poll_return1 = 0  # A non-reactive component of the return value
-        poll_return2 = value(0)  # A reactive component of the return value
+        poll_return2 = Value(0)  # A reactive component of the return value
         value_invocations = 0
-        value_dep = value(0)
+        value_dep = Value(0)
 
         def poll_func():
             nonlocal poll_invocations

--- a/tests/pytest/test_poll.py
+++ b/tests/pytest/test_poll.py
@@ -11,7 +11,7 @@ import pytest
 
 from shiny import Session, _utils, session
 from shiny._namespaces import Root
-from shiny.reactive import Effect, Value, file_reader, flush, isolate, poll
+from shiny.reactive import effect, file_reader, flush, isolate, poll, value
 
 from .mocktime import MockTime
 
@@ -57,9 +57,9 @@ async def test_poll():
     async with OnEndedSessionCallbacks():
         poll_invocations = 0
         poll_return1 = 0  # A non-reactive component of the return value
-        poll_return2 = Value(0)  # A reactive component of the return value
+        poll_return2 = value(0)  # A reactive component of the return value
         value_invocations = 0
-        value_dep = Value(0)
+        value_dep = value(0)
 
         def poll_func():
             nonlocal poll_invocations
@@ -83,7 +83,7 @@ async def test_poll():
             # @poll returns a lazy Calc, so value hasn't been invoked yet.
             assert (poll_invocations, value_invocations) == (2, 0)
 
-            @Effect()
+            @effect()
             def _():
                 value_func()
 
@@ -157,7 +157,7 @@ async def test_poll_errors():
 
             invocations = 0
 
-            @Effect()
+            @effect()
             def _():
                 nonlocal invocations
                 invocations += 1

--- a/tests/pytest/test_shinysession.py
+++ b/tests/pytest/test_shinysession.py
@@ -3,7 +3,7 @@
 import pytest
 
 from shiny import ui
-from shiny.reactive import Effect, flush, isolate
+from shiny.reactive import effect, flush, isolate
 from shiny.session import Inputs
 from shiny.types import SilentException
 
@@ -55,7 +55,7 @@ async def test_input_nonexistent_deps():
     input = Inputs({})
     result = None
 
-    @Effect()
+    @effect()
     def o1():
         nonlocal result
         result = "x" in input


### PR DESCRIPTION
This closes #814.

Many users have wondered why `reactive.Value`, `.Calc`, and `.Effect` are capitalized. There are technical reasons for this, but from a user perspective it makes more sense to just use lowercase names.

This PR changes those names to lowercase, and adds aliases so that the old capitalized names still work. 

This PR does not change any examples because if users on a previous version of shiny were to use the example code, it wouldn't work for them, and it would be unclear to them why. In a future release, we should update the examples to use the new lowercase names.