### PR TITLE
Make `page_fillable()` the default for express mode

### DIFF
--- a/shiny/express/_run.py
+++ b/shiny/express/_run.py
@@ -19,7 +19,7 @@ from .display_decorator._node_transformers import (
 
 __all__ = ("wrap_express_app",)
 
-_DEFAULT_PAGE_FUNCTION = ui.page_fluid
+_DEFAULT_PAGE_FUNCTION = ui.page_fillable
 
 
 def wrap_express_app(file: Path) -> App:


### PR DESCRIPTION
Closes #846.

With this PR, `page_fillable()` becomes the new page default for express. This should lead to the same experience as before for non-fill items (e.g., inputs, text, etc), but fill items like plots, cards, layouts, etc. will now fill the page (when wide enough).

Moreover, this default is more consistent with the `with layout.sidebar()` experience, which treats the main content area as a fillable container (by default).

For a concrete example, notice that the plot here will now fill the page:

```python
from shiny import App, render, ui
from shiny.express import input

ui.input_slider("slider", label="Slider", min=0, max=100, value=50)

@render.plot()
def plt():
    import matplotlib.pyplot as plt
    import numpy as np
    x = np.linspace(0, 2 * np.pi, 100)
    y = np.sin(x * input.slider())
    fig, ax = plt.subplots()
    ax.plot(x, y)
    return fig
```