### PR TITLE
Express' `value_box()` no longer includes named positional args

### DIFF
--- a/shiny/express/ui/_cm_components.py
+++ b/shiny/express/ui/_cm_components.py
@@ -1115,8 +1115,6 @@ def nav_menu(
 # Value boxes
 # ======================================================================================
 def value_box(
-    title: TagChild,
-    value: TagChild,
     *,
     showcase: Optional[TagChild] = None,
     showcase_layout: ui._valuebox.SHOWCASE_LAYOUTS_STR
@@ -1134,16 +1132,14 @@ def value_box(
 
     This function wraps :func:`~shiny.ui.value_box`.
 
-    An opinionated (:func:`~shiny.ui.card`-powered) box, designed for
-    displaying a `value` and `title`. Optionally, a `showcase` can provide for context
-    for what the `value` represents (for example, it could hold an icon, or even a
+    An opinionated (:func:`~shiny.ui.card`-powered) box, designed for displaying a title
+    (the 1st child), value (the 2nd child), and other explanation text (other children,
+    if any). Optionally, a `showcase` can provide for context for what the `value`
+    represents (for example, it could hold an icon, or even a
     :func:`~shiny.ui.output_plot`).
 
     Parameters
     ----------
-    title,value
-        A string, number, or :class:`~htmltools.Tag` child to display as
-        the title or value of the value box. The `title` appears above the `value`.
     showcase
         A :class:`~htmltools.Tag` child to showcase (e.g., an icon, a
         :func:`~shiny.ui.output_plot`, etc).
@@ -1184,7 +1180,6 @@ def value_box(
     """
     return RecallContextManager(
         ui.value_box,
-        args=(title, value),
         kwargs=dict(
             showcase=showcase,
             showcase_layout=showcase_layout,


### PR DESCRIPTION
Currently a `shiny.express.ui.value_box()` _must_ be created with positional arguments passed to the context manager.

```python
from shiny.express import ui

with ui.value_box("title", "value"):
  pass
```

With this PR, those `title` and `value` positional args will go away in favor of taking the 1st 2 children as the title and value:

```python
from shiny.express import ui

with ui.value_box():
  "title"
  "value"
```

Not only does this feel more "express-like" to me, but it'll be much easier to render reactive values.