### PR TITLE
Revert `render.transformer.ValueFn` type change; Require pkg authors to type `Optional` for `render.renderer.ValueFn`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `shiny.render.RenderFunction` and `shiny.render.RenderFunctionAsync` have been removed. They were deprecated in v0.6.0. Instead, please use `shiny.render.renderer.Renderer`. (#964)
 
-* When transforming values within `shiny.render.transformer.output_transformer` transform function,  `shiny.render.transformer.resolve_value_fn` is no longer needed as the value function given to the output transformer is now **always** an asynchronous function. `resolve_value_fn(fn)` method has been deprecated. Please change your code from `value = await resolve_value_fn(_fn)` to `value = await _fn()`. (#964)
-
-* `shiny.render.OutputRendererSync` and `shiny.render.OutputRendererAsync` helper classes have been removed in favor of an updated `shiny.render.OutputRenderer` class. Now, the app's output value function will be transformed into an asynchronous function for simplified, consistent execution behavior. If redesigning your code, instead please create a new renderer that inherits from `shiny.render.renderer.Renderer`. (#964)
+* `shiny.render.OutputRendererSync` and `shiny.render.OutputRendererAsync` helper classes have been removed in favor of an updated `shiny.render.OutputRenderer` class. Now, the app's output value function will be transformed into an asynchronous function for simplified, consistent execution behavior. If redesigning your code, instead please create a new renderer that inherits from `shiny.render.renderer.Renderer`. `shiny.render.*` will be removed in the near future. (#964)
 
 
 ## [0.6.1.1] - 2023-12-22

--- a/shiny/__init__.py
+++ b/shiny/__init__.py
@@ -1,6 +1,6 @@
 """A package for building reactive web applications."""
 
-__version__ = "0.6.1.9002"
+__version__ = "0.6.1.9003"
 
 from ._shinyenv import is_pyodide as _is_pyodide
 

--- a/shiny/api-examples/Renderer/app.py
+++ b/shiny/api-examples/Renderer/app.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, Optional
 
 from shiny import App, Inputs, Outputs, Session, ui
 from shiny.render.renderer import Renderer, ValueFn
@@ -36,7 +36,7 @@ class render_capitalize(Renderer[str]):
 
     def __init__(
         self,
-        _fn: ValueFn[str | None] | None = None,
+        _fn: Optional[ValueFn[str]] | None = None,
         *,
         to_case: Literal["upper", "lower", "ignore"] = "upper",
         placeholder: bool = True,

--- a/shiny/render/_display.py
+++ b/shiny/render/_display.py
@@ -41,7 +41,7 @@ class display(Renderer[None]):
         )
 
     def __call__(self, fn: ValueFn[None]) -> Self:
-        if fn is None:
+        if fn is None:  # pyright: ignore[reportUnnecessaryComparison]
             raise TypeError("@render.display requires a function when called")
 
         async_fn = AsyncValueFn(fn)
@@ -63,7 +63,7 @@ class display(Renderer[None]):
 
     def __init__(
         self,
-        _fn: ValueFn[None] = None,
+        _fn: Optional[ValueFn[None]] = None,
         *,
         inline: bool = False,
         container: Optional[TagFunction] = None,

--- a/shiny/render/renderer/__init__.py
+++ b/shiny/render/renderer/__init__.py
@@ -4,10 +4,6 @@ from ._renderer import (  # noqa: F401
     ValueFn,
     Jsonifiable,
     RendererBaseT,  # pyright: ignore[reportUnusedImport]
-    ValueFnApp,  # pyright: ignore[reportUnusedImport]
-    ValueFnSync,  # pyright: ignore[reportUnusedImport]
-    ValueFnAsync,  # pyright: ignore[reportUnusedImport]
-    # WrapAsync,  # pyright: ignore[reportUnusedImport]
     AsyncValueFn,
     # IT,  # pyright: ignore[reportUnusedImport]
 )

--- a/shiny/render/renderer/_renderer.py
+++ b/shiny/render/renderer/_renderer.py
@@ -32,8 +32,8 @@ from ..._utils import is_async_callable, wrap_async
 __all__ = (
     "Renderer",
     "RendererBase",
-    "ValueFn",
     "Jsonifiable",
+    "ValueFn",
     "AsyncValueFn",
 )
 
@@ -82,22 +82,14 @@ DefaultUIFnResult = Union[TagList, Tag, MetadataNode, str]
 DefaultUIFnResultOrNone = Union[DefaultUIFnResult, None]
 DefaultUIFn = Callable[[str], DefaultUIFnResultOrNone]
 
-ValueFnSync = Callable[[], IT]
-"""
-App-supplied output value function which returns type `IT`. This function is
-synchronous.
-"""
-ValueFnAsync = Callable[[], Awaitable[IT]]
-"""
-App-supplied output value function which returns type `IT`. This function is
-asynchronous.
-"""
-ValueFnApp = Union[Callable[[], IT], Callable[[], Awaitable[IT]]]
+ValueFn = Union[
+    Callable[[], Union[IT, None]],
+    Callable[[], Awaitable[Union[IT, None]]],
+]
 """
 App-supplied output value function which returns type `IT`. This function can be
 synchronous or asynchronous.
 """
-ValueFn = Optional[ValueFnApp[Union[IT, None]]]
 
 
 class RendererBase(ABC):
@@ -233,8 +225,7 @@ class AsyncValueFn(Generic[IT]):
 
     def __init__(self, fn: Callable[[], IT] | Callable[[], Awaitable[IT]]):
         if isinstance(fn, AsyncValueFn):
-            fn = cast(AsyncValueFn[IT], fn)
-            return fn
+            return cast(AsyncValueFn[IT], fn)
         self._is_async = is_async_callable(fn)
         self._fn = wrap_async(fn)
         self._orig_fn = fn
@@ -300,7 +291,7 @@ class Renderer(RendererBase, Generic[IT]):
     asynchonously.
     """
 
-    def __call__(self, _fn: ValueFnApp[IT | None]) -> Self:
+    def __call__(self, _fn: ValueFn[IT]) -> Self:
         """
         Renderer __call__ docs here; Sets app's value function
 
@@ -324,7 +315,7 @@ class Renderer(RendererBase, Generic[IT]):
 
     def __init__(
         self,
-        _fn: ValueFn[IT | None] = None,
+        _fn: Optional[ValueFn[IT]] = None,
     ):
         # Do not display docs here. If docs are present, it could highjack the docs of
         # the subclass's `__init__` method.

--- a/shiny/render/renderer/_renderer.py
+++ b/shiny/render/renderer/_renderer.py
@@ -83,8 +83,8 @@ DefaultUIFnResultOrNone = Union[DefaultUIFnResult, None]
 DefaultUIFn = Callable[[str], DefaultUIFnResultOrNone]
 
 ValueFn = Union[
-    Callable[[], Union[IT, None]],
-    Callable[[], Awaitable[Union[IT, None]]],
+    Callable[[], IT],
+    Callable[[], Awaitable[IT]],
 ]
 """
 App-supplied output value function which returns type `IT`. This function can be
@@ -291,7 +291,7 @@ class Renderer(RendererBase, Generic[IT]):
     asynchonously.
     """
 
-    def __call__(self, _fn: ValueFn[IT]) -> Self:
+    def __call__(self, _fn: ValueFn[IT | None]) -> Self:
         """
         Renderer __call__ docs here; Sets app's value function
 
@@ -315,7 +315,7 @@ class Renderer(RendererBase, Generic[IT]):
 
     def __init__(
         self,
-        _fn: Optional[ValueFn[IT]] = None,
+        _fn: Optional[ValueFn[IT | None]] = None,
     ):
         # Do not display docs here. If docs are present, it could highjack the docs of
         # the subclass's `__init__` method.

--- a/shiny/render/transformer/__init__.py
+++ b/shiny/render/transformer/__init__.py
@@ -5,7 +5,6 @@ from ._transformer import (  # noqa: F401
     output_transformer,
     is_async_callable,
     ValueFn,
-    ValueFnApp,  # pyright: ignore[reportUnusedImport]
     ValueFnSync,  # pyright: ignore[reportUnusedImport]
     ValueFnAsync,  # pyright: ignore[reportUnusedImport]
     TransformFn,  # pyright: ignore[reportUnusedImport]

--- a/shiny/render/transformer/_transformer.py
+++ b/shiny/render/transformer/_transformer.py
@@ -639,10 +639,7 @@ def output_transformer(
 
 async def resolve_value_fn(value_fn: ValueFn[IT]) -> IT:
     """
-    Soft deprecated. Resolve the value function
-
-    Deprecated: v0.7.0 - This function is no longer needed as all value functions are
-    now async for consistency and speed.
+    Resolve the value function
 
     This function is used to resolve the value function (`value_fn`) to an object of
     type `IT`. If the value function is asynchronous, it will be awaited. If the value
@@ -675,9 +672,6 @@ async def resolve_value_fn(value_fn: ValueFn[IT]) -> IT:
     :
         The resolved value from `value_fn`.
     """
-    warn_deprecated(
-        "`resolve_value_fn()` is unnecessary when resolving the value function in a custom render method. Now, the value function is always async. `resolve_value_fn()` will be removed in a future release."
-    )
     if is_async_callable(value_fn):
         return await value_fn()
     else:

--- a/shiny/templates/package-templates/js-output/custom_component/custom_component.py
+++ b/shiny/templates/package-templates/js-output/custom_component/custom_component.py
@@ -1,5 +1,6 @@
 # from pathlib import Path
 from pathlib import PurePath
+from typing import Optional
 
 from htmltools import HTMLDependency, Tag
 
@@ -31,7 +32,7 @@ class render_custom_component(Renderer[int]):
 
     # The init method is used to set up the renderer's parameters.
     # If no parameters are needed, then the `__init__()` method can be omitted.
-    def __init__(self, _fn: ValueFn[int] = None, *, height: str = "200px"):
+    def __init__(self, _fn: Optional[ValueFn[int]] = None, *, height: str = "200px"):
         super().__init__(_fn)
         self.height: str = height
 

--- a/shiny/templates/package-templates/js-react/custom_component/custom_component.py
+++ b/shiny/templates/package-templates/js-react/custom_component/custom_component.py
@@ -44,7 +44,7 @@ class render_custom_component(Renderer[str]):
 
     # # There are no parameters being supplied to the `output_custom_component` rendering function.
     # # Therefore, we can omit the `__init__()` method.
-    # def __init__(self, _fn: ValueFn[int] = None, *, extra_arg: str = "bar"):
+    # def __init__(self, _fn: Optional[ValueFn[int]] = None, *, extra_arg: str = "bar"):
     #     super().__init__(_fn)
     #     self.extra_arg: str = extra_arg
 

--- a/tests/playwright/examples/test_examples.py
+++ b/tests/playwright/examples/test_examples.py
@@ -42,10 +42,10 @@ app_hard_wait: typing.Dict[str, int] = {
 output_transformer_errors = [
     "ShinyDeprecationWarning: `shiny.render.transformer.output_transformer()`",
     "  return OutputRenderer",
-    "ShinyDeprecationWarning: `resolve_value_fn()`",
-    "ShinyDeprecationWarning:",
-    "`resolve_value_fn()`",
-    "value = await resolve_value_fn(_fn)",
+    # "ShinyDeprecationWarning: `resolve_value_fn()`",
+    # "ShinyDeprecationWarning:",
+    # "`resolve_value_fn()`",
+    # "value = await resolve_value_fn(_fn)",
     # brownian example app
     "shiny.render.transformer.output_transformer()",
 ]
@@ -61,7 +61,7 @@ app_allow_shiny_errors: typing.Dict[
         "RuntimeWarning: divide by zero encountered",
         "UserWarning: This figure includes Axes that are not compatible with tight_layout",
     ],
-    # Remove after shinywidgets accepts `resolve_value_fn()` PR
+    # Remove after shinywidgets accepts `Renderer` PR
     "airmass": [*output_transformer_errors],
     "brownian": [*output_transformer_errors],
     "multi-page": [*output_transformer_errors],

--- a/tests/playwright/examples/test_examples.py
+++ b/tests/playwright/examples/test_examples.py
@@ -42,11 +42,8 @@ app_hard_wait: typing.Dict[str, int] = {
 output_transformer_errors = [
     "ShinyDeprecationWarning: `shiny.render.transformer.output_transformer()`",
     "  return OutputRenderer",
-    # "ShinyDeprecationWarning: `resolve_value_fn()`",
-    # "ShinyDeprecationWarning:",
-    # "`resolve_value_fn()`",
-    # "value = await resolve_value_fn(_fn)",
     # brownian example app
+    "ShinyDeprecationWarning:",
     "shiny.render.transformer.output_transformer()",
 ]
 express_warnings = ["Detected Shiny Express app. "]

--- a/tests/playwright/shiny/server/output_transformer/app.py
+++ b/tests/playwright/shiny/server/output_transformer/app.py
@@ -8,6 +8,7 @@ from shiny.render.transformer import (
     ValueFn,
     is_async_callable,
     output_transformer,
+    resolve_value_fn,
 )
 
 
@@ -18,7 +19,7 @@ async def TestTextTransformer(
     *,
     extra_txt: Optional[str] = None,
 ) -> str | None:
-    value = await _fn()
+    value = await resolve_value_fn(_fn)
     value = str(value)
     value += "; "
     value += "async" if is_async_callable(_fn) else "sync"

--- a/tests/playwright/shiny/server/output_transformer/test_output_transformer_async.py
+++ b/tests/playwright/shiny/server/output_transformer/test_output_transformer_async.py
@@ -6,9 +6,9 @@ from playwright.sync_api import Page
 def test_output_image_kitchen(page: Page, local_app: ShinyAppProc) -> None:
     page.goto(local_app.url)
 
-    OutputTextVerbatim(page, "t1").expect_value("t1; no call; async")
+    OutputTextVerbatim(page, "t1").expect_value("t1; no call; sync")
     OutputTextVerbatim(page, "t2").expect_value("t2; no call; async")
-    OutputTextVerbatim(page, "t3").expect_value("t3; call; async")
+    OutputTextVerbatim(page, "t3").expect_value("t3; call; sync")
     OutputTextVerbatim(page, "t4").expect_value("t4; call; async")
-    OutputTextVerbatim(page, "t5").expect_value("t5; call; async; w/ extra_txt")
+    OutputTextVerbatim(page, "t5").expect_value("t5; call; sync; w/ extra_txt")
     OutputTextVerbatim(page, "t6").expect_value("t6; call; async; w/ extra_txt")

--- a/tests/pytest/test_output_transformer.py
+++ b/tests/pytest/test_output_transformer.py
@@ -211,7 +211,6 @@ def test_output_transformer_result_does_not_allow_args():
         assert "Expected `params` to be of type `TransformerParams`" in str(e)
 
 
-# "Currently, `ValueFn` can not be truly async and "support sync render methods"
 @pytest.mark.asyncio
 async def test_renderer_handler_or_transform_fn_can_be_async():
     @output_transformer
@@ -219,10 +218,9 @@ async def test_renderer_handler_or_transform_fn_can_be_async():
         _meta: TransformerMetadata,
         _fn: ValueFn[str],
     ) -> str:
-        assert is_async_callable(_fn)
         # Actually sleep to test that the handler is truly async
         await asyncio.sleep(0)
-        ret = await _fn()
+        ret = await resolve_value_fn(_fn)
         return ret
 
     # ## Setup overloads =============================================
@@ -281,82 +279,13 @@ async def test_renderer_handler_or_transform_fn_can_be_async():
         assert ret == async_test_val
 
 
-# "Currently, `ValueFnA` can not be truly async and "support sync render methods".
-# Test that conditionally calling async works.
-@pytest.mark.asyncio
-async def test_renderer_handler_fn_can_be_yield_while_async():
-    @output_transformer
-    async def YieldTransformer(
-        _meta: TransformerMetadata,
-        _fn: ValueFn[str],
-    ) -> str:
-        if is_async_callable(_fn):
-            # Actually sleep to test that the handler is truly async
-            await asyncio.sleep(0)
-        ret = await _fn()
-        return ret
+# @pytest.mark.asyncio
+# async def test_resolve_value_fn_is_deprecated():
+#     with pytest.warns(ShinyDeprecationWarning):
+#         test_val = 42
 
-    # ## Setup overloads =============================================
+#         async def value_fn():
+#             return test_val
 
-    @overload
-    def yield_renderer() -> YieldTransformer.OutputRendererDecorator:
-        ...
-
-    @overload
-    def yield_renderer(
-        _fn: YieldTransformer.ValueFn,
-    ) -> YieldTransformer.OutputRenderer:
-        ...
-
-    def yield_renderer(
-        _fn: YieldTransformer.ValueFn | None = None,
-    ) -> YieldTransformer.OutputRenderer | YieldTransformer.OutputRendererDecorator:
-        with pytest.warns(ShinyDeprecationWarning):
-            return YieldTransformer(_fn)
-
-    test_val = "Test: Hello World!"
-
-    def app_render_fn() -> str:
-        return test_val
-
-    # ## Test Sync: √ =============================================
-
-    renderer_sync = yield_renderer(app_render_fn)
-    renderer_sync._set_output_metadata(
-        output_name="renderer_sync",
-    )
-    assert is_async_callable(renderer_sync)
-
-    with session_context(test_session):
-        ret = await renderer_sync()
-        assert ret == test_val
-
-    # ## Test Async: √ =============================================
-
-    async_test_val = "Async: Hello World!"
-
-    async def async_app_render_fn() -> str:
-        await asyncio.sleep(0)
-        return async_test_val
-
-    renderer_async = yield_renderer(async_app_render_fn)
-    renderer_async._set_output_metadata(
-        output_name="renderer_async",
-    )
-    assert is_async_callable(renderer_async)
-
-    with session_context(test_session):
-        ret = await renderer_async()
-        assert ret == async_test_val
-
-
-@pytest.mark.asyncio
-async def test_resolve_value_fn_is_deprecated():
-    with pytest.warns(ShinyDeprecationWarning):
-        test_val = 42
-
-        async def value_fn():
-            return test_val
-
-        ret = await resolve_value_fn(value_fn)
-        assert test_val == ret
+#         ret = await resolve_value_fn(value_fn)
+#         assert test_val == ret

--- a/tests/pytest/test_renderer.py
+++ b/tests/pytest/test_renderer.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Optional
+
 import pytest
 
 from shiny.render.renderer import Renderer, ValueFn
@@ -31,7 +33,7 @@ async def test_renderer_works():
 async def test_renderer_works_with_args():
     # No args works
     class test_renderer_with_args(Renderer[str]):
-        def __init__(self, _fn: ValueFn[str] = None, *, times: int = 2):
+        def __init__(self, _fn: Optional[ValueFn[str]] = None, *, times: int = 2):
             super().__init__(_fn)
             self.times: int = times
 


### PR DESCRIPTION
Reverting type change in transformer as to not break existing renderers when we will be switching to Renderer very shortly.