### PR TITLE
Fix `render.download` in Shiny Express, take 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+* Fixed `render.download` not working in Express. (#1085)
 
 
 ## [0.7.0] - 2024-01-25

--- a/shiny/api-examples/download_button/app-express.py
+++ b/shiny/api-examples/download_button/app-express.py
@@ -1,0 +1,15 @@
+import asyncio
+import random
+from datetime import date
+
+from shiny.express import render
+
+
+@render.download(
+    filename=lambda: f"新型-{date.today().isoformat()}-{random.randint(100,999)}.csv"
+)
+async def downloadData():
+    await asyncio.sleep(0.25)
+    yield "one,two,three\n"
+    yield "新,1,2\n"
+    yield "型,4,5\n"

--- a/shiny/render/_render.py
+++ b/shiny/render/_render.py
@@ -30,6 +30,7 @@ from .. import ui as _ui
 from .._docstring import add_example, no_example
 from .._namespaces import ResolvedId
 from .._typing_extensions import Self
+from ..express._mock_session import MockSession
 from ..session import get_current_session, require_active_session
 from ..session._session import DownloadHandler, DownloadInfo
 from ..types import MISSING, MISSING_TYPE, ImgData
@@ -688,7 +689,7 @@ class download(Renderer[str]):
         # not being None is because in Express, when the UI is rendered, this function
         # `render.download()()`  called once before any sessions have been started.
         session = get_current_session()
-        if session is not None:
+        if session is not None and not isinstance(session, MockSession):
             session._downloads[self.output_id] = DownloadInfo(
                 filename=self.filename,
                 content_type=self.media_type,


### PR DESCRIPTION
This PR supersedes #1084.

Note that the solution here is similar to the one in used #1049. In the future, it should be replaced with a check that doesn't need to explicitly know about `MockSession`s at that location.

Another odd thing about the existing code is that it accesses and modifies `session._downloads` directly. Perhaps a better fix is to add a method like `Session.register_download()`.

Both of the proposed changes mentioned above are more invasive than this one, so it would be best to do them in a future PR, after things have settled down.