### PR TITLE
api!: Merge RendererBase class into Renderer

### DIFF
--- a/docs/_quartodoc.yml
+++ b/docs/_quartodoc.yml
@@ -177,10 +177,10 @@ quartodoc:
             desc: ""
           contents:
             - render.renderer.Renderer
-            - render.renderer.RendererBase
             - render.renderer.Jsonifiable
             - render.renderer.ValueFn
             - render.renderer.AsyncValueFn
+            - render.renderer.RendererT
     - title: Reactive programming
       desc: ""
       contents:

--- a/shiny/__init__.py
+++ b/shiny/__init__.py
@@ -1,6 +1,6 @@
 """A package for building reactive web applications."""
 
-__version__ = "0.6.1.9005"
+__version__ = "0.6.1.9006"
 
 from ._shinyenv import is_pyodide as _is_pyodide
 

--- a/shiny/reactive/_reactives.py
+++ b/shiny/reactive/_reactives.py
@@ -480,9 +480,9 @@ class Effect_:
         self.__name__ = fn.__name__
         self.__doc__ = fn.__doc__
 
-        from ..render.renderer import RendererBase
+        from ..render.renderer import Renderer
 
-        if isinstance(fn, RendererBase):
+        if isinstance(fn, Renderer):
             raise TypeError(
                 "`@reactive.effect` can not be combined with `@render.xx`.\n"
                 + "Please remove your call of `@reactive.effect`."
@@ -819,9 +819,9 @@ def event(
 
         # This is here instead of at the top of the .py file in order to avoid a
         # circular dependency.
-        from ..render.renderer import RendererBase
+        from ..render.renderer import Renderer
 
-        if isinstance(user_fn, RendererBase):
+        if isinstance(user_fn, Renderer):
             # At some point in the future, we may allow this condition, if we find an
             # use case. For now we'll disallow it, for simplicity.
             raise TypeError(

--- a/shiny/render/_deprecated.py
+++ b/shiny/render/_deprecated.py
@@ -1,19 +1,9 @@
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
 from typing import Generic
 
-from .transformer._transformer import (
-    IT,
-    OT,
-    OutputRendererAsync,
-    OutputRendererSync,
-    TransformerMetadata,
-    ValueFn,
-    ValueFnAsync,
-    ValueFnSync,
-    empty_params,
-)
+from .._deprecated import ShinyDeprecationWarning
+from .transformer._transformer import IT, OT, ValueFnAsync, ValueFnSync
 
 # ======================================================================================
 # Deprecated classes
@@ -24,56 +14,32 @@ from .transformer._transformer import (
 # the .__call__ method is invoked, it calls the app-supplied function (which returns an
 # `IT`), then converts the `IT` to an `OT`. Note that in many cases but not all, `IT`
 # and `OT` will be the same.
-class RenderFunction(Generic[IT, OT], OutputRendererSync[OT], ABC):
+class RenderFunction(Generic[IT, OT]):
     """
-    Deprecated. Please use :func:`~shiny.render.renderer_components` instead.
+    Deprecated. Please use :class:`~shiny.render.renderer.Renderer` class instead.
     """
-
-    @abstractmethod
-    def __call__(self) -> OT:
-        ...
-
-    @abstractmethod
-    async def run(self) -> OT:
-        ...
 
     def __init__(self, fn: ValueFnSync[IT]) -> None:
-        async def transformer(_meta: TransformerMetadata, _fn: ValueFn[IT]) -> OT:
-            ret = await self.run()
-            return ret
-
-        super().__init__(
-            value_fn=fn,
-            transform_fn=transformer,
-            params=empty_params(),
+        raise ShinyDeprecationWarning(
+            "Class `"
+            + str(self.__class__.__name__)
+            + "` inherits from the deprecated class `shiny.render.RenderFunction`. "
+            "Please update your renderer to use `shiny.render.renderer.Renderer` instead."
         )
-        self._fn = fn
 
 
 # The reason for having a separate RenderFunctionAsync class is because the __call__
 # method is marked here as async; you can't have a single class where one method could
 # be either sync or async.
-class RenderFunctionAsync(Generic[IT, OT], OutputRendererAsync[OT], ABC):
+class RenderFunctionAsync(Generic[IT, OT]):
     """
-    Deprecated. Please use :func:`~shiny.render.renderer_components` instead.
+    Deprecated. Please use :class:`~shiny.render.renderer.Renderer` class instead.
     """
-
-    @abstractmethod
-    async def __call__(self) -> OT:  # pyright: ignore[reportIncompatibleMethodOverride]
-        ...
-
-    @abstractmethod
-    async def run(self) -> OT:
-        ...
 
     def __init__(self, fn: ValueFnAsync[IT]) -> None:
-        async def transformer(_meta: TransformerMetadata, _fn: ValueFn[IT]) -> OT:
-            ret = await self.run()
-            return ret
-
-        super().__init__(
-            value_fn=fn,
-            transform_fn=transformer,
-            params=empty_params(),
+        raise ShinyDeprecationWarning(
+            "Class `"
+            + str(self.__class__.__name__)
+            + "` inherits from the deprecated class `shiny.render.RenderFunctionAsync`. "
+            "Please update your renderer to use `shiny.render.renderer.Renderer` instead."
         )
-        self._fn = fn

--- a/shiny/render/renderer/__init__.py
+++ b/shiny/render/renderer/__init__.py
@@ -1,18 +1,16 @@
 from ._renderer import (  # noqa: F401
-    RendererBase,
     Renderer,
     ValueFn,
     Jsonifiable,
-    RendererBaseT,
+    RendererT,
     AsyncValueFn,
     # IT,  # pyright: ignore[reportUnusedImport]
 )
 
 __all__ = (
-    "RendererBase",
     "Renderer",
     "ValueFn",
     "Jsonifiable",
     "AsyncValueFn",
-    "RendererBaseT",
+    "RendererT",
 )

--- a/shiny/render/renderer/_renderer.py
+++ b/shiny/render/renderer/_renderer.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
 from typing import (
     Any,
     Awaitable,
@@ -31,18 +30,17 @@ from ..._utils import is_async_callable, wrap_async
 
 __all__ = (
     "Renderer",
-    "RendererBase",
     "Jsonifiable",
     "ValueFn",
     "AsyncValueFn",
-    "RendererBaseT",
+    "RendererT",
 )
 
-RendererBaseT = TypeVar("RendererBaseT", bound="RendererBase")
+RendererT = TypeVar("RendererT", bound="Renderer[Any]")
 """
 Generic class to pass the Renderer class through a decorator.
 
-When accepting and returning a `RendererBase` class, utilize this TypeVar as to not reduce the variable type to `RendererBase`
+When accepting and returning a `Renderer` class, utilize this TypeVar as to not reduce the variable type to `Renderer[Any]`
 """
 
 # Input type for the user-spplied function that is passed to a render.xx
@@ -96,9 +94,9 @@ synchronous or asynchronous.
 """
 
 
-class RendererBase(ABC):
+class Renderer(Generic[IT]):
     """
-    Base class for all renderers.
+    Output renderer class
 
     TODO-barret-docs
     """
@@ -112,10 +110,9 @@ class RendererBase(ABC):
     """
     Name of output function supplied. (The value will not contain any module prefix.)
 
-    Set within `Renderer.__call__()` method.
+    Set within `.__call__()` method.
     """
 
-    # Meta
     output_id: str
     """
     Output function name or ID (provided to `@output(id=)`).
@@ -127,6 +124,41 @@ class RendererBase(ABC):
     An initial value of `.__name__` (set within `Renderer.__call__(_fn)`) will be used until the
     output renderer is registered within the session.
     """
+
+    fn: AsyncValueFn[IT]
+    """
+    App-supplied output value function which returns type `IT`. This function is always
+    asyncronous as the original app-supplied function possibly wrapped to execute
+    asynchonously.
+    """
+
+    def __call__(self, _fn: ValueFn[IT]) -> Self:
+        """
+        Renderer __call__ docs here; Sets app's value function
+
+        TODO-barret-docs
+        """
+
+        if not callable(_fn):
+            raise TypeError("Value function must be callable")
+
+        # Set value function with extra meta information
+        self.fn = AsyncValueFn(_fn)
+
+        # Copy over function name as it is consistent with how Session and Output
+        # retrieve function names
+        self.__name__ = _fn.__name__
+
+        # Set the value of `output_id` to the function name.
+        # This helps with testing and other situations where no session is present
+        # for auto-registration to occur.
+        self.output_id = self.__name__
+
+        # Allow for App authors to not require `@output`
+        self._auto_register()
+
+        # Return self for possible chaining of methods!
+        return self
 
     def _set_output_metadata(
         self,
@@ -151,13 +183,49 @@ class RendererBase(ABC):
     ) -> DefaultUIFnResultOrNone:
         return None
 
-    @abstractmethod
-    async def render(self) -> Jsonifiable:
-        ...
-
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        _fn: Optional[ValueFn[IT]] = None,
+    ) -> None:
+        # Do not display docs here. If docs are present, it could highjack the docs of
+        # the subclass's `__init__` method.
+        # """
+        # Renderer - init docs here
+        # """
         super().__init__()
+
         self._auto_registered: bool = False
+
+        # Must be done last
+        if callable(_fn):
+            # Register the value function
+            self(_fn)
+
+    async def transform(self, value: IT) -> Jsonifiable:
+        """
+        Renderer - transform docs here
+
+        TODO-barret-docs
+        """
+        raise NotImplementedError(
+            "Please implement either the `transform(self, value: IT)` or `render(self)` method.\n"
+            "* `transform(self, value: IT)` should transform the `value` (of type `IT`) into Jsonifiable object. Ex: `dict`, `None`, `str`. (standard)\n"
+            "* `render(self)` method has full control of how an App author's value is retrieved (`self._fn()`) and utilized. (rare)\n"
+            "By default, the `render` retrieves the value and then calls `transform` method on non-`None` values."
+        )
+
+    async def render(self) -> Jsonifiable:
+        """
+        Renderer - render docs here
+
+        TODO-barret-docs
+        """
+        value = await self.fn()
+        if value is None:
+            return None
+
+        rendered = await self.transform(value)
+        return rendered
 
     # ######
     # Tagify-like methods
@@ -284,86 +352,3 @@ class AsyncValueFn(Generic[IT]):
             )
         sync_fn = cast(Callable[[], IT], self._orig_fn)
         return sync_fn
-
-
-class Renderer(RendererBase, Generic[IT]):
-    """
-    Renderer cls docs here
-
-    TODO-barret-docs
-    """
-
-    fn: AsyncValueFn[IT]
-    """
-    App-supplied output value function which returns type `IT`. This function is always
-    asyncronous as the original app-supplied function possibly wrapped to execute
-    asynchonously.
-    """
-
-    def __call__(self, _fn: ValueFn[IT]) -> Self:
-        """
-        Renderer __call__ docs here; Sets app's value function
-
-        TODO-barret-docs
-        """
-
-        if not callable(_fn):
-            raise TypeError("Value function must be callable")
-
-        # Set value function with extra meta information
-        self.fn = AsyncValueFn(_fn)
-
-        # Copy over function name as it is consistent with how Session and Output
-        # retrieve function names
-        self.__name__ = _fn.__name__
-
-        # Set the value of `output_id` to the function name.
-        # This helps with testing and other situations where no session is present
-        # for auto-registration to occur.
-        self.output_id = self.__name__
-
-        # Allow for App authors to not require `@output`
-        self._auto_register()
-
-        # Return self for possible chaining of methods!
-        return self
-
-    def __init__(
-        self,
-        _fn: Optional[ValueFn[IT]] = None,
-    ):
-        # Do not display docs here. If docs are present, it could highjack the docs of
-        # the subclass's `__init__` method.
-        # """
-        # Renderer - init docs here
-        # """
-        super().__init__()
-        if callable(_fn):
-            # Register the value function
-            self(_fn)
-
-    async def transform(self, value: IT) -> Jsonifiable:
-        """
-        Renderer - transform docs here
-
-        TODO-barret-docs
-        """
-        raise NotImplementedError(
-            "Please implement either the `transform(self, value: IT)` or `render(self)` method.\n"
-            "* `transform(self, value: IT)` should transform the `value` (of type `IT`) into Jsonifiable object. Ex: `dict`, `None`, `str`. (standard)\n"
-            "* `render(self)` method has full control of how an App author's value is retrieved (`self._fn()`) and utilized. (rare)\n"
-            "By default, the `render` retrieves the value and then calls `transform` method on non-`None` values."
-        )
-
-    async def render(self) -> Jsonifiable:
-        """
-        Renderer - render docs here
-
-        TODO-barret-docs
-        """
-        value = await self.fn()
-        if value is None:
-            return None
-
-        rendered = await self.transform(value)
-        return rendered

--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -49,7 +49,7 @@ from ..http_staticfiles import FileResponse
 from ..input_handler import input_handlers
 from ..reactive import Effect_, Value, effect, flush, isolate
 from ..reactive._core import lock, on_flushed
-from ..render.renderer import Jsonifiable, RendererBase, RendererBaseT
+from ..render.renderer import Jsonifiable, Renderer, RendererT
 from ..types import SafeException, SilentCancelOutputException, SilentException
 from ._utils import RenderedDeps, read_thunk_opt, session_context
 
@@ -973,7 +973,7 @@ class Outputs:
         self._suspend_when_hidden = suspend_when_hidden
 
     @overload
-    def __call__(self, renderer: RendererBaseT) -> RendererBaseT:
+    def __call__(self, renderer: RendererT) -> RendererT:
         ...
 
     @overload
@@ -983,19 +983,19 @@ class Outputs:
         id: Optional[str] = None,
         suspend_when_hidden: bool = True,
         priority: int = 0,
-    ) -> Callable[[RendererBaseT], RendererBaseT]:
+    ) -> Callable[[RendererT], RendererT]:
         ...
 
     def __call__(
         self,
-        renderer: Optional[RendererBaseT] = None,
+        renderer: Optional[RendererT] = None,
         *,
         id: Optional[str] = None,
         suspend_when_hidden: bool = True,
         priority: int = 0,
-    ) -> RendererBaseT | Callable[[RendererBaseT], RendererBaseT]:
-        def set_renderer(renderer: RendererBaseT) -> RendererBaseT:
-            if not isinstance(renderer, RendererBase):
+    ) -> RendererT | Callable[[RendererT], RendererT]:
+        def set_renderer(renderer: RendererT) -> RendererT:
+            if not isinstance(renderer, Renderer):
                 raise TypeError(
                     "`@output` must be applied to a `@render.xx` function.\n"
                     + "In other words, `@output` must be above `@render.xx`."

--- a/tests/playwright/shiny/components/data_frame/test_data_frame.py
+++ b/tests/playwright/shiny/components/data_frame/test_data_frame.py
@@ -54,10 +54,7 @@ def test_grid_mode(
 
 @pytest.mark.flaky(reruns=RERUNS)
 def test_summary_navigation(
-    page: Page,
-    data_frame_app: ShinyAppProc,
-    grid_container: Locator,
-    summary: Locator,
+    page: Page, data_frame_app: ShinyAppProc, grid_container: Locator, summary: Locator
 ):
     page.goto(data_frame_app.url)
 
@@ -65,8 +62,8 @@ def test_summary_navigation(
     expect(summary).to_have_text(re.compile("^Viewing rows 1 through \\d+ of 20$"))
     # Put focus in the table and hit End keystroke
     grid_container.locator("tbody tr:first-child td:first-child").click()
-    page.keyboard.press("End")
-
+    with expect_to_change(lambda: summary.inner_text()):
+        page.keyboard.press("End")
     # Ensure that summary updated
     expect(summary).to_have_text(re.compile("^Viewing rows \\d+ through 20 of 20$"))
 

--- a/tests/playwright/shiny/components/data_frame/test_data_frame.py
+++ b/tests/playwright/shiny/components/data_frame/test_data_frame.py
@@ -59,6 +59,9 @@ def test_summary_navigation(
     grid_container: Locator,
     summary: Locator,
 ):
+    # Update the page size to be big
+    page.set_viewport_size({"width": 2000, "height": 2000})
+
     page.goto(data_frame_app.url)
 
     # Check that summary responds to navigation

--- a/tests/playwright/shiny/components/data_frame/test_data_frame.py
+++ b/tests/playwright/shiny/components/data_frame/test_data_frame.py
@@ -54,7 +54,10 @@ def test_grid_mode(
 
 @pytest.mark.flaky(reruns=RERUNS)
 def test_summary_navigation(
-    page: Page, data_frame_app: ShinyAppProc, grid_container: Locator, summary: Locator
+    page: Page,
+    data_frame_app: ShinyAppProc,
+    grid_container: Locator,
+    summary: Locator,
 ):
     page.goto(data_frame_app.url)
 
@@ -62,8 +65,8 @@ def test_summary_navigation(
     expect(summary).to_have_text(re.compile("^Viewing rows 1 through \\d+ of 20$"))
     # Put focus in the table and hit End keystroke
     grid_container.locator("tbody tr:first-child td:first-child").click()
-    with expect_to_change(lambda: summary.inner_text()):
-        page.keyboard.press("End")
+    page.keyboard.press("End")
+
     # Ensure that summary updated
     expect(summary).to_have_text(re.compile("^Viewing rows \\d+ through 20 of 20$"))
 

--- a/tests/playwright/shiny/components/data_frame/test_data_frame.py
+++ b/tests/playwright/shiny/components/data_frame/test_data_frame.py
@@ -59,9 +59,6 @@ def test_summary_navigation(
     grid_container: Locator,
     summary: Locator,
 ):
-    # Update the page size to be big
-    page.set_viewport_size({"width": 2000, "height": 2000})
-
     page.goto(data_frame_app.url)
 
     # Check that summary responds to navigation

--- a/tests/pytest/test_output_transformer.py
+++ b/tests/pytest/test_output_transformer.py
@@ -251,10 +251,10 @@ async def test_renderer_handler_or_transform_fn_can_be_async():
         return test_val
 
     # All renderers are async in execution.
-    assert not is_async_callable(renderer_sync)
+    assert not is_async_callable(renderer_sync._value_fn)
 
     with session_context(test_session):
-        val = renderer_sync()
+        val = await renderer_sync._run()
         assert val == test_val
 
     # ## Test Async: √ =============================================
@@ -266,11 +266,11 @@ async def test_renderer_handler_or_transform_fn_can_be_async():
         await asyncio.sleep(0)
         return async_test_val
 
-    if not is_async_callable(renderer_async):
+    if not is_async_callable(renderer_async._value_fn):
         raise RuntimeError("Expected `renderer_async` to be a coro function")
 
     with session_context(test_session):
-        ret = await renderer_async()
+        ret = await renderer_async._run()
         assert ret == async_test_val
 
 

--- a/tests/pytest/test_utils.py
+++ b/tests/pytest/test_utils.py
@@ -165,7 +165,7 @@ def test_random_port():
             # Port `port + j` is busy,
             # Shift the test range and try again
             port += j + 1
-            print(port)
+            print("Trying port: ", port)
     # If no port is available, throw an error
     # `attempts` should be << n
     if attempts == n:
@@ -191,6 +191,19 @@ def test_random_port_unusable():
 
 
 def test_random_port_starvation():
-    with socketserver.TCPServer(("127.0.0.1", 9000), socketserver.BaseRequestHandler):
-        with pytest.raises(RuntimeError, match="Failed to find a usable random port"):
-            random_port(9000, 9000)
+    port = 9000
+    for _ in range(100):
+        try:
+            with socketserver.TCPServer(
+                ("127.0.0.1", port),
+                socketserver.BaseRequestHandler,
+            ):
+                with pytest.raises(
+                    RuntimeError, match="Failed to find a usable random port"
+                ):
+                    random_port(port, port)
+        except OSError as e:
+            print(e)
+            # Port is busy, bump the port number
+            port += 1
+            print("Trying port: ", port)


### PR DESCRIPTION
* Removes RendererBase class.
* `RendererBaseT` -> `RendererT`
* Hard deprecate `RenderFunction` / `RenderFunctionAsync`
	* The `RenderFunction.__call__(self)` method was an `@abstractmethod`. This method's signature and intent did not agree with `Renderer.__call__(self, _fn: ValueFn[...])`. 
	* This might occur with older versions of `shinywidgets` with newer versions of `shiny`.
	* This goes against https://github.com/posit-dev/py-shiny/issues/1003 in that now the methods are hard deprecated. But at least the message is much clearer on how to move forward.