### PR TITLE
Pass express' sidebar title arg to the page title

### DIFF
--- a/shiny/express/layout.py
+++ b/shiny/express/layout.py
@@ -56,11 +56,11 @@ pre = wrap_recall_context_manager(htmltools.pre)
 # ======================================================================================
 def sidebar(
     *,
+    title: Optional[str | Tag | TagList] = None,
     width: CssUnit = 250,
     position: Literal["left", "right"] = "left",
     open: Literal["desktop", "open", "closed", "always"] = "always",
     id: Optional[str] = None,
-    title: TagChild | str = None,
     bg: Optional[str] = None,
     fg: Optional[str] = None,
     class_: Optional[str] = None,  # TODO-future; Consider using `**kwargs` instead
@@ -69,12 +69,14 @@ def sidebar(
     padding: Optional[CssUnit | list[CssUnit]] = None,
 ) -> RecallContextManager[ui.Sidebar]:
     """
-    Sidebar element
+    A page-level sidebar layout.
 
     Create a collapsing sidebar layout. This function wraps :func:`~shiny.ui.sidebar`.
 
     Parameters
     ----------
+    title
+        A title to display at the top of the page.
     width
         A valid CSS unit used for the width of the sidebar.
     position
@@ -91,11 +93,6 @@ def sidebar(
     id
         A character string. Required if wanting to re-actively read (or update) the
         `collapsible` state in a Shiny app.
-    title
-        A character title to be used as the sidebar title, which will be wrapped in a
-        `<div>` element with class `sidebar-title`. You can also provide a custom
-        :class:`~htmltools.Tag` for the title element, in which case you'll
-        likely want to give this element `class = "sidebar-title"`.
     bg,fg
         A background or foreground color.
     class_
@@ -126,13 +123,12 @@ def sidebar(
     """
     return RecallContextManager(
         ui.sidebar,
-        default_page=page_sidebar(),
+        default_page=page_sidebar(title=title),
         kwargs=dict(
             width=width,
             position=position,
             open=open,
             id=id,
-            title=title,
             bg=bg,
             fg=fg,
             class_=class_,


### PR DESCRIPTION
With this change, this code will yield the following:

```python
from shiny.express import layout

with layout.sidebar(title="My title"):
    "Sidebar"

"Main content"
```

<img width="1062" alt="Screenshot 2023-12-06 at 10 33 03 AM" src="https://github.com/posit-dev/py-shiny/assets/1365941/410c78b1-f709-4ed0-b958-9139190d04f3">


Instead of 

<img width="1060" alt="Screenshot 2023-12-06 at 10 34 29 AM" src="https://github.com/posit-dev/py-shiny/assets/1365941/80f8881a-f5c8-4831-9e9f-9aaaa5c4a992">


(The latter design is intended more for "inline" sidebar layouts, which `with layout.sidebar()` doesn't support)
