### PR TITLE
Add `fill` to `__all__` in `ui` and `express.ui`

### DIFF
--- a/shiny/express/ui/__init__.py
+++ b/shiny/express/ui/__init__.py
@@ -30,6 +30,10 @@ from htmltools import (
 )
 
 from ...ui import (
+    fill,
+)
+
+from ...ui import (
     AccordionPanel,
     AnimationOptions,
     CardItem,
@@ -169,6 +173,8 @@ __all__ = (
     "span",
     "strong",
     "tags",
+    # Submodules
+    "fill",
     # Imports from ...ui
     "AccordionPanel",
     "AnimationOptions",

--- a/shiny/ui/__init__.py
+++ b/shiny/ui/__init__.py
@@ -31,8 +31,12 @@ from htmltools import (
     tags,
 )
 
-# Expose the following modules for extended usage: ex: ui.fill.as_fill_item(x)
-from . import css, fill  # noqa: F401  # pyright: ignore[reportUnusedImport]
+from . import (
+    # The css module is for internal use, so we won't re-export it.
+    css,  # noqa: F401  # pyright: ignore[reportUnusedImport]
+    # Expose the fill module for extended usage: ex: ui.fill.as_fill_item(x).
+    fill,
+)
 from ._accordion import (
     AccordionPanel,
     accordion,
@@ -346,6 +350,8 @@ __all__ = (
     "strong",
     "em",
     "hr",
+    # Submodules
+    "fill",
     # utils
     "js_eval",
 )

--- a/shiny/ui/__init__.py
+++ b/shiny/ui/__init__.py
@@ -31,12 +31,12 @@ from htmltools import (
     tags,
 )
 
-from . import (
-    # The css module is for internal use, so we won't re-export it.
-    css,  # noqa: F401  # pyright: ignore[reportUnusedImport]
-    # Expose the fill module for extended usage: ex: ui.fill.as_fill_item(x).
-    fill,
-)
+# The css module is for internal use, so we won't re-export it.
+from . import css  # noqa: F401  # pyright: ignore[reportUnusedImport]
+
+# Expose the fill module for extended usage: ex: ui.fill.as_fill_item(x).
+from . import fill
+
 from ._accordion import (
     AccordionPanel,
     accordion,


### PR DESCRIPTION
`fill` is currently imported into `shiny.ui`, but are not listed in the `__all__` in that file. This PR:

- Adds it to `__all__` in `shiny.ui`
- Imports it into `shiny.express.ui` and also adds them to `__all__` in that file.

Note that this PR doesn't do the same for `css`. This is because `css` is meant for internal use.