### PR TITLE
docs: Add ExtendedTask to API index

### DIFF
--- a/docs/_quartodoc-core.yml
+++ b/docs/_quartodoc-core.yml
@@ -260,6 +260,17 @@ quartodoc:
               dynamic: false
             - name: htmltools.css
               dynamic: false
+        - kind: page
+          path: ExtendedTask
+          flatten: true
+          summary:
+            name: "Create an extended task"
+            desc: ""
+          contents:
+            - reactive.ExtendedTask
+            - reactive.ExtendedTask.invoke
+            - reactive.ExtendedTask.result
+            - reactive.ExtendedTask.cancel
     - title: Types
       desc: ""
       contents:

--- a/docs/_quartodoc-core.yml
+++ b/docs/_quartodoc-core.yml
@@ -264,8 +264,8 @@ quartodoc:
           path: ExtendedTask
           flatten: true
           summary:
-            name: "Create an extended task"
-            desc: ""
+            name: "ExtendedTask"
+            desc: "Supervise an extended, long-running task"
           contents:
             - reactive.ExtendedTask
             - reactive.ExtendedTask.invoke

--- a/docs/_quartodoc-core.yml
+++ b/docs/_quartodoc-core.yml
@@ -184,6 +184,7 @@ quartodoc:
         - reactive.event
         - reactive.isolate
         - reactive.invalidate_later
+        - reactive.extended_task
         - reactive.flush
         - reactive.poll
         - reactive.file_reader

--- a/docs/_quartodoc-express.yml
+++ b/docs/_quartodoc-express.yml
@@ -83,6 +83,7 @@ quartodoc:
         - reactive.event
         - reactive.isolate
         - reactive.invalidate_later
+        - reactive.extended_task
         - reactive.flush
         - reactive.poll
         - reactive.file_reader


### PR DESCRIPTION
This PR addes `reactive.extended_task` and `reactive.ExtendedTask` to the API reference index (under reactives and developer tools, respectively). The `reactive.ExtendedTask` is only shown in the Core docs, in line with the rest of the developer tools.