### PR TITLE
chore(render.display): Improve error message

### DIFF
--- a/shiny/render/_display.py
+++ b/shiny/render/_display.py
@@ -94,7 +94,7 @@ class display(Renderer[None]):
             ret = sync_value_fn()
             if ret is not None:
                 raise RuntimeError(
-                    "@render.display functions should not return values. (`None` is allowed)."
+                    "@render.display functions should not return values. Instead, the function body should include Shiny Express code that will be dynamically rendered in the app. (`None` is a valid return value.)"
                 )
         finally:
             sys.displayhook = orig_displayhook

--- a/shiny/render/_display.py
+++ b/shiny/render/_display.py
@@ -94,7 +94,7 @@ class display(Renderer[None]):
             ret = sync_value_fn()
             if ret is not None:
                 raise RuntimeError(
-                    "@render.display functions should not return values. Instead, the function body should include Shiny Express code that will be dynamically rendered in the app. (`None` is a valid return value.)"
+                    "@render.display functions should not return values. Instead, @render.display dynamically renders every printable line within the function body. (`None` is a valid return value.)"
                 )
         finally:
             sys.displayhook = orig_displayhook


### PR DESCRIPTION
Changes the error thrown by `@render.display` when the decorated function has a return value from

```
@render.display functions should not return values. (`None` is allowed).
```

to

```
@render.display functions should not return values. Instead, the function
body should include Shiny Express code that will be dynamically rendered
in the app. (`None` is a valid return value.)
```

## Notes and Questions

Is `@render.display` intended only for Shiny Express? (If yes, this does speak to having `shiny.express.render` and for not including `render.display` in `shiny`.)

@schloerke described `@render.display` as follows on Slack:

> * `render.ui` renders the last thing returned.
> * `render.display` renders every printable line within the function.

If `render.display` is intended for Shiny Core as well then we could fall back to "Instead, @render.display dynamically renders every printable line within the function body" rather than naming Shiny Express. This phrasing is technically more precise but still not quite actionable for someone just starting with Shiny or Express.