### PR TITLE
Use `htmltools.wrap_displayhook_handler()`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     starlette>=0.17.1
     websockets>=10.0
     python-multipart
-    htmltools>=0.4.1.9001
+    htmltools @ git+https://github.com/posit-dev/py-htmltools.git
     click>=8.1.4
     markdown-it-py>=1.1.0
     # This is needed for markdown-it-py. Without it, when loading shiny/ui/_markdown.py,

--- a/shiny/express/_recall_context.py
+++ b/shiny/express/_recall_context.py
@@ -5,7 +5,7 @@ import sys
 from types import TracebackType
 from typing import Callable, Generic, Mapping, Optional, Type, TypeVar
 
-from htmltools import HTML, Tag, Tagifiable, TagList, tags
+from htmltools import Tag, wrap_displayhook_handler
 
 from .._typing_extensions import ParamSpec
 
@@ -32,19 +32,6 @@ class RecallContextManager(Generic[R]):
         self.args: list[object] = list(args)
         self.kwargs: dict[str, object] = dict(kwargs)
 
-    def append_arg(self, value: object):
-        if isinstance(value, (Tag, TagList, Tagifiable)):
-            self.args.append(value)
-        elif hasattr(value, "_repr_html_"):
-            self.args.append(HTML(value._repr_html_()))  # pyright: ignore
-        else:
-            # We should NOT end up here for objects that were `def`ed, because they
-            # would already have been filtered out by _display_decorator_function_def().
-            # This is only for other kinds of expressions, the kind which would normally
-            # be printed at the console.
-            if value is not None:
-                self.args.append(tags.pre(repr(value)))
-
     def __enter__(self) -> None:
         if self.default_page is not None:
             from . import _run
@@ -53,7 +40,7 @@ class RecallContextManager(Generic[R]):
 
         self._prev_displayhook = sys.displayhook
         # Collect each of the "printed" values in the args list.
-        sys.displayhook = self.append_arg
+        sys.displayhook = wrap_displayhook_handler(self.args.append)
 
     def __exit__(
         self,

--- a/shiny/render/_display.py
+++ b/shiny/render/_display.py
@@ -4,7 +4,7 @@ import inspect
 import sys
 from typing import Any, Callable, Optional, Union, overload
 
-from htmltools import TagAttrValue, TagFunction, TagList
+from htmltools import TagAttrValue, TagFunction, TagList, wrap_displayhook_handler
 
 from .. import ui as _ui
 from ..session._utils import RenderedDeps
@@ -29,7 +29,7 @@ async def DisplayTransformer(
 ) -> RenderedDeps | None:
     results: list[object] = []
     orig_displayhook = sys.displayhook
-    sys.displayhook = results.append
+    sys.displayhook = wrap_displayhook_handler(results.append)
     try:
         x = _fn()
         if inspect.iscoroutine(x):


### PR DESCRIPTION
This PR depends on https://github.com/posit-dev/py-htmltools/pull/77.

These two PRs together consolidate the logic for how different kinds values should be handled by the `sys.displayhook`, into a single location, `htmltools.wrap_displayhook_handler()`.