### PR TITLE
chore: Pin black to version 23

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -86,7 +86,7 @@ test =
     folium
 
 dev =
-    black>=23.1.0
+    black >=23.1, <24.0
     flake8>=6.0.0
     flake8-bugbear>=23.2.13
     isort>=5.10.1


### PR DESCRIPTION
Version 24 introduces many new changes across our codebase and introduces a conflicts across a number of open PRs. We can remove this pin after finishing the Express docs release.

https://pypi.org/project/black/