### PR TITLE
Fix input_task_button for modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [UNRELEASED] - YYYY-MM-DD
+
+### Bug fixes
+
+* Fixed `input_task_button` not working in a Shiny module. (#1108)
+
+
 ## [0.7.1] - 2024-02-05
 
 ### Bug fixes

--- a/shiny/express/_run.py
+++ b/shiny/express/_run.py
@@ -55,6 +55,7 @@ def wrap_express_app(file: Path) -> App:
         except Exception:
             import traceback
 
+            # Starting in Python 3.10 this could be traceback.print_exception(e)
             traceback.print_exception(*sys.exc_info())
             raise
 

--- a/shiny/module.py
+++ b/shiny/module.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
-__all__ = ("current_namespace", "resolve_id", "ui", "server")
+__all__ = ("current_namespace", "resolve_id", "ui", "server", "ResolvedId")
 
 from typing import TYPE_CHECKING, Callable, TypeVar
 
 from ._docstring import no_example
-from ._namespaces import Id, current_namespace, namespace_context, resolve_id
+from ._namespaces import (
+    Id,
+    ResolvedId,
+    current_namespace,
+    namespace_context,
+    resolve_id,
+)
 from ._typing_extensions import Concatenate, ParamSpec
 
 if TYPE_CHECKING:

--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -11,6 +11,7 @@ import functools
 import json
 import os
 import re
+import sys
 import traceback
 import typing
 import urllib.parse
@@ -334,7 +335,7 @@ class Session(object, metaclass=SessionMeta):
                 ...
             except Exception as e:
                 try:
-                    traceback.print_exception(e)
+                    traceback.print_exception(*sys.exc_info())
                     self._send_error_response(str(e))
                 except Exception:
                     pass

--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -214,9 +214,9 @@ class Session(object, metaclass=SessionMeta):
 
         self._outbound_message_queues = OutBoundMessageQueues()
 
-        self._message_handlers: dict[
-            str, Callable[..., Awaitable[object]]
-        ] = self._create_message_handlers()
+        self._message_handlers: dict[str, Callable[..., Awaitable[object]]] = (
+            self._create_message_handlers()
+        )
         self._file_upload_manager: FileUploadManager = FileUploadManager()
         self._on_ended_callbacks = _utils.AsyncCallbacks()
         self._has_run_session_end_tasks: bool = False
@@ -335,6 +335,7 @@ class Session(object, metaclass=SessionMeta):
                 ...
             except Exception as e:
                 try:
+                    # Starting in Python 3.10 this could be traceback.print_exception(e)
                     traceback.print_exception(*sys.exc_info())
                     self._send_error_response(str(e))
                 except Exception:
@@ -607,26 +608,22 @@ class Session(object, metaclass=SessionMeta):
     @overload
     def _send_progress(
         self, type: Literal["binding"], message: BindingProgressMessage
-    ) -> None:
-        ...
+    ) -> None: ...
 
     @overload
     def _send_progress(
         self, type: Literal["open"], message: OpenProgressMessage
-    ) -> None:
-        ...
+    ) -> None: ...
 
     @overload
     def _send_progress(
         self, type: Literal["close"], message: CloseProgressMessage
-    ) -> None:
-        ...
+    ) -> None: ...
 
     @overload
     def _send_progress(
         self, type: Literal["update"], message: UpdateProgressMessage
-    ) -> None:
-        ...
+    ) -> None: ...
 
     def _send_progress(self, type: str, message: object) -> None:
         msg: dict[str, object] = {"progress": {"type": type, "message": message}}
@@ -1036,8 +1033,7 @@ class Outputs:
         self._suspend_when_hidden = suspend_when_hidden
 
     @overload
-    def __call__(self, renderer: RendererT) -> RendererT:
-        ...
+    def __call__(self, renderer: RendererT) -> RendererT: ...
 
     @overload
     def __call__(
@@ -1046,8 +1042,7 @@ class Outputs:
         id: Optional[str] = None,
         suspend_when_hidden: bool = True,
         priority: int = 0,
-    ) -> Callable[[RendererT], RendererT]:
-        ...
+    ) -> Callable[[RendererT], RendererT]: ...
 
     def __call__(
         self,

--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -334,6 +334,7 @@ class Session(object, metaclass=SessionMeta):
                 ...
             except Exception as e:
                 try:
+                    traceback.print_exception(e)
                     self._send_error_response(str(e))
                 except Exception:
                     pass
@@ -351,7 +352,9 @@ class Session(object, metaclass=SessionMeta):
                     + key
                 )
             if len(keys) == 2:
-                val = input_handlers._process_value(keys[1], val, keys[0], self)
+                val = input_handlers._process_value(
+                    keys[1], val, ResolvedId(keys[0]), self
+                )
 
             # The keys[0] value is already a fully namespaced id; make that explicit by
             # wrapping it in ResolvedId, otherwise self.input will throw an id

--- a/shiny/ui/_input_update.py
+++ b/shiny/ui/_input_update.py
@@ -158,7 +158,9 @@ manual_task_reset_buttons: set[ResolvedId] = set()
 
 
 @input_handlers.add("bslib.taskbutton")
-def _(value: dict[str, object], name: str, session: Session) -> ActionButtonValue:
+def _(
+    value: dict[str, object], name: ResolvedId, session: Session
+) -> ActionButtonValue:
     if value["autoReset"]:
 
         @session.on_flush
@@ -166,7 +168,7 @@ def _(value: dict[str, object], name: str, session: Session) -> ActionButtonValu
             # This is input_task_button's auto-reset feature: unless the button has
             # opted out using set_task_button_manual_reset(), we should reset after a
             # flush cycle where a bslib.taskbutton value is seen.
-            if ResolvedId(name) not in manual_task_reset_buttons:
+            if name not in manual_task_reset_buttons:
                 update_task_button(name, state="ready", session=session)
 
     return ActionButtonValue(cast(int, value["value"]))
@@ -1010,9 +1012,11 @@ def update_tooltip(
         drop_none(
             {
                 "method": "update",
-                "title": require_active_session(session)._process_ui(TagList(*args))
-                if len(args) > 0
-                else None,
+                "title": (
+                    require_active_session(session)._process_ui(TagList(*args))
+                    if len(args) > 0
+                    else None
+                ),
             }
         ),
     )
@@ -1069,9 +1073,9 @@ def update_popover(
             drop_none(
                 {
                     "method": "update",
-                    "content": session._process_ui(TagList(*args))
-                    if len(args) > 0
-                    else None,
+                    "content": (
+                        session._process_ui(TagList(*args)) if len(args) > 0 else None
+                    ),
                     "header": session._process_ui(title) if title is not None else None,
                 },
             ),
@@ -1088,13 +1092,11 @@ def update_popover(
 
 
 @overload
-def _normalize_show_value(show: None) -> Literal["toggle"]:
-    ...
+def _normalize_show_value(show: None) -> Literal["toggle"]: ...
 
 
 @overload
-def _normalize_show_value(show: bool) -> Literal["show", "hide"]:
-    ...
+def _normalize_show_value(show: bool) -> Literal["show", "hide"]: ...
 
 
 def _normalize_show_value(show: bool | None) -> Literal["toggle", "show", "hide"]:

--- a/shiny/ui/_input_update.py
+++ b/shiny/ui/_input_update.py
@@ -1092,11 +1092,13 @@ def update_popover(
 
 
 @overload
-def _normalize_show_value(show: None) -> Literal["toggle"]: ...
+def _normalize_show_value(show: None) -> Literal["toggle"]:
+    ...
 
 
 @overload
-def _normalize_show_value(show: bool) -> Literal["show", "hide"]: ...
+def _normalize_show_value(show: bool) -> Literal["show", "hide"]:
+    ...
 
 
 def _normalize_show_value(show: bool | None) -> Literal["toggle", "show", "hide"]:

--- a/tests/playwright/shiny/inputs/input_task_button2/app.py
+++ b/tests/playwright/shiny/inputs/input_task_button2/app.py
@@ -1,0 +1,36 @@
+import time
+
+from shiny import App, Inputs, Outputs, Session, module, reactive, render, ui
+
+
+@module.ui
+def button_ui():
+    return ui.TagList(
+        ui.input_task_button("btn", label="Go"),
+        ui.output_text("text_counter"),
+    )
+
+
+@module.server
+def button_server(input: Inputs, output: Outputs, session: Session):
+    counter = reactive.Value(0)
+
+    @render.text
+    def text_counter():
+        return f"Button clicked {counter()} times"
+
+    @reactive.effect
+    @reactive.event(input.btn)
+    def increment_counter():
+        time.sleep(0.5)
+        counter.set(counter() + 1)
+
+
+app_ui = ui.page_fluid(button_ui("mod1"))
+
+
+def server(input: Inputs, output: Outputs, session: Session):
+    button_server("mod1")
+
+
+app = App(app_ui, server)

--- a/tests/playwright/shiny/inputs/input_task_button2/test_input_task_button2.py
+++ b/tests/playwright/shiny/inputs/input_task_button2/test_input_task_button2.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from conftest import ShinyAppProc
+from controls import InputTaskButton, OutputText
+from playwright.sync_api import Page
+
+
+def click_extended_task_button(
+    button: InputTaskButton,
+) -> None:
+    button.expect_state("ready")
+    button.click(timeout=0)
+    button.expect_state("busy", timeout=0)
+    button.expect_state("ready", timeout=0)
+
+
+def test_input_action_task_button(page: Page, local_app: ShinyAppProc) -> None:
+    page.goto(local_app.url)
+
+    OutputText(page, "mod1-text_counter").expect_value("Button clicked 0 times")
+
+    # Extended task
+    button_task = InputTaskButton(page, "mod1-btn")
+    button_task.expect_label_ready("Go")
+    button_task.expect_auto_reset(True)
+    click_extended_task_button(button_task)
+
+    OutputText(page, "mod1-text_counter").expect_value("Button clicked 1 times")


### PR DESCRIPTION
Fixes #1107

The task button installs an input handler, which it uses to implement its auto-reset feature. One of the arguments to the input handler is the name/id of the input, a string. When a task button is in a module, that id string contains the module/namespace name as well.

Module-aware code in Shiny assumes regular strings are un-namespaced id's (akin to a relative path), and `ResolvedId` objects as namespaced id's (akin to an absolute path). In this case, we had a string that contained a namespaced id. That's then passed to `update_task_button`, which complains that it contains characters that shouldn't be part of an id.

This PR fixes the problem by changing the `input_handler` invoking code, changing the string id to a ResolvedId as early as possible.