### PR TITLE
chore: Remove deprecated datetime method calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other changes
 
 * Replaced use of `sys.stderr.write()` with `print(file=sys.stderr)`, because on some platforms `sys.stderr` can be `None`. (#1131)
+* Replaced deprecated `datetime` method calls with `datetime.fromtimestamp(tz=timezone.utc)` and `datetime.now(timezone.utc)`. (#1142)
 
 
 ## [0.7.1] - 2024-02-05

--- a/shiny/input_handler.py
+++ b/shiny/input_handler.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 __all__ = ("input_handlers",)
 
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from typing import TYPE_CHECKING, Any, Callable, Dict
 
 if TYPE_CHECKING:
@@ -113,10 +113,10 @@ def _(
     value: int | float | list[int] | list[float], name: ResolvedId, session: Session
 ) -> datetime | tuple[datetime, datetime]:
     if isinstance(value, (int, float)):
-        return datetime.utcfromtimestamp(value)
+        return datetime.fromtimestamp(value, timezone.utc)
     return (
-        datetime.utcfromtimestamp(value[0]),
-        datetime.utcfromtimestamp(value[1]),
+        datetime.fromtimestamp(value[0], timezone.utc),
+        datetime.fromtimestamp(value[1], timezone.utc),
     )
 
 

--- a/shiny/plotutils.py
+++ b/shiny/plotutils.py
@@ -312,7 +312,7 @@ def near_points(
     if all_rows:
         # Add selected_ column if needed
         new_df["selected_"] = False
-        new_df.iloc[
+        new_df.iloc[  # pyright: ignore[reportArgumentType]
             keep_idx,
             new_df.columns.get_loc(  # pyright: ignore[reportUnknownMemberType]
                 "selected_"

--- a/tests/playwright/shiny/inputs/input_task_button/app.py
+++ b/tests/playwright/shiny/inputs/input_task_button/app.py
@@ -1,5 +1,5 @@
 import asyncio
-from datetime import datetime
+from datetime import datetime, timezone
 
 from shiny import reactive, render
 from shiny.express import input, ui
@@ -10,7 +10,7 @@ ui.h5("Current time")
 @render.text()
 def current_time() -> str:
     reactive.invalidate_later(0.1)
-    return str(datetime.now().utcnow())
+    return str(datetime.now(timezone.utc).isoformat())
 
 
 with ui.p():


### PR DESCRIPTION
> The method "utcfromtimestamp" in class "datetime" is deprecated
>    Use timezone-aware objects to represent datetimes in UTC; e.g. by calling .fromtimestamp(datetime.UTC) (reportDeprecated)