### PR TITLE
feat: Make `MISSING_TYPE` a `None`-alike object

### DIFF
--- a/shiny/reactive/_reactives.py
+++ b/shiny/reactive/_reactives.py
@@ -119,7 +119,7 @@ class Value(Generic[T]):
     def __call__(self) -> T:
         return self.get()
 
-    def get(self) -> T:
+    def get(self) -> T | MISSING_TYPE:
         """
         Read the reactive value.
 
@@ -137,9 +137,6 @@ class Value(Generic[T]):
         """
 
         self._value_dependents.register()
-
-        if isinstance(self._value, MISSING_TYPE):
-            raise SilentException
 
         return self._value
 

--- a/shiny/types.py
+++ b/shiny/types.py
@@ -25,7 +25,20 @@ if TYPE_CHECKING:
 
 # Sentinel value - indicates a missing value in a function call.
 class MISSING_TYPE:
-    pass
+    def __eq__(self, _: Any) -> bool:
+        return False
+
+    def __bool__(self) -> bool:
+        return False
+
+    def __len__(self) -> int:
+        return 0
+
+    def __repr__(self) -> str:
+        return "<MISSING>"
+
+    def __str__(self) -> str:
+        return ""
 
 
 MISSING: MISSING_TYPE = MISSING_TYPE()


### PR DESCRIPTION
This PR updates `MISSING_TYPE` to make it behave similar to a `None` object by implementing several dunder methods. It also updates `reactive.Value()` to return the `MISSING` value when accessing an uninitialized reactive, rather than raising a `SilentException`.

## Behavior

```python
>>> import shiny
>>> missing = shiny.types.MISSING
>>> missing
<MISSING>
>>> str(missing)
''
>>> missing or "default"
'default'
>>> 'yes' if missing else 'no'
'no'
>>> # No two missing values are ever the same
>>> missing == missing
False
>>> isinstance(missing, shiny.types.MISSING_TYPE)
```

## Example App

Before this PR, the following app would never render the slider because calling `input.slider()` would raise an exception and the `ui.input_slider()` would never be returned.

```python
from shiny import render
from shiny.express import input, ui

ui.input_switch("show_slider", "Show slider", True)


@render.ui
def uiElement():
    if input.show_slider():
        value = input.slider() or 5
        return ui.input_slider("slider", "Choose a number", min=1, max=10, value=value)
```

This could be worked around by calling

```py
value = input.slider() if "slider" in input else 5
```

but that's not as concise or pythonic as `value = input.slider() or 5`. 