### PR TITLE
fix(page_sidebar): Add semicolon to end style declaration

### DIFF
--- a/shiny/ui/_page.py
+++ b/shiny/ui/_page.py
@@ -94,7 +94,7 @@ def page_sidebar(
             sidebar,
             *children,
             # Make the main area background white instead of the default gray.
-            {"style": "--bslib-shiny-preset-main-bg: white"},
+            {"style": "--bslib-shiny-preset-main-bg: white;"},
             attrs,
             fillable=fillable,
             border=False,


### PR DESCRIPTION
If internally-added styles are constructed by hand and not with the help of `css()`, we need to include the semicolon. Otherwise users styles will be space-separated with our internal property declarations, leading to broken `style` attributes.