### PR TITLE
Fix failing deploy tests

### DIFF
--- a/tests/playwright/deploys/apps/plotly_app/requirements.txt
+++ b/tests/playwright/deploys/apps/plotly_app/requirements.txt
@@ -1,5 +1,5 @@
 pandas
 plotly
 git+https://github.com/posit-dev/py-shiny.git#egg=shiny
-git+https://github.com/posit-dev/py-htmltools#egg=htmltools
-git+https://github.com/posit-dev/py-shinywidgets#egg=shinywidgets
+git+https://github.com/posit-dev/py-htmltools.git#egg=htmltools
+git+https://github.com/posit-dev/py-shinywidgets.git#egg=shinywidgets

--- a/tests/playwright/deploys/apps/shiny-express-accordion/requirements.txt
+++ b/tests/playwright/deploys/apps/shiny-express-accordion/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/posit-dev/py-shiny.git#egg=shiny
-git+https://github.com/posit-dev/py-htmltools#egg=htmltools
+git+https://github.com/posit-dev/py-htmltools.git#egg=htmltools

--- a/tests/playwright/deploys/apps/shiny-express-page-default/app.py
+++ b/tests/playwright/deploys/apps/shiny-express-page-default/app.py
@@ -7,8 +7,6 @@ ui.tags.style(
     background-color: #00000022}
 """
 )
-
-
 with layout.div(id="shell"):
     with layout.row():
         with layout.column(width=8):
@@ -30,20 +28,20 @@ with layout.div(id="shell"):
 
 with layout.column(width=6):
     # check height is below 300px - bounding box
-    with layout.navset_card_tab(id="express_navset_card_tab"):
-        with layout.nav(title="Two"):
+    with layout.navset_card(id="express_navset_card_tab", type="tab"):
+        with layout.nav_panel(title="Two"):
             ...
 
 
 with layout.column(width=6):
     with layout.row():
-        with layout.navset_tab(id="express_navset_tab"):
+        with layout.navset(id="express_navset_tab", type="tab"):
             for fn_txt, fn in [
                 ("pre", layout.pre),
                 ("div", layout.div),
                 ("span", layout.span),
             ]:
-                with layout.nav(title=fn_txt):
+                with layout.nav_panel(title=fn_txt):
                     for i in range(3):
                         with fn():
                             ui.HTML(f"{fn_txt} {i}")

--- a/tests/playwright/deploys/apps/shiny-express-page-default/requirements.txt
+++ b/tests/playwright/deploys/apps/shiny-express-page-default/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/posit-dev/py-shiny.git#egg=shiny
-git+https://github.com/posit-dev/py-htmltools#egg=htmltools
+git+https://github.com/posit-dev/py-htmltools.git#egg=htmltools

--- a/tests/playwright/deploys/apps/shiny-express-page-fillable/requirements.txt
+++ b/tests/playwright/deploys/apps/shiny-express-page-fillable/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/posit-dev/py-shiny.git#egg=shiny
-git+https://github.com/posit-dev/py-htmltools#egg=htmltools
+git+https://github.com/posit-dev/py-htmltools.git#egg=htmltools

--- a/tests/playwright/deploys/apps/shiny-express-page-fluid/requirements.txt
+++ b/tests/playwright/deploys/apps/shiny-express-page-fluid/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/posit-dev/py-shiny.git#egg=shiny
-git+https://github.com/posit-dev/py-htmltools#egg=htmltools
+git+https://github.com/posit-dev/py-htmltools.git#egg=htmltools

--- a/tests/playwright/deploys/apps/shiny-express-page-sidebar/requirements.txt
+++ b/tests/playwright/deploys/apps/shiny-express-page-sidebar/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/posit-dev/py-shiny.git#egg=shiny
-git+https://github.com/posit-dev/py-htmltools#egg=htmltools
+git+https://github.com/posit-dev/py-htmltools.git#egg=htmltools


### PR DESCRIPTION
The deploy tests were using an older version of `py-htmltools` because it was missing `.git` in requirements.txt
Also, use `navset_card` instead of `navset_card_tab` for shiny express