### PR TITLE
fix(layout_columns): Add missing `bslib-mb-spacing` class

### DIFF
--- a/shiny/ui/_layout_columns.py
+++ b/shiny/ui/_layout_columns.py
@@ -126,7 +126,7 @@ def layout_columns(
     tag = Tag(
         "bslib-layout-columns",
         {
-            "class": "bslib-grid grid",
+            "class": "bslib-grid grid bslib-mb-spacing",
             "style": css(
                 gap=as_css_unit(gap),
                 height=as_css_unit(height),


### PR DESCRIPTION
Adds the `.bslib-mb-spacing` class to the `bslib-layout-columns` component to ensure that it receives bottom margin outside of gap-driven spacing contexts.

<details>
<summary>Example App</summary>

```python
from shiny import App, render, ui

app_ui = ui.page_navbar(
    ui.nav(
        "Page 1",
        ui.layout_columns(
            ui.fill.as_fill_item(ui.div({"class": "bg-primary ex-box"})),
            ui.fill.as_fill_item(ui.div({"class": "bg-secondary ex-box"})),
        ),
        ui.layout_columns(
            ui.fill.as_fill_item(ui.div({"class": "bg-warning ex-box"})),
            ui.fill.as_fill_item(ui.div({"class": "bg-danger ex-box"})),
        ),
        ui.tags.style(".ex-box { min-height: 100px !important; }"),
    ),
    fillable=False,
)


def server(input, output, session):
    ...


app = App(app_ui, server)
```

</details>