### PR TITLE
Express translation of `shiny/api-examples/input_action_button`

### DIFF
--- a/shiny/api-examples/input_action_button/app-express.py
+++ b/shiny/api-examples/input_action_button/app-express.py
@@ -1,0 +1,26 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+from shiny import App, Inputs, Outputs, Session, reactive, render, ui
+
+app_ui = ui.page_fluid(
+    ui.input_slider("n", "Number of observations", min=0, max=1000, value=500),
+    ui.input_action_button("go", "Go!", class_="btn-success"),
+    ui.output_plot("plot"),
+)
+
+
+def server(input: Inputs, output: Outputs, session: Session):
+    @render.plot(alt="A histogram")
+    # Use reactive.event() to invalidate the plot only when the button is pressed
+    # (not when the slider is changed)
+    @reactive.event(input.go, ignore_none=False)
+    def plot():
+        np.random.seed(19680801)
+        x = 100 + 15 * np.random.randn(input.n())
+        fig, ax = plt.subplots()
+        ax.hist(x, bins=30, density=True)
+        return fig
+
+
+app = App(app_ui, server)

--- a/shiny/api-examples/input_action_button/app-express.py
+++ b/shiny/api-examples/input_action_button/app-express.py
@@ -1,26 +1,20 @@
 import matplotlib.pyplot as plt
 import numpy as np
 
-from shiny import App, Inputs, Outputs, Session, reactive, render, ui
+from shiny import reactive, render
+from shiny.express import input, ui
 
-app_ui = ui.page_fluid(
-    ui.input_slider("n", "Number of observations", min=0, max=1000, value=500),
-    ui.input_action_button("go", "Go!", class_="btn-success"),
-    ui.output_plot("plot"),
-)
+ui.input_slider("n", "Number of observations", min=0, max=1000, value=500)
+ui.input_action_button("go", "Go!", class_="btn-success")
 
 
-def server(input: Inputs, output: Outputs, session: Session):
-    @render.plot(alt="A histogram")
-    # Use reactive.event() to invalidate the plot only when the button is pressed
-    # (not when the slider is changed)
-    @reactive.event(input.go, ignore_none=False)
-    def plot():
-        np.random.seed(19680801)
-        x = 100 + 15 * np.random.randn(input.n())
-        fig, ax = plt.subplots()
-        ax.hist(x, bins=30, density=True)
-        return fig
-
-
-app = App(app_ui, server)
+@render.plot(alt="A histogram")
+# Use reactive.event() to invalidate the plot only when the button is pressed
+# (not when the slider is changed)
+@reactive.event(input.go, ignore_none=False)
+def plot():
+    np.random.seed(19680801)
+    x = 100 + 15 * np.random.randn(input.n())
+    fig, ax = plt.subplots()
+    ax.hist(x, bins=30, density=True)
+    return fig


### PR DESCRIPTION
For #987

Adds a Shiny Express version of `shiny/api-examples/input_action_button/app.py`.

> [!NOTE]
> I did this PR in two steps so you can see the change in syntax from `app.py` → `app-express.py`. You don't need to commit these as separate steps.
>
> Mention the parent issue and add @gadenbuie as a reviewer (I can't add myself on this PR).

> [!TIP]
> Run `black` and `isort` on the `app-express.py` file before committing, otherwise CI checks may fail.
>
> ```
> cd shiny/api-examples/input_action_button/
> black app-express.py
> isort app-express.py
> ```