### PR TITLE
Consolidate component dependency assets into a single dependency that gets included more generally

### DIFF
--- a/shiny/ui/_accordion.py
+++ b/shiny/ui/_accordion.py
@@ -9,7 +9,7 @@ from .._namespaces import resolve_id_or_none
 from .._utils import drop_none, private_random_id
 from ..session import require_active_session
 from ..types import MISSING, MISSING_TYPE
-from ._html_deps_shinyverse import components_dependency
+from ._html_deps_shinyverse import components_dependencies
 from ._tag import consolidate_attrs
 from .css._css_unit import CssUnit, as_css_unit
 
@@ -287,7 +287,7 @@ def accordion(
         # just for ease of identifying autoclosing client-side
         {"class": "autoclose"} if not multiple else None,
         binding_class_value,
-        components_dependency(),
+        components_dependencies(),
         attrs,
         *panel_tags,
     )

--- a/shiny/ui/_card.py
+++ b/shiny/ui/_card.py
@@ -18,7 +18,7 @@ from htmltools import (
 from .._docstring import add_example
 from .._utils import private_random_id
 from ..types import MISSING, MISSING_TYPE
-from ._html_deps_shinyverse import components_dependency
+from ._html_deps_shinyverse import components_dependencies
 from ._tag import consolidate_attrs
 from ._tooltip import tooltip
 from .css._css_unit import CssUnit, as_css_padding, as_css_unit
@@ -148,7 +148,7 @@ def _card_impl(
         *children,
         attrs,
         _full_screen_toggle(attrs["id"]) if full_screen else None,
-        components_dependency(),
+        components_dependencies(),
         _card_js_init(),
     )
     if fill:

--- a/shiny/ui/_html_deps_shinyverse.py
+++ b/shiny/ui/_html_deps_shinyverse.py
@@ -38,7 +38,7 @@ def fill_dependency() -> HTMLDependency:
 # -- bslib -------------------------
 
 
-def components_dependency() -> HTMLDependency:
+def components_dependencies() -> HTMLDependency:
     return HTMLDependency(
         name="bslib-components",
         version=bslib_version,
@@ -46,18 +46,9 @@ def components_dependency() -> HTMLDependency:
             "package": "shiny",
             "subdir": f"{_components_path}",
         },
-        script={"src": "components.min.js"},
+        script=[
+            {"src": "components.min.js"},
+            {"src": "web-components.min.js", "type": "module"},
+        ],
         stylesheet={"href": "components.css"},
-    )
-
-
-def web_component_dependency() -> HTMLDependency:
-    return HTMLDependency(
-        name="bslib-web-components",
-        version=bslib_version,
-        source={
-            "package": "shiny",
-            "subdir": f"{_components_path}",
-        },
-        script={"src": "web-components.min.js", "type": "module"},
     )

--- a/shiny/ui/_input_check_radio.py
+++ b/shiny/ui/_input_check_radio.py
@@ -12,7 +12,7 @@ from htmltools import Tag, TagChild, css, div, span, tags
 
 from .._docstring import add_example
 from .._namespaces import resolve_id
-from ._html_deps_shinyverse import components_dependency
+from ._html_deps_shinyverse import components_dependencies
 from ._utils import shiny_input_label
 
 # Canonical format for representing select options.
@@ -160,7 +160,7 @@ def _bslib_input_checkbox(
             ),
             class_=class_,
         ),
-        components_dependency(),
+        components_dependencies(),
         class_="form-group shiny-input-container",
         style=css(width=width),
     )

--- a/shiny/ui/_input_task_button.py
+++ b/shiny/ui/_input_task_button.py
@@ -15,7 +15,7 @@ from .._typing_extensions import ParamSpec
 from ..reactive._extended_task import ExtendedTask
 from ..reactive._reactives import effect
 from ._html_deps_py_shiny import spin_dependency
-from ._html_deps_shinyverse import components_dependency, web_component_dependency
+from ._html_deps_shinyverse import components_dependencies
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -146,8 +146,7 @@ def input_task_button(
             *args,
             case="ready",
         ),
-        components_dependency(),
-        web_component_dependency(),
+        components_dependencies(),
         spin_dependency(),
         id=resolve_id(id),
         type="button",

--- a/shiny/ui/_layout.py
+++ b/shiny/ui/_layout.py
@@ -7,7 +7,7 @@ from htmltools import Tag, TagAttrs, TagAttrValue, TagChild, css, div
 from .._deprecated import warn_deprecated
 from .._docstring import add_example
 from ..types import MISSING, MISSING_TYPE
-from ._html_deps_shinyverse import components_dependency
+from ._html_deps_shinyverse import components_dependencies
 from ._tag import consolidate_attrs
 from ._utils import is_01_scalar
 from .css import CssUnit, as_css_unit
@@ -155,7 +155,7 @@ def layout_column_wrap(
         },
         attrs,
         *wrap_all_in_gap_spaced_container(children, fillable),
-        components_dependency(),
+        components_dependencies(),
     )
     if fill:
         tag = as_fill_item(tag)

--- a/shiny/ui/_layout_columns.py
+++ b/shiny/ui/_layout_columns.py
@@ -7,7 +7,7 @@ from warnings import warn
 from htmltools import Tag, TagAttrs, TagAttrValue, TagChild, css
 
 from .._docstring import add_example
-from ._html_deps_shinyverse import web_component_dependency
+from ._html_deps_shinyverse import components_dependencies
 from ._layout import wrap_all_in_gap_spaced_container
 from ._tag import consolidate_attrs
 from .css import CssUnit, as_css_unit
@@ -135,7 +135,7 @@ def layout_columns(
         attrs,
         row_heights_attrs(row_heights),
         *wrap_all_in_gap_spaced_container(children, fillable, "bslib-grid-item"),
-        web_component_dependency(),
+        components_dependencies(),
     )
 
     # Apply fill to the outer layout (fillable is applied to the children)

--- a/shiny/ui/_navs.py
+++ b/shiny/ui/_navs.py
@@ -34,7 +34,7 @@ from .._utils import private_random_int
 from ..types import NavSetArg
 from ._bootstrap import column, row
 from ._card import CardItem, WrapperCallable, card, card_body, card_footer, card_header
-from ._html_deps_shinyverse import components_dependency
+from ._html_deps_shinyverse import components_dependencies
 from ._sidebar import Sidebar, layout_sidebar
 from .css import CssUnit, as_css_padding, as_css_unit
 from .fill import as_fill_item, as_fillable_container
@@ -215,7 +215,7 @@ def nav_spacer() -> NavPanel:
     See :func:`~shiny.ui.nav_panel`
     """
 
-    return NavPanel(tags.li(components_dependency(), class_="bslib-nav-spacer"))
+    return NavPanel(tags.li(components_dependencies(), class_="bslib-nav-spacer"))
 
 
 class NavMenu:

--- a/shiny/ui/_page.py
+++ b/shiny/ui/_page.py
@@ -33,7 +33,7 @@ from ..types import MISSING, MISSING_TYPE, NavSetArg
 from ._bootstrap import panel_title
 from ._html_deps_external import bootstrap_deps
 from ._html_deps_py_shiny import page_output_dependency
-from ._html_deps_shinyverse import components_dependency
+from ._html_deps_shinyverse import components_dependencies
 from ._navs import NavMenu, NavPanel, navset_bar
 from ._sidebar import Sidebar, SidebarOpen, layout_sidebar
 from ._tag import consolidate_attrs
@@ -325,7 +325,7 @@ def page_fillable(
         {"class": "bslib-flow-mobile"} if not fillable_mobile else None,
         attrs,
         *children,
-        components_dependency(),
+        components_dependencies(),
         title=title,
         lang=lang,
     )

--- a/shiny/ui/_sidebar.py
+++ b/shiny/ui/_sidebar.py
@@ -23,7 +23,7 @@ from .._utils import private_random_id
 from ..session import require_active_session
 from ..types import MISSING, MISSING_TYPE
 from ._card import CardItem
-from ._html_deps_shinyverse import components_dependency
+from ._html_deps_shinyverse import components_dependencies
 from ._tag import consolidate_attrs, trinary
 from ._utils import css_no_sub
 from .css import CssUnit, as_css_padding, as_css_unit
@@ -652,7 +652,7 @@ def layout_sidebar(
         {"class": "sidebar-collapsed"} if sidebar.open().desktop == "closed" else None,
         main,
         sidebar,
-        components_dependency(),
+        components_dependencies(),
         _sidebar_init_js(),
         data_bslib_sidebar_init="true",
         data_open_desktop=sidebar.open().desktop,

--- a/shiny/ui/_web_component.py
+++ b/shiny/ui/_web_component.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from htmltools import Tag, TagAttrs, TagAttrValue, TagChild
 
-from ._html_deps_shinyverse import web_component_dependency
+from ._html_deps_shinyverse import components_dependencies
 
 
 def web_component(
@@ -12,7 +12,7 @@ def web_component(
 ) -> Tag:
     return Tag(
         tag_name,
-        web_component_dependency(),
+        components_dependencies(),
         *args,
         _add_ws=False,
         **kwargs,


### PR DESCRIPTION
Closes #1159

This PR also brings the dependency handling closer to how we handle it in bslib (i.e., we have just one `components_dependencies()` that gets included whenever we need additional, component-specific, JS/CSS)