### PR TITLE
Add `shiny.express.app_globals()`

### DIFF
--- a/shiny/express/__init__.py
+++ b/shiny/express/__init__.py
@@ -16,6 +16,7 @@ from ._output import (  # noqa: F401
     suspend_display,  # pyright: ignore[reportUnusedImport] - Deprecated
 )
 from ._run import wrap_express_app
+from ._app_globals import app_globals
 from .expressify_decorator import expressify
 
 
@@ -27,6 +28,7 @@ __all__ = (
     "is_express_app",
     "wrap_express_app",
     "ui",
+    "app_globals",
     "expressify",
 )
 

--- a/shiny/express/_app_globals.py
+++ b/shiny/express/_app_globals.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Generator
+
+from ..session import session_context
+
+__all__ = ("app_globals",)
+
+
+@contextmanager
+def app_globals() -> Generator[None, None, None]:
+    with session_context(None):
+        yield


### PR DESCRIPTION
This is a possible solution for #1079.

Usage:

```py
## app.py ##
from shiny.express import app_globals, render

with app_globals():
    from shared import x

@render.text
def txt():
    return f"The value of shared.x() is {x()}"


## shared.py ##
from shiny import reactive

@reactive.poll(check_fn, 1)
def x():
    ...

def check_fn():
    ...
```