### PR TITLE
docs(input_task_button): Add to reference index, also update methods for action button/link

### DIFF
--- a/docs/_quartodoc-core.yml
+++ b/docs/_quartodoc-core.yml
@@ -56,6 +56,7 @@ quartodoc:
         - ui.input_password
         - ui.input_action_button
         - ui.input_action_link
+        - ui.input_task_button
     - title: Value boxes
       desc: Prominently display a value and label in a box that can be expanded to show more information.
       contents:
@@ -140,6 +141,9 @@ quartodoc:
           dynamic: "shiny.ui.update_text"
         - name: ui.update_navs
           dynamic: true
+        - ui.update_action_button
+        - ui.update_action_link
+        - ui.update_task_button
     - title: Update UI Layouts
       desc: ""
       contents:

--- a/docs/_quartodoc-express.yml
+++ b/docs/_quartodoc-express.yml
@@ -28,6 +28,7 @@ quartodoc:
         - express.ui.input_password
         - express.ui.input_action_button
         - express.ui.input_action_link
+        - express.ui.input_task_button
     - title: Output components
       desc: Reactively render output.
       contents:
@@ -121,6 +122,9 @@ quartodoc:
           dynamic: "shiny.ui.update_text"
         - name: express.ui.update_navs
           dynamic: true
+        - express.ui.update_action_button
+        - express.ui.update_action_link
+        - express.ui.update_task_button
     - title: Update UI Layouts
       desc: ""
       contents:


### PR DESCRIPTION
Adds `ui.input_task_button()` and `ui.update_task_button()` to the reference index for Core and Express.

Also adds `update_action_button()` and `update_action_link()` to both indices.