### PR TITLE
Set a MockSession context for the initial execution of express code

### DIFF
--- a/shiny/express/__init__.py
+++ b/shiny/express/__init__.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from typing import cast
+
 # Import these with underscore names so they won't show in autocomplete from the Python
 # console.
-from ..session import Inputs as _Inputs, Outputs as _Outputs, Session as _Session
-from ..session import _utils as _session_utils
+from ..session import Inputs as _Inputs, Outputs as _Outputs
+from ..session._session import ExpressSession as _ExpressSession
+from ..session._utils import get_current_session
 from .. import render
 from . import ui
 from ._is_express import is_express_app
@@ -29,7 +32,7 @@ __all__ = (
 # Add types to help type checkers
 input: _Inputs
 output: _Outputs
-session: _Session
+session: _ExpressSession
 
 
 # Note that users should use `from shiny.express import input` instead of `from shiny
@@ -39,42 +42,15 @@ session: _Session
 # cases, but when it fails, it will be very confusing.
 def __getattr__(name: str) -> object:
     if name == "input":
-        return _get_current_session_or_mock().input
+        return get_express_session().input
     elif name == "output":
-        return _get_current_session_or_mock().output
+        return get_express_session().output
     elif name == "session":
-        return _get_current_session_or_mock()
+        return get_express_session()
 
     raise AttributeError(f"Module 'shiny.express' has no attribute '{name}'")
 
 
-# A very bare-bones mock session class that is used only in shiny.express.
-class _MockSession:
-    def __init__(self):
-        from typing import cast
-
-        from .._namespaces import Root
-
-        self.input = _Inputs({})
-        self.output = _Outputs(cast(_Session, self), Root, {}, {})
-
-    # This is needed so that Outputs don't throw an error.
-    def _is_hidden(self, name: str) -> bool:
-        return False
-
-
-_current_mock_session: _MockSession | None = None
-
-
-def _get_current_session_or_mock() -> _Session:
-    from typing import cast
-
-    session = _session_utils.get_current_session()
-    if session is None:
-        global _current_mock_session
-        if _current_mock_session is None:
-            _current_mock_session = _MockSession()
-        return cast(_Session, _current_mock_session)
-
-    else:
-        return session
+# Express code gets executed twice: once with a MockSession and once with a real session.
+def get_express_session() -> _ExpressSession:
+    return cast(_ExpressSession, get_current_session())

--- a/shiny/express/_run.py
+++ b/shiny/express/_run.py
@@ -8,7 +8,8 @@ from typing import cast
 from htmltools import Tag, TagList
 
 from .._app import App
-from ..session import Inputs, Outputs, Session
+from ..session import Inputs, Outputs, Session, session_context
+from ..session._session import MockSession
 from ._recall_context import RecallContextManager
 from .expressify_decorator._func_displayhook import _expressify_decorator_function_def
 from .expressify_decorator._node_transformers import (
@@ -39,7 +40,8 @@ def wrap_express_app(file: Path) -> App:
         # catch them here and convert them to a different type of error, because uvicorn
         # specifically catches AttributeErrors and prints an error message that is
         # misleading for Shiny Express. https://github.com/posit-dev/py-shiny/issues/937
-        app_ui = run_express(file).tagify()
+        with session_context(cast(Session, MockSession())):
+            app_ui = run_express(file).tagify()
     except AttributeError as e:
         raise RuntimeError(e) from e
 


### PR DESCRIPTION
This is currently a quick and dirty draft at addressing #1034.

The main idea here is that if you try to access session attributes on the 1st run of an express app, you get an informative error (to wrap that code in `if session:` ), so that something like this can work without error:

```python
from shiny import reactive
from shiny.express import session, ui

@reactive.effect
async def _():
    if session:
        x = {"message": "Hello from Python!"}
        await session.send_custom_message("send_alert", x)

ui.tags.script(
    """
    Shiny.addCustomMessageHandler("send_alert", function(x) {
        document.body.innerHTML = x.message;
    });
    """
)
```


Also, more controversially, `require_active_session()` will now throw a silent exception when there is no actual session inside a reactive context, so that something like this just works without error:

```python
from shiny import reactive, session
from shiny.express import ui

ui.input_slider("n", "N", 1, 100, 50)

@reactive.effect
def _():
    ui.update_slider("n", value=10)
```
