### PR TITLE
fix(layout_columns): If the breakpoint name is an enum, need to collect the value

### DIFF
--- a/shiny/ui/_layout_columns.py
+++ b/shiny/ui/_layout_columns.py
@@ -237,6 +237,8 @@ def col_widths_attrs(col_widths: BreakpointsOptional[int] | None) -> TagAttrs:
         return ret
 
     for break_name, value in col_widths.items():
+        if isinstance(break_name, Enum):
+            break_name = break_name.value
         break_name = f"col-widths-{break_name}"
         if value is None:
             ret[break_name] = ""


### PR DESCRIPTION
Mostly relevant in the case of `col_widths` being a single value or a tuple/list.