### PR TITLE
fix(layout_columns): Don't apply fillable class to layout container

### DIFF
--- a/shiny/ui/_layout_columns.py
+++ b/shiny/ui/_layout_columns.py
@@ -139,11 +139,9 @@ def layout_columns(
         web_component_dependency(),
     )
 
-    # Apply fill and fillable
+    # Apply fill to the outer layout (fillable is applied to the children)
     if fill:
         tag = as_fill_item(tag)
-    if fillable:
-        tag = as_fillable_container(tag)
 
     return tag
 


### PR DESCRIPTION
I was accidentally applying the fillable class to both the children and the parent layout columns container; instead `fillable` should be applied to wrapper where the children are placed and `fill` is applied to the layou container.