### PR TITLE
Pin starlette version below 0.35

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ setup_requires =
 install_requires =
     typing-extensions>=4.0.1
     uvicorn>=0.16.0
-    starlette>=0.17.1
+    starlette>=0.17.1,<0.35.0
     websockets>=10.0
     python-multipart
     htmltools>=0.5.1


### PR DESCRIPTION
There have been issues reported where Shiny apps deployed to Posit Connect break with the latest release of starlette/fastapi. This should keep folks from running into that (for now; we can remove this after a while once Posit Connect customers have time to upgrade with the fix). 