### PR TITLE
fix(layout_columns): Remove use of enum for breakpoints

### DIFF
--- a/shiny/ui/_layout_columns.py
+++ b/shiny/ui/_layout_columns.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Dict, Iterable, Optional, TypeVar, Union, cast
+from typing import Dict, Iterable, Literal, Optional, TypeVar, Union, cast
 from warnings import warn
 
 from htmltools import Tag, TagAttrs, TagAttrValue, TagChild, css
@@ -15,19 +15,16 @@ from .fill import as_fill_item
 T = TypeVar("T")
 
 
-class Breakpoints(Enum):
-    """
-    References
-    ----------
-    * [Available Bootstrap breakpoints](https://getbootstrap.com/docs/5.3/layout/breakpoints/#available-breakpoints)
-    """
+Breakpoints = Literal["xs", "sm", "md", "lg", "xl", "xxl"]
+"""
+References
+----------
+* [Available Bootstrap breakpoints](https://getbootstrap.com/docs/5.3/layout/breakpoints/#available-breakpoints)
+"""
 
-    xs = "xs"
-    sm = "sm"
-    md = "md"
-    lg = "lg"
-    xl = "xl"
-    xxl = "xxl"
+
+def bs_breakpoints() -> Iterable[Breakpoints]:
+    return ("xs", "sm", "md", "lg", "xl", "xxl")
 
 
 BreakpointsSoft = Dict[Breakpoints, Union[Iterable[T], T, None]]
@@ -155,16 +152,15 @@ def as_col_spec(
         return None
 
     if not isinstance(col_widths, Dict):
-        return {Breakpoints.md: validate_col_width(col_widths, n_kids, Breakpoints.md)}
+        return {"md": validate_col_width(col_widths, n_kids, "md")}
 
     ret: BreakpointsOptional[int] = {}
     col_widths_items = cast(BreakpointsSoft[int], col_widths).items()
 
     for brk, value in col_widths_items:
-        bs_breakpoints = [str(bp.value) for bp in Breakpoints]
-        if str(brk) not in bs_breakpoints:
+        if brk not in bs_breakpoints():
             raise ValueError(
-                f"Breakpoint '{brk}' is not valid. Valid breakpoints are: {', '.join(bs_breakpoints)}'."
+                f"Breakpoint '{brk}' is not valid. Valid breakpoints are: {', '.join(bs_breakpoints())}'."
             )
 
         if value is None:
@@ -266,9 +262,7 @@ def row_heights_attrs(
     # row height is derived from xs or defaults to auto in the CSS, so we don't need the
     # class to activate it
     classes = [
-        f"bslib-grid--row-heights--{brk}"
-        for brk in x_complete.keys()
-        if brk != Breakpoints.xs
+        f"bslib-grid--row-heights--{brk}" for brk in x_complete.keys() if brk != "xs"
     ]
 
     # Create CSS variables, treating numeric values as fractional units, passing strings


### PR DESCRIPTION
It turns out that using an enum is over-engineering and annoying as a user. With an enum the following code gives a type warning

```python
ui.layout_columns(
  col_widths={"md": (3, 3, 6)}
)
```

because `"md"` isn't literally the `Breakpoints.md` value. Unless I'm missing something, you'd have to use

```python
ui.layout_columns(
  col_widths={ui.Breakpoints.md.value: (3, 3, 6)}
)
```

assuming we export `Breakpoints`. Currently you'd have to `ui._layout_columns.Breakpoints.md.value`, which is just too much.

This PR goes back to a typed `Breakpoints` literal type and adds a `bs_breakpoints()` helper function.