### PR TITLE
Switch from `requests` to `urllib`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [UNRELEASED]
+
+### Bug fixes
+
+* Fixed #935: `shiny create` required the `requests` package, but it was not listed as a dependency. (#940)
+
+
 ## [0.6.1] - 2023-12-18
 
 ### New features

--- a/shiny/_template_utils.py
+++ b/shiny/_template_utils.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import os
 import shutil
 import sys
 import tempfile
 import zipfile
 from pathlib import Path
-from typing import Dict, List, Optional, cast
+from typing import Optional, cast
 from urllib.error import URLError
 from urllib.parse import urlparse
 from urllib.request import urlopen
@@ -34,7 +36,7 @@ cancel_choice: Choice = Choice(title=[("class:secondary", "[Cancel]")], value="c
 back_choice: Choice = Choice(title=[("class:secondary", "← Back")], value="back")
 
 
-def choice_from_dict(choice_dict: Dict[str, str]) -> List[Choice]:
+def choice_from_dict(choice_dict: dict[str, str]) -> list[Choice]:
     return [Choice(title=key, value=value) for key, value in choice_dict.items()]
 
 


### PR DESCRIPTION
This fixes #935.

I tested with this, which still works:

```
shiny create -g https://github.com/posit-dev/py-shiny-templates/tree/main/dashboard
```

And if you give it a nonexistent URL, like this:

```
shiny create -g https://github.com/posit-dev/nothinghere/tree/main/dashboard
```

The previous error message looked like this:

```
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://github.com/posit-dev/nothinghere/archive/refs/heads/main.zip
```

After this PR, it looks like this:

```
urllib.error.HTTPError: HTTP Error 404: Not Found for url: https://github.com/posit-dev/nothinghere/archive/refs/heads/main.zip
```