### PR TITLE
Change `Renderer.value_fn` to `Renderer.fn`

### DIFF
--- a/shiny/__init__.py
+++ b/shiny/__init__.py
@@ -1,6 +1,6 @@
 """A package for building reactive web applications."""
 
-__version__ = "0.6.1.9001"
+__version__ = "0.6.1.9002"
 
 from ._shinyenv import is_pyodide as _is_pyodide
 

--- a/shiny/api-examples/Renderer/app.py
+++ b/shiny/api-examples/Renderer/app.py
@@ -68,7 +68,7 @@ class render_capitalize(Renderer[str]):
         self.to_case = to_case
 
     async def render(self) -> str | None:
-        value = await self.value_fn()
+        value = await self.fn()
         if value is None:
             # If `None` is returned, then do not render anything.
             return None

--- a/shiny/render/_display.py
+++ b/shiny/render/_display.py
@@ -83,14 +83,14 @@ class display(Renderer[None]):
         orig_displayhook = sys.displayhook
         sys.displayhook = wrap_displayhook_handler(results.append)
 
-        if self.value_fn.is_async():
+        if self.fn.is_async():
             raise TypeError(
                 "@render.display does not support async functions. Use @render.ui instead."
             )
 
         try:
             # Run synchronously
-            sync_value_fn = self.value_fn.get_sync_fn()
+            sync_value_fn = self.fn.get_sync_fn()
             ret = sync_value_fn()
             if ret is not None:
                 raise RuntimeError(

--- a/shiny/render/_render.py
+++ b/shiny/render/_render.py
@@ -165,21 +165,21 @@ class plot(Renderer[object]):
 
     def __init__(
         self,
-        fn: Optional[ValueFn[object]] = None,
+        _fn: Optional[ValueFn[object]] = None,
         *,
         alt: Optional[str] = None,
         width: float | None | MISSING_TYPE = MISSING,
         height: float | None | MISSING_TYPE = MISSING,
         **kwargs: object,
     ) -> None:
-        super().__init__(fn)
+        super().__init__(_fn)
         self.alt = alt
         self.width = width
         self.height = height
         self.kwargs = kwargs
 
     async def render(self) -> dict[str, Jsonifiable] | Jsonifiable | None:
-        is_userfn_async = self.value_fn.is_async()
+        is_userfn_async = self.fn.is_async()
         name = self.output_id
         session = require_active_session(None)
         width = self.width
@@ -220,7 +220,7 @@ class plot(Renderer[object]):
         )
 
         # Call the user function to get the plot object.
-        x = await self.value_fn()
+        x = await self.fn()
 
         # Note that x might be None; it could be a matplotlib.pyplot
 
@@ -325,11 +325,11 @@ class image(Renderer[ImgData]):
 
     def __init__(
         self,
-        fn: Optional[ValueFn[ImgData]] = None,
+        _fn: Optional[ValueFn[ImgData]] = None,
         *,
         delete_file: bool = False,
     ) -> None:
-        super().__init__(fn)
+        super().__init__(_fn)
         self.delete_file: bool = delete_file
 
     async def transform(self, value: ImgData) -> dict[str, Jsonifiable] | None:
@@ -413,14 +413,14 @@ class table(Renderer[TableResult]):
 
     def __init__(
         self,
-        fn: Optional[ValueFn[TableResult]] = None,
+        _fn: Optional[ValueFn[TableResult]] = None,
         *,
         index: bool = False,
         classes: str = "table shiny-table w-auto",
         border: int = 0,
         **kwargs: object,
     ) -> None:
-        super().__init__(fn)
+        super().__init__(_fn)
         self.index: bool = index
         self.classes: str = classes
         self.border: int = border

--- a/shiny/render/renderer/_renderer.py
+++ b/shiny/render/renderer/_renderer.py
@@ -293,29 +293,29 @@ class Renderer(RendererBase, Generic[IT]):
     TODO-barret-docs
     """
 
-    value_fn: AsyncValueFn[IT | None]
+    fn: AsyncValueFn[IT | None]
     """
     App-supplied output value function which returns type `IT`. This function is always
     asyncronous as the original app-supplied function possibly wrapped to execute
     asynchonously.
     """
 
-    def __call__(self, value_fn: ValueFnApp[IT | None]) -> Self:
+    def __call__(self, _fn: ValueFnApp[IT | None]) -> Self:
         """
         Renderer __call__ docs here; Sets app's value function
 
         TODO-barret-docs
         """
 
-        if not callable(value_fn):
+        if not callable(_fn):
             raise TypeError("Value function must be callable")
 
         # Copy over function name as it is consistent with how Session and Output
         # retrieve function names
-        self.__name__: str = value_fn.__name__
+        self.__name__: str = _fn.__name__
 
         # Set value function with extra meta information
-        self.value_fn: AsyncValueFn[IT | None] = AsyncValueFn(value_fn)
+        self.fn: AsyncValueFn[IT | None] = AsyncValueFn(_fn)
 
         # Allow for App authors to not require `@output`
         self._auto_register()
@@ -324,7 +324,7 @@ class Renderer(RendererBase, Generic[IT]):
 
     def __init__(
         self,
-        value_fn: ValueFn[IT | None] = None,
+        _fn: ValueFn[IT | None] = None,
     ):
         # Do not display docs here. If docs are present, it could highjack the docs of
         # the subclass's `__init__` method.
@@ -332,9 +332,9 @@ class Renderer(RendererBase, Generic[IT]):
         # Renderer - init docs here
         # """
         super().__init__()
-        if callable(value_fn):
+        if callable(_fn):
             # Register the value function
-            self(value_fn)
+            self(_fn)
 
     async def transform(self, value: IT) -> Jsonifiable:
         """
@@ -345,7 +345,7 @@ class Renderer(RendererBase, Generic[IT]):
         raise NotImplementedError(
             "Please implement either the `transform(self, value: IT)` or `render(self)` method.\n"
             "* `transform(self, value: IT)` should transform the `value` (of type `IT`) into Jsonifiable object. Ex: `dict`, `None`, `str`. (standard)\n"
-            "* `render(self)` method has full control of how an App author's value is retrieved (`self.value_fn()`) and utilized. (rare)\n"
+            "* `render(self)` method has full control of how an App author's value is retrieved (`self._fn()`) and utilized. (rare)\n"
             "By default, the `render` retrieves the value and then calls `transform` method on non-`None` values."
         )
 
@@ -355,7 +355,7 @@ class Renderer(RendererBase, Generic[IT]):
 
         TODO-barret-docs
         """
-        value = await self.value_fn()
+        value = await self.fn()
         if value is None:
             return None
 

--- a/shiny/render/transformer/_transformer.py
+++ b/shiny/render/transformer/_transformer.py
@@ -258,8 +258,8 @@ class OutputRenderer(RendererBase, Generic[OT]):
         # Checking if a function is async has a 180+ns overhead (barret's machine)
         # -> It is faster to always call an async function than to always check if it is async
         # Always being async simplifies the execution
-        self._value_fn = AsyncValueFn(value_fn)
-        self._value_fn_is_async = self._value_fn.is_async()  # legacy key
+        self._fn = AsyncValueFn(value_fn)
+        self._value_fn_is_async = self._fn.is_async()  # legacy key
         self.__name__ = value_fn.__name__
 
         self._transformer = transform_fn
@@ -304,7 +304,7 @@ class OutputRenderer(RendererBase, Generic[OT]):
             # TransformerMetadata
             self._meta(),
             # Callable[[], Awaitable[IT]]
-            self._value_fn,
+            self._fn,
             # P
             *self._params.args,
             **self._params.kwargs,

--- a/shiny/templates/package-templates/js-output/custom_component/custom_component.py
+++ b/shiny/templates/package-templates/js-output/custom_component/custom_component.py
@@ -31,8 +31,8 @@ class render_custom_component(Renderer[int]):
 
     # The init method is used to set up the renderer's parameters.
     # If no parameters are needed, then the `__init__()` method can be omitted.
-    def __init__(self, _value_fn: ValueFn[int] = None, *, height: str = "200px"):
-        super().__init__(_value_fn)
+    def __init__(self, _fn: ValueFn[int] = None, *, height: str = "200px"):
+        super().__init__(_fn)
         self.height: str = height
 
     # Transforms non-`None` values into a `Jsonifiable` object.

--- a/shiny/templates/package-templates/js-react/custom_component/custom_component.py
+++ b/shiny/templates/package-templates/js-react/custom_component/custom_component.py
@@ -44,8 +44,8 @@ class render_custom_component(Renderer[str]):
 
     # # There are no parameters being supplied to the `output_custom_component` rendering function.
     # # Therefore, we can omit the `__init__()` method.
-    # def __init__(self, _value_fn: ValueFn[int] = None, *, extra_arg: str = "bar"):
-    #     super().__init__(_value_fn)
+    # def __init__(self, _fn: ValueFn[int] = None, *, extra_arg: str = "bar"):
+    #     super().__init__(_fn)
     #     self.extra_arg: str = extra_arg
 
     # Transforms non-`None` values into a `Jsonifiable` object.


### PR DESCRIPTION
I like the new name more after looking at it a bunch.

Also, make sure all `Renderer` value functions are received as `_fn`.