### PR TITLE
Replace `sys.stderr.write()` with `print(file=sys.stderr)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed `input_task_button` not working in a Shiny module. (#1108)
 * Fixed several issues with `page_navbar()` styling. (#1124)
 
+### Other changes
+
+* Replaced use of `sys.stderr.write()` with `print(file=sys.stderr)`, because on some platforms `sys.stderr` can be `None`. (#1131)
+
+
 ## [0.7.1] - 2024-02-05
 
 ### Bug fixes

--- a/shiny/_main.py
+++ b/shiny/_main.py
@@ -314,8 +314,9 @@ def run_app(
             autoreload_port = _utils.random_port(host=host)
 
         if autoreload_port == port:
-            sys.stderr.write(
-                "Autoreload port is already being used by the app; disabling autoreload\n"
+            print(
+                "Autoreload port is already being used by the app; disabling autoreload\n",
+                file=sys.stderr,
             )
             reload = False
         else:
@@ -426,10 +427,10 @@ def resolve_app(app: str, app_dir: str | None) -> tuple[str, str | None]:
         #       unfriendly. We should probably throw a custom error that the shiny run
         #       entrypoint knows not to print the stack trace for.
         if not os.path.exists(module_path):
-            sys.stderr.write(f"Error: {module_path} not found\n")
+            print(f"Error: {module_path} not found\n", file=sys.stderr)
             sys.exit(1)
         if not os.path.isfile(module_path):
-            sys.stderr.write(f"Error: {module_path} is not a file\n")
+            print(f"Error: {module_path} is not a file\n", file=sys.stderr)
             sys.exit(1)
         dirname, filename = os.path.split(module_path)
         module = filename[:-3] if filename.endswith(".py") else filename

--- a/tests/pytest/asyncio_prevent.py
+++ b/tests/pytest/asyncio_prevent.py
@@ -33,7 +33,8 @@ if __name__ == "__main__":
 
     # Doing this instead of "import shiny" so no linter is tempted to remove it
     importlib.import_module("shiny")
-    sys.stderr.write(
+    print(
         "Success; shiny module loading did not attempt to access an asyncio event "
-        "loop\n"
+        "loop\n",
+        file=sys.stderr,
     )


### PR DESCRIPTION
This addresses #1054. 

In some cases, `sys.stdout` and `sys.stderr` can be `None`, which would cause `sys.stderr.write()` to throw an error. This changes it to use `print(file=sys.stderr)`, which will not throw an error when `sys.stderr` is `None`.

From https://docs.python.org/3/library/sys.html#sys.__stderr__:

> Under some conditions stdin, stdout and stderr as well as the original values `__stdin__`, `__stdout__` and `__stderr__` can be `None`. It is usually the case for Windows GUI apps that aren’t connected to a console and Python apps started with **pythonw**.