### PR TITLE
Fix failing express tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,13 +94,16 @@ install-playwright:
 install-trcli:
 	which trcli || pip install trcli
 
+install-rsconnect: ## install the main version of rsconnect till pypi version supports shiny express
+	pip install git+https://github.com/rstudio/rsconnect-python.git#egg=rsconnect-python
+
 playwright-shiny: install-playwright ## end-to-end tests with playwright
 	pytest tests/playwright/shiny/$(SUB_FILE)
 
 playwright-examples: install-playwright ## end-to-end tests on examples with playwright
 	pytest tests/playwright/examples
 
-playwright-deploys: install-playwright ## end-to-end tests on deploys with playwright
+playwright-deploys: install-playwright install-rsconnect ## end-to-end tests on deploys with playwright
 	pytest tests/playwright/deploys/$(SUB_FILE) -s
 
 testrail-junit: install-playwright install-trcli ## end-to-end tests with playwright and generate junit report

--- a/tests/playwright/shiny/shiny-express/page_default/app.py
+++ b/tests/playwright/shiny/shiny-express/page_default/app.py
@@ -28,14 +28,14 @@ with layout.div(id="shell"):
 
 with layout.column(width=6):
     # check height is below 300px - bounding box
-    with layout.navset_card_tab(id="express_navset_card_tab"):
+    with layout.navset_card(id="express_navset_card_tab", type="tab"):
         with layout.nav(title="Two"):
             ...
 
 
 with layout.column(width=6):
     with layout.row():
-        with layout.navset_tab(id="express_navset_tab"):
+        with layout.navset(id="express_navset_tab", type="tab"):
             for fn_txt, fn in [
                 ("pre", layout.pre),
                 ("div", layout.div),

--- a/tests/playwright/shiny/shiny-express/page_default/test_page_default.py
+++ b/tests/playwright/shiny/shiny-express/page_default/test_page_default.py
@@ -3,6 +3,6 @@ from playwright.sync_api import Page
 from utils.express_utils import verify_express_page_default
 
 
-def test_express_accordion(page: Page, local_app: ShinyAppProc) -> None:
+def test_page_default(page: Page, local_app: ShinyAppProc) -> None:
     page.goto(local_app.url)
     verify_express_page_default(page)


### PR DESCRIPTION
1. Fix the `pyright` errors since recent code changes in Shiny express from `navset_tab()` ->` navset()` and `navset_card_tab()` -> `navset_card()`
2. install main version of `rsconnect-python` instead of pypi since pypi version does not yet support shiny express tests and we want to test shiny express tests.
3. Modify name of the test since it was copied from another test and not changed to reflect the test file name.