### PR TITLE
Add `render.download`

### DIFF
--- a/shiny/express/ui/_cm_components.py
+++ b/shiny/express/ui/_cm_components.py
@@ -1115,6 +1115,8 @@ def nav_menu(
 # Value boxes
 # ======================================================================================
 def value_box(
+    title: TagChild,
+    value: TagChild,
     *,
     showcase: Optional[TagChild] = None,
     showcase_layout: ui._valuebox.SHOWCASE_LAYOUTS_STR
@@ -1132,14 +1134,16 @@ def value_box(
 
     This function wraps :func:`~shiny.ui.value_box`.
 
-    An opinionated (:func:`~shiny.ui.card`-powered) box, designed for displaying a title
-    (the 1st child), value (the 2nd child), and other explanation text (other children,
-    if any). Optionally, a `showcase` can provide for context for what the `value`
-    represents (for example, it could hold an icon, or even a
+    An opinionated (:func:`~shiny.ui.card`-powered) box, designed for
+    displaying a `value` and `title`. Optionally, a `showcase` can provide for context
+    for what the `value` represents (for example, it could hold an icon, or even a
     :func:`~shiny.ui.output_plot`).
 
     Parameters
     ----------
+    title,value
+        A string, number, or :class:`~htmltools.Tag` child to display as
+        the title or value of the value box. The `title` appears above the `value`.
     showcase
         A :class:`~htmltools.Tag` child to showcase (e.g., an icon, a
         :func:`~shiny.ui.output_plot`, etc).
@@ -1180,6 +1184,7 @@ def value_box(
     """
     return RecallContextManager(
         ui.value_box,
+        args=(title, value),
         kwargs=dict(
             showcase=showcase,
             showcase_layout=showcase_layout,

--- a/shiny/express/ui/_cm_components.py
+++ b/shiny/express/ui/_cm_components.py
@@ -1115,8 +1115,6 @@ def nav_menu(
 # Value boxes
 # ======================================================================================
 def value_box(
-    title: TagChild,
-    value: TagChild,
     *,
     showcase: Optional[TagChild] = None,
     showcase_layout: ui._valuebox.SHOWCASE_LAYOUTS_STR
@@ -1134,16 +1132,14 @@ def value_box(
 
     This function wraps :func:`~shiny.ui.value_box`.
 
-    An opinionated (:func:`~shiny.ui.card`-powered) box, designed for
-    displaying a `value` and `title`. Optionally, a `showcase` can provide for context
-    for what the `value` represents (for example, it could hold an icon, or even a
+    An opinionated (:func:`~shiny.ui.card`-powered) box, designed for displaying a title
+    (the 1st child), value (the 2nd child), and other explanation text (other children,
+    if any). Optionally, a `showcase` can provide for context for what the `value`
+    represents (for example, it could hold an icon, or even a
     :func:`~shiny.ui.output_plot`).
 
     Parameters
     ----------
-    title,value
-        A string, number, or :class:`~htmltools.Tag` child to display as
-        the title or value of the value box. The `title` appears above the `value`.
     showcase
         A :class:`~htmltools.Tag` child to showcase (e.g., an icon, a
         :func:`~shiny.ui.output_plot`, etc).
@@ -1184,7 +1180,6 @@ def value_box(
     """
     return RecallContextManager(
         ui.value_box,
-        args=(title, value),
         kwargs=dict(
             showcase=showcase,
             showcase_layout=showcase_layout,

--- a/shiny/render/__init__.py
+++ b/shiny/render/__init__.py
@@ -24,6 +24,7 @@ from ._render import (
     table,
     text,
     ui,
+    download,
 )
 
 __all__ = (
@@ -35,6 +36,7 @@ __all__ = (
     "image",
     "table",
     "ui",
+    "download",
     "DataGrid",
     "DataTable",
 )


### PR DESCRIPTION
This PR adds `render.download`. This is a proof-of-concept; the final implementation will have to be done after #964 is merged, and will be significantly different. But the app-developer-facing API will be mostly the same.

The existing API is to use `session.download`, like this:

```py
# UI contains:
ui.download_button("dl", "Download File")

# Server function contains:
@session.download(filename="hello.txt")
def dl():
    yield "Hello, world!\n"
```

This is quite a bit different from all other outputs, because it relies on the `session` object. This also doesn't work for Express apps, because there isn't a `session` object available. (I'll note here that it would be possible to add a `session` object that could be imported from `shiny.express`, but the change in this PR is a better one.)

With this PR, the app uses `render.download` instead of `session.download`:

```py
# UI contains:
ui.download_button("dl", "Download File")

# Server function contains:
@render.download(filename="hello.txt")
def dl():
    yield "Hello, world!\n"
```

I think this makes more sense from the app author's perspective.

In an Express app, the code would look like this (the button is automatically inserted in the UI):

```py
@render.download(filename="hello.txt")
def dl():
    yield "Hello, world!\n"
```

However, there is currently one limitation with this: it would be nice to be able to pass in a label for the button, but it doesn't work, because of where the function is defined for the button. @schloerke With the changes in #964, would it be possible to pass the label to the `ui.download_button` function?