### PR TITLE
Change `page_sidebar()` and `page_navbar()` to default to `fillable=False`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Breaking Changes
+
+* Closed #938: `page_sidebar()` and `page_navbar()` now use `fillable=False` by default. (#990)
+
 ### Bug fixes
 
 * CLI command `shiny create`... (#965)

--- a/shiny/ui/_page.py
+++ b/shiny/ui/_page.py
@@ -44,7 +44,7 @@ def page_sidebar(
     sidebar: Sidebar,
     *args: TagChild | TagAttrs,
     title: Optional[str | Tag | TagList] = None,
-    fillable: bool = True,
+    fillable: bool = False,
     fillable_mobile: bool = False,
     window_title: str | MISSING_TYPE = MISSING,
     lang: Optional[str] = None,
@@ -116,7 +116,7 @@ def page_navbar(
     sidebar: Optional[Sidebar] = None,
     # Only page_navbar gets enhanced treatement for `fillable`
     # If an `*args`'s `data-value` attr string is in `fillable`, then the component is fillable
-    fillable: bool | list[str] = True,
+    fillable: bool | list[str] = False,
     fillable_mobile: bool = False,
     gap: Optional[CssUnit] = None,
     padding: Optional[CssUnit | list[CssUnit]] = None,


### PR DESCRIPTION
Closes #938. This PR changes `page_sidebar()` and `page_navbar()` to default to `fillable=False`.

