### PR TITLE
Better messages for `AttributeError` in Shiny Express

### DIFF
--- a/shiny/express/_run.py
+++ b/shiny/express/_run.py
@@ -126,7 +126,7 @@ def run_express(file: Path) -> Tag | TagList:
         # Need to catch AttributeError and convert to a different type of error, because
         # uvicorn specifically catches AttributeErrors and prints an error message that
         # is helpful for normal ASGI apps, but misleading in the case of Shiny Express.
-        raise RuntimeError(e)
+        raise RuntimeError(e) from e
 
     finally:
         sys.displayhook = prev_displayhook

--- a/shiny/express/_run.py
+++ b/shiny/express/_run.py
@@ -72,51 +72,64 @@ def run_express(file: Path) -> Tag | TagList:
         nonlocal ui_result
         ui_result = cast(Tag, x)
 
+    prev_displayhook = sys.displayhook
     sys.displayhook = set_result
 
-    reset_top_level_recall_context_manager()
-    get_top_level_recall_context_manager().__enter__()
+    try:
+        reset_top_level_recall_context_manager()
+        get_top_level_recall_context_manager().__enter__()
 
-    file_path = str(file.resolve())
+        file_path = str(file.resolve())
 
-    var_context: dict[str, object] = {
-        "__file__": file_path,
-        display_decorator_func_name: _display_decorator_function_def,
-    }
+        var_context: dict[str, object] = {
+            "__file__": file_path,
+            display_decorator_func_name: _display_decorator_function_def,
+        }
 
-    # Execute each top-level node in the AST
-    for node in tree.body:
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            exec(
-                compile(ast.Module([node], type_ignores=[]), file_path, "exec"),
-                var_context,
-                var_context,
+        # Execute each top-level node in the AST
+        for node in tree.body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                exec(
+                    compile(ast.Module([node], type_ignores=[]), file_path, "exec"),
+                    var_context,
+                    var_context,
+                )
+            else:
+                exec(
+                    compile(
+                        ast.Interactive([node], type_ignores=[]), file_path, "single"
+                    ),
+                    var_context,
+                    var_context,
+                )
+
+        # When we called the function to get the top level recall context manager, we didn't
+        # store the result in a variable and re-use that variable here. That is intentional,
+        # because during the evaluation of the app code,
+        # replace_top_level_recall_context_manager() may have been called, which swaps
+        # out the context manager, and it's the new one that we need to exit here.
+        get_top_level_recall_context_manager().__exit__(None, None, None)
+
+        # If we're running as an Express app but there's also a top-level item named app
+        # which is a shiny.App object, the user probably made a mistake.
+        if "app" in var_context and isinstance(var_context["app"], App):
+            raise RuntimeError(
+                "This looks like a Shiny Express app because it imports shiny.express, "
+                "but it also looks like a Shiny Classic app because it has a variable named "
+                "`app` which is a shiny.App object. Remove either the shiny.express import, "
+                "or the app=App()."
             )
-        else:
-            exec(
-                compile(ast.Interactive([node], type_ignores=[]), file_path, "single"),
-                var_context,
-                var_context,
-            )
 
-    # When we called the function to get the top level recall context manager, we didn't
-    # store the result in a variable and re-use that variable here. That is intentional,
-    # because during the evaluation of the app code,
-    # replace_top_level_recall_context_manager() may have been called, which swaps
-    # out the context manager, and it's the new one that we need to exit here.
-    get_top_level_recall_context_manager().__exit__(None, None, None)
+        return ui_result
 
-    # If we're running as an Express app but there's also a top-level item named app
-    # which is a shiny.App object, the user probably made a mistake.
-    if "app" in var_context and isinstance(var_context["app"], App):
-        raise RuntimeError(
-            "This looks like a Shiny Express app because it imports shiny.express, "
-            "but it also looks like a Shiny Classic app because it has a variable named "
-            "`app` which is a shiny.App object. Remove either the shiny.express import, "
-            "or the app=App()."
-        )
+    except AttributeError as e:
+        # Need to catch AttributeError and convert to a different type of error, because
+        # uvicorn specifically catches AttributeErrors and prints an error message that
+        # is helpful for normal ASGI apps, but misleading in the case of Shiny Express.
+        raise RuntimeError(e)
 
-    return ui_result
+    finally:
+        sys.displayhook = prev_displayhook
 
 
 _top_level_recall_context_manager: RecallContextManager[Tag]


### PR DESCRIPTION
This closes #869.

Previously in the case of an `AttributeError`, it would print this:

```
ERROR:    Error loading ASGI app. Attribute "_2f_Users_2f_winston_2f_Projects_2f_py_2d_shiny_2f_examples_2f_express_2f_plot_5f_app_2e_py" not found in module "shiny.express.app".
```

With this PR, it will print a normal stack trace and then a `RuntimeError`:

```
  ...
  File "/Users/winston/Library/py-shiny/shiny/express/app.py", line 13, in __getattr__
    return wrap_express_app(Path(name))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/winston/Library/py-shiny/shiny/express/_run.py", line 44, in wrap_express_app
    app_ui = run_express(file)
             ^^^^^^^^^^^^^^^^^
  File "/Users/winston/Library/py-shiny/shiny/express/_run.py", line 129, in run_express
    raise RuntimeError(e)
RuntimeError: This is an error
```

This PR wraps the bulk of the `run_express` function in a `try` statement. I also added a bit of code to preserve the previous `sys.displayhook`, and then restore it in the `finally`. This is helpful when running multiple concurrent apps, to ensure that `sys.displayhook` isn't left in an intermediate state.

To see the actual substantive changes (and not just indentation change), turn on "Hide whitespace".
