### PR TITLE
Use development version of shiny for Connect deployments.

### DIFF
--- a/tests/deploys/apps/plotly_app/app.py
+++ b/tests/deploys/apps/plotly_app/app.py
@@ -3,9 +3,7 @@ import plotly.express as px
 import plotly.graph_objs as go
 from shinywidgets import output_widget, render_widget
 
-from shiny import App
-from shiny import experimental as x
-from shiny import reactive, render, req, session, ui
+from shiny import App, reactive, render, req, session, ui
 
 # Load the Gapminder dataset
 df = px.data.gapminder()
@@ -26,23 +24,23 @@ summary_df = (
 summary_df.columns = ["_".join(col).strip() for col in summary_df.columns.values]
 summary_df.rename(columns={"country_": "country"}, inplace=True)
 
-app_ui = x.ui.page_fillable(
+app_ui = ui.page_fillable(
     {"class": "p-3"},
     ui.p(
         ui.strong("Instructions:"),
         " Select one or more countries in the table below to see more information.",
     ),
-    x.ui.layout_column_wrap(
+    ui.layout_column_wrap(
         1,
-        x.ui.card(
+        ui.card(
             ui.output_data_frame("summary_data"),
         ),
-        x.ui.layout_column_wrap(
+        ui.layout_column_wrap(
             1 / 2,
-            x.ui.card(
+            ui.card(
                 output_widget("country_detail_pop", height="100%"),
             ),
-            x.ui.card(
+            ui.card(
                 output_widget("country_detail_percap", height="100%"),
             ),
         ),

--- a/tests/deploys/apps/plotly_app/requirements.txt
+++ b/tests/deploys/apps/plotly_app/requirements.txt
@@ -2,4 +2,4 @@ pandas
 plotly
 git+https://github.com/posit-dev/py-shiny.git#egg=shiny
 git+https://github.com/posit-dev/py-htmltools#egg=htmltools
-shinywidgets
+git+https://github.com/posit-dev/py-shinywidgets#egg=shinywidgets

--- a/tests/deploys/apps/plotly_app/requirements.txt
+++ b/tests/deploys/apps/plotly_app/requirements.txt
@@ -1,4 +1,5 @@
 pandas
 plotly
-shiny
+git+https://github.com/posit-dev/py-shiny.git#egg=shiny
+git+https://github.com/posit-dev/py-htmltools#egg=htmltools
 shinywidgets


### PR DESCRIPTION
The previous deployment tests were not actually testing the development version of pyshiny on Connect. The way Connect deployment works is:

1) Check if there's a requirements.txt file, if not, generate a new one from the active environment with `pip freeze`
2) Install packages from that file in a virtual environment on Connect

So when we had a requirments.txt file which specified `shiny` it would install shiny from pypi which is to say that our deployment tests were always testing one version back. 