### PR TITLE
Add shiny/templates to MANIFEST.in files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,3 +9,4 @@ recursive-include docs *.rst conf.py Makefile make.bat *.jpg *.png *.gif
 recursive-include shiny/www *
 recursive-include shiny/experimental/www *
 recursive-include shiny/api-examples *
+recursive-include shiny/templates *


### PR DESCRIPTION
Closes #922

Note that #922 is only reproducible if you do a non-editable install (e.g.,  `pip install .`)