### PR TITLE
Raise when `express.[input,output,session]` are used outside of Express app

### DIFF
--- a/shiny/express/__init__.py
+++ b/shiny/express/__init__.py
@@ -42,11 +42,39 @@ session: _Session
 # returns the input for the current session. This will work in the vast majority of
 # cases, but when it fails, it will be very confusing.
 def __getattr__(name: str) -> object:
+    session = _get_current_session()
+
     if name == "input":
-        return _get_current_session().input  # pyright: ignore
+        if session is None:
+            return _ExpressOnlyPlaceholder("input")
+        else:
+            return session.input  # pyright: ignore
     elif name == "output":
-        return _get_current_session().output  # pyright: ignore
+        if session is None:
+            return _ExpressOnlyPlaceholder("output")
+        else:
+            return session.output  # pyright: ignore
     elif name == "session":
-        return _get_current_session()
+        if session is None:
+            return _ExpressOnlyPlaceholder("session")
+        else:
+            return session
 
     raise AttributeError(f"Module 'shiny.express' has no attribute '{name}'")
+
+
+class _ExpressOnlyPlaceholder:
+    """Placeholder class for objects that can only be used in a Shiny Express app."""
+
+    def __init__(self, name: str):
+        self.name = name
+
+    def __getattr__(self, name: str) -> None:
+        raise RuntimeError(
+            f"shiny.express.{self.name} can only be used inside of a Shiny Express app."
+        )
+
+    def __call__(self, *args: object, **kwargs: object) -> None:
+        raise RuntimeError(
+            f"shiny.express.{self.name} can only be used inside of a Shiny Express app."
+        )


### PR DESCRIPTION
This closes #1065.

Now, if the user does an import outside of an Express app, it will not throw immediately, but it will throw if they try to use the object.

```
>>> from shiny.express import *

>>> input
<shiny.express._ExpressOnlyPlaceholder object at 0x1044c0490>
>>> input.d
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/winston/Projects/py-shiny/shiny/express/__init__.py", line 73, in __getattr__
    raise RuntimeError(
RuntimeError: shiny.express.input can only be used inside of a Shiny Express app.


>>> session
<shiny.express._ExpressOnlyPlaceholder object at 0x107897a10>
>>> session.d
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/winston/Projects/py-shiny/shiny/express/__init__.py", line 73, in __getattr__
    raise RuntimeError(
RuntimeError: shiny.express.session can only be used inside of a Shiny Express app.


>>> output
<shiny.express._ExpressOnlyPlaceholder object at 0x1044c22d0>
>>> output()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/winston/Projects/py-shiny/shiny/express/__init__.py", line 78, in __call__
    raise RuntimeError(
RuntimeError: shiny.express.output can only be used inside of a Shiny Express app.
```