### PR TITLE
bug(module): Do not use the module prefix in the `Renderer.output_id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Fixed `input_task_button` not working in a Shiny module. (#1108)
 * Fixed several issues with `page_navbar()` styling. (#1124)
+* Fixed `Renderer.output_id` to not contain the module namespace prefix, only the output id. (#1130)
 
 ## [0.7.1] - 2024-02-05
 

--- a/shiny/render/_render.py
+++ b/shiny/render/_render.py
@@ -281,6 +281,8 @@ class plot(Renderer[object]):
         is_userfn_async = self.fn.is_async()
         name = self.output_id
         session = require_active_session(None)
+        # Module support
+        name = session.ns(name)
         width = self.width
         height = self.height
         alt = self.alt

--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -1071,7 +1071,7 @@ class Outputs:
             output_name = self._ns(output_id)
 
             # renderer is a Renderer object. Give it a bit of metadata.
-            renderer._set_output_metadata(output_id=output_name)
+            renderer._set_output_metadata(output_id=output_id)
 
             renderer._on_register()
 


### PR DESCRIPTION
🤦 
cc @gshotwell 