### PR TITLE
Make @display_body and @render.display work in Jupyter cells

### DIFF
--- a/shiny/quarto.py
+++ b/shiny/quarto.py
@@ -79,6 +79,8 @@ from shiny import App, Inputs, Outputs, Session, ui
 def server(input: Inputs, output: Outputs, session: Session) -> None:
 { "".join(session_code_cell_texts) }
 
+    return None
+
 
 _static_assets = ##STATIC_ASSETS_PLACEHOLDER##
 _static_assets = {{"/" + sa: Path(__file__).parent / sa for sa in _static_assets}}


### PR DESCRIPTION
Also small fix to make Shiny Express compile cleanly even if there are no code cells. I ran into this when I made a minimal server:shiny .qmd and tried to run it.