### PR TITLE
bug: Remove timezone info from `shiny.datetime` input handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other changes
 
 * Replaced use of `sys.stderr.write()` with `print(file=sys.stderr)`, because on some platforms `sys.stderr` can be `None`. (#1131)
-* Replaced deprecated `datetime` method calls with `datetime.fromtimestamp(tz=timezone.utc)` and `datetime.now(timezone.utc)`. (#1142)
+* Replaced soon-to-be deprecated `datetime` method calls when handling `shiny.datetime` inputs. (#1146)
 
 
 ## [0.7.1] - 2024-02-05

--- a/shiny/input_handler.py
+++ b/shiny/input_handler.py
@@ -110,14 +110,20 @@ def _(
 
 @input_handlers.add("shiny.datetime")
 def _(
-    value: int | float | list[int] | list[float], name: ResolvedId, session: Session
+    value: int | float | list[int] | list[float],
+    name: ResolvedId,
+    session: Session,
 ) -> datetime | tuple[datetime, datetime]:
+    def as_utc_date(x: int | float) -> datetime:
+        dt = datetime.fromtimestamp(x, timezone.utc)
+        # Remove hour offset from print method by removing the timezone
+        # Ex: 2021-08-01T00:00:00+00:00 -> 2021-08-01T00:00:00
+        # This is done as all dates are in UTC
+        return dt.replace(tzinfo=None)
+
     if isinstance(value, (int, float)):
-        return datetime.fromtimestamp(value, timezone.utc)
-    return (
-        datetime.fromtimestamp(value[0], timezone.utc),
-        datetime.fromtimestamp(value[1], timezone.utc),
-    )
+        return as_utc_date(value)
+    return (as_utc_date(value[0]), as_utc_date(value[1]))
 
 
 @input_handlers.add("shiny.action")

--- a/tests/playwright/shiny/bugs/0648-update-slider-datetime-value/test_update_slider_datetime_value.py
+++ b/tests/playwright/shiny/bugs/0648-update-slider-datetime-value/test_update_slider_datetime_value.py
@@ -37,8 +37,8 @@ def test_slider_app(page: Page, local_app: ShinyAppProc) -> None:
 
     page.goto(local_app.url)
 
-    start_time = "2023-07-01 00:00:00+00:00"
-    end_time = "2023-07-01 01:00:00+00:00"
+    start_time = "2023-07-01 00:00:00"
+    end_time = "2023-07-01 01:00:00"
 
     check_case("one", value=(start_time, end_time))
     check_case(


### PR DESCRIPTION
Followup to #1142 and #1143 
Fixes #1144 

```python
>>> datetime.fromtimestamp(1, tz = timezone.utc)
datetime.datetime(1970, 1, 1, 0, 0, 1, tzinfo=datetime.timezone.utc)
>>> str(datetime.fromtimestamp(1, tz = timezone.utc))
'1970-01-01 00:00:01+00:00'

>>> pr = datetime.fromtimestamp(1, tz = timezone.utc).replace(tzinfo=None)
>>> pr
datetime.datetime(1970, 1, 1, 0, 0, 1)
>>> before = datetime.utcfromtimestamp(1)
datetime.datetime(1970, 1, 1, 0, 0, 1)

>>> str(pr)
'1970-01-01 00:00:01'
>>> before = datetime.utcfromtimestamp(1)
>>> str(before)
'1970-01-01 00:00:01'
```