### PR TITLE
In Express, set session to `None` when importing `shared`

### DIFF
--- a/shiny/express/_run.py
+++ b/shiny/express/_run.py
@@ -14,7 +14,9 @@ from ._recall_context import RecallContextManager
 from .expressify_decorator._func_displayhook import _expressify_decorator_function_def
 from .expressify_decorator._node_transformers import (
     DisplayFuncsTransformer,
+    ImportSharedSessionContextTransformer,
     expressify_decorator_func_name,
+    session_context_func_name,
 )
 
 __all__ = ("wrap_express_app",)
@@ -67,6 +69,7 @@ def run_express(file: Path) -> Tag | TagList:
 
     tree = ast.parse(content, file)
     tree = DisplayFuncsTransformer().visit(tree)
+    tree = ImportSharedSessionContextTransformer("shared").visit(tree)
     tree = ast.fix_missing_locations(tree)
 
     ui_result: Tag | TagList = TagList()
@@ -87,6 +90,7 @@ def run_express(file: Path) -> Tag | TagList:
         var_context: dict[str, object] = {
             "__file__": file_path,
             expressify_decorator_func_name: _expressify_decorator_function_def,
+            session_context_func_name: session_context,
             "input": InputNotImportedShim(),
         }
 


### PR DESCRIPTION
This is one possible solution for #1079.

When it sees `import shared` or `from shared import ...` at the top level, it puts that within a `with session_context(None):` block.

One possible limitation is that, if someone does this:


```py
import module1, shared
```


Then that gets transformed into

```py
with session_context(None):
    import module1, shared
```

which means that `module1` would also have the session set to `None`. In practice, it seems unusual for people to put multiple imports on a line like that, but still, it could happen.