### PR TITLE
chore: exclude `_dev/` folder 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,6 @@ docs/source/reference/
 .Rproj.user
 
 /.luarc.json
+
+# Developer scratch area
+_dev/

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -6,6 +6,7 @@
     "dist",
     "typings",
     "sandbox",
+    "_dev",
     "docs",
     "tests/playwright/deploys/apps",
     "shiny/templates"

--- a/setup.cfg
+++ b/setup.cfg
@@ -124,7 +124,7 @@ console_scripts =
 # W503: Line break occurred before a binary operator
 # E203: whitespace before ':' (see https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8)
 ignore = E302, E501, F403, F405, W503, E203
-extend_exclude = docs, .venv, venv, typings, build
+extend_exclude = docs, .venv, venv, typings, build, _dev
 
 [isort]
 profile=black


### PR DESCRIPTION
Excludes `_dev/` from project-level tracking, linting and type checking.

This is the folder I typically use to track notes, reprex and examples apps, design documents, etc. The underscore helps `_dev/` float to the top of the file tree and separates it from general project folders.