### PR TITLE
Express: don't automatically put strings in a `<pre>` block

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     starlette>=0.17.1
     websockets>=10.0
     python-multipart
-    htmltools>=0.4.1.9001
+    htmltools @ git+https://github.com/posit-dev/py-htmltools.git
     click>=8.1.4
     markdown-it-py>=1.1.0
     # This is needed for markdown-it-py. Without it, when loading shiny/ui/_markdown.py,

--- a/shiny/express/_recall_context.py
+++ b/shiny/express/_recall_context.py
@@ -42,7 +42,7 @@ class RecallContextManager(Generic[R]):
             # would already have been filtered out by _display_decorator_function_def().
             # This is only for other kinds of expressions, the kind which would normally
             # be printed at the console.
-            if value is not None:
+            if value not in [None, ...]:
                 self.args.append(value)
 
     def __enter__(self) -> None:

--- a/shiny/express/_recall_context.py
+++ b/shiny/express/_recall_context.py
@@ -5,7 +5,7 @@ import sys
 from types import TracebackType
 from typing import Callable, Generic, Mapping, Optional, Type, TypeVar
 
-from htmltools import HTML, Tag, Tagifiable, TagList, tags
+from htmltools import HTML, Tag, Tagifiable, TagList
 
 from .._typing_extensions import ParamSpec
 
@@ -43,7 +43,7 @@ class RecallContextManager(Generic[R]):
             # This is only for other kinds of expressions, the kind which would normally
             # be printed at the console.
             if value is not None:
-                self.args.append(tags.pre(repr(value)))
+                self.args.append(value)
 
     def __enter__(self) -> None:
         if self.default_page is not None:

--- a/shiny/render/_display.py
+++ b/shiny/render/_display.py
@@ -4,7 +4,7 @@ import inspect
 import sys
 from typing import Any, Callable, Optional, Union, overload
 
-from htmltools import TagAttrValue, TagFunction, TagList
+from htmltools import TagAttrValue, TagFunction, TagList, wrap_displayhook_handler
 
 from .. import ui as _ui
 from ..session._utils import RenderedDeps
@@ -29,7 +29,7 @@ async def DisplayTransformer(
 ) -> RenderedDeps | None:
     results: list[object] = []
     orig_displayhook = sys.displayhook
-    sys.displayhook = results.append
+    sys.displayhook = wrap_displayhook_handler(results.append)
     try:
         x = _fn()
         if inspect.iscoroutine(x):

--- a/tests/playwright/utils/express_utils.py
+++ b/tests/playwright/utils/express_utils.py
@@ -51,11 +51,11 @@ def verify_express_page_default(page: Page) -> None:
     nav_html.set("span")
     nav_html.expect_content("span 0span 1span 2")
     navset_card_tab = LayoutNavsetTab(page, "express_navset_card_tab")
-    navset_card_tab.expect_content("Ellipsis")
+    navset_card_tab.expect_content("")
     # since it is a custom table we can't use the OutputTable controls
     shell_text = page.locator("#shell").inner_text().strip()
     assert shell_text == (
-        "'R1C1R1'\n'R1C1R2-R1C1R1'\n'R1C1R2-R1C1R2'\n'R1C1R2-R1C2'\n'R1C2'"
+        "R1C1R1\nR1C1R2-R1C1R1\nR1C1R2-R1C1R2\nR1C1R2-R1C2\nR1C2"
     ), "Locator contents don't match expected text"
 
 
@@ -79,7 +79,7 @@ def verify_express_page_fluid(page: Page) -> None:
 
 def verify_express_page_sidebar(page: Page) -> None:
     sidebar = Sidebar(page, "sidebar")
-    sidebar.expect_text("SidebarTitle 'Sidebar Content'")
+    sidebar.expect_text("SidebarTitle Sidebar Content")
     output_txt = OutputTextVerbatim(page, "txt")
     output_txt.expect_value("50")
     compare_annotations(ui.sidebar, layout.sidebar)


### PR DESCRIPTION
Closes #872.

This PR makes it so strings (and other types of objects) are not automatically wrapped in a `<pre>` block, as described in https://github.com/posit-dev/py-shiny/issues/872#issuecomment-1852630725.

<img width="1098" alt="image" src="https://github.com/posit-dev/py-shiny/assets/86978/38f8cd2d-3acb-4ead-95c2-dde57a1a1e40">

