### PR TITLE
Update examples with lower-case `calc`, `effect`, and `value`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * The sidebar's collapse toggle now has a high `z-index` value to ensure it always appears above elements in the main content area of `ui.layout_sidebar()`. The sidebar overlay also now receives the same high `z-index` on mobile layouts. (#1129)
 
+* Updated example apps to use lower-case versions of `reactive.Calc`->`reactive.calc`, `reactive.Effect`->`reactive.effect`, and `reactive.Value`->`reactive.value`. (#1164)
+
 ### Bug fixes
 
 * Fixed `input_task_button` not working in a Shiny module. (#1108)

--- a/examples/airmass/app.py
+++ b/examples/airmass/app.py
@@ -61,17 +61,17 @@ def server(input: Inputs, output: Outputs, session: Session):
     loc = location_server("location")
     time_padding = datetime.timedelta(hours=1.5)
 
-    @reactive.Calc
+    @reactive.calc
     def obj_names() -> List[str]:
         """Returns a split and *slightly* cleaned-up list of object names"""
         req(input.objects())
         return [x.strip() for x in input.objects().split(",") if x.strip() != ""]
 
-    @reactive.Calc
+    @reactive.calc
     def obj_coords() -> List[SkyCoord]:
         return [SkyCoord.from_name(name) for name in obj_names()]
 
-    @reactive.Calc
+    @reactive.calc
     def times_utc() -> Tuple[datetime.datetime, datetime.datetime]:
         req(input.date())
         lat, long = loc()
@@ -81,18 +81,18 @@ def server(input: Inputs, output: Outputs, session: Session):
             sun.get_sunrise_time(input.date() + datetime.timedelta(days=1)),
         )
 
-    @reactive.Calc
+    @reactive.calc
     def timezone() -> Optional[str]:
         lat, long = loc()
         return timezonefinder.TimezoneFinder().timezone_at(lat=lat, lng=long)
 
-    @reactive.Calc
+    @reactive.calc
     def times_at_loc():
         start, end = times_utc()
         tz = pytz.timezone(timezone())
         return (start.astimezone(tz), end.astimezone(tz))
 
-    @reactive.Calc
+    @reactive.calc
     def df() -> Dict[str, pd.DataFrame]:
         start, end = times_at_loc()
         times = pd.date_range(

--- a/examples/airmass/location.py
+++ b/examples/airmass/location.py
@@ -100,24 +100,24 @@ def location_server(
 
     register_widget("map", map)
 
-    @reactive.Effect
+    @reactive.effect
     def _():
         coords = reactive_read(marker, "location")
         if coords:
             update_text_inputs(coords[0], coords[1])
 
-    @reactive.Effect
+    @reactive.effect
     def sync_autolocate():
         coords = input.here()
         ui.notification_remove("searching")
         if coords and not input.lat() and not input.long():
             update_text_inputs(coords["latitude"], coords["longitude"])
 
-    @reactive.Effect
+    @reactive.effect
     def sync_inputs_to_marker():
         update_marker(input.lat(), input.long())
 
-    @reactive.Calc
+    @reactive.calc
     def location():
         """Returns tuple of (lat,long) floats--or throws silent error if no lat/long is
         selected"""

--- a/examples/annotation-export/app.py
+++ b/examples/annotation-export/app.py
@@ -39,7 +39,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    annotated_data = reactive.Value(weather_df)
+    annotated_data = reactive.value(weather_df)
 
     @reactive.calc
     def selected_data():

--- a/examples/annotation-export/app.py
+++ b/examples/annotation-export/app.py
@@ -41,12 +41,12 @@ app_ui = ui.page_fluid(
 def server(input: Inputs, output: Outputs, session: Session):
     annotated_data = reactive.Value(weather_df)
 
-    @reactive.Calc
+    @reactive.calc
     def selected_data():
         out = brushed_points(annotated_data(), input.time_series_brush(), xvar="date")
         return out
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.annotate_button)
     def _():
         selected = selected_data()

--- a/examples/brownian/app.py
+++ b/examples/brownian/app.py
@@ -44,7 +44,7 @@ app_ui = ui.page_fluid(
 def server(input, output, session):
     # BROWNIAN MOTION ====
 
-    @reactive.Calc
+    @reactive.calc
     def random_walk():
         """Generates brownian data whenever 'New Data' is clicked"""
         input.data_btn()
@@ -54,7 +54,7 @@ def server(input, output, session):
     widget = brownian_widget(600, 600)
     register_widget("plot", widget)
 
-    @reactive.Effect
+    @reactive.effect
     def update_plotly_data():
         walk = random_walk()
         layer = widget.data[0]
@@ -65,7 +65,7 @@ def server(input, output, session):
 
     # HAND TRACKING ====
 
-    @reactive.Calc
+    @reactive.calc
     def camera_eye():
         """The eye position, as reflected by the hand input"""
         hand_val = input.hand()
@@ -78,7 +78,7 @@ def server(input, output, session):
     # The raw data is a little jittery. Smooth it out by averaging a few samples
     smooth_camera_eye = reactive_smooth(n_samples=5, smoother=xyz_mean)(camera_eye)
 
-    @reactive.Effect
+    @reactive.effect
     def update_plotly_camera():
         """Update Plotly camera using the hand tracking"""
         widget.layout.scene.camera.eye = smooth_camera_eye()
@@ -114,7 +114,7 @@ def reactive_smooth(n_samples, smoother, *, filter_none=True):
         buffer = []  # Ring buffer of capacity `n_samples`
         result = reactive.Value(None)  # Holds the most recent smoothed result
 
-        @reactive.Effect
+        @reactive.effect
         def _():
             # Get latest value. Because this is happening in a reactive Effect, we'll
             # automatically take a reactive dependency on whatever is happening in the

--- a/examples/brownian/app.py
+++ b/examples/brownian/app.py
@@ -112,7 +112,7 @@ def reactive_smooth(n_samples, smoother, *, filter_none=True):
 
     def wrapper(calc):
         buffer = []  # Ring buffer of capacity `n_samples`
-        result = reactive.Value(None)  # Holds the most recent smoothed result
+        result = reactive.value(None)  # Holds the most recent smoothed result
 
         @reactive.effect
         def _():

--- a/examples/cpuinfo/app.py
+++ b/examples/cpuinfo/app.py
@@ -102,7 +102,7 @@ app_ui = ui.page_fluid(
 )
 
 
-@reactive.Calc
+@reactive.calc
 def cpu_current():
     reactive.invalidate_later(SAMPLE_PERIOD)
     return cpu_percent(percpu=True)
@@ -111,7 +111,7 @@ def cpu_current():
 def server(input: Inputs, output: Outputs, session: Session):
     cpu_history = reactive.Value(None)
 
-    @reactive.Calc
+    @reactive.calc
     def cpu_history_with_hold():
         # If "hold" is on, grab an isolated snapshot of cpu_history; if not, then do a
         # regular read
@@ -123,7 +123,7 @@ def server(input: Inputs, output: Outputs, session: Session):
             with reactive.isolate():
                 return cpu_history()
 
-    @reactive.Effect
+    @reactive.effect
     def collect_cpu_samples():
         """cpu_percent() reports just the current CPU usage sample; this Effect gathers
         them up and stores them in the cpu_history reactive value, in a numpy 2D array

--- a/examples/cpuinfo/app.py
+++ b/examples/cpuinfo/app.py
@@ -109,7 +109,7 @@ def cpu_current():
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    cpu_history = reactive.Value(None)
+    cpu_history = reactive.value(None)
 
     @reactive.calc
     def cpu_history_with_hold():

--- a/examples/dataframe/app.py
+++ b/examples/dataframe/app.py
@@ -55,7 +55,7 @@ def light_dark_switcher(dark):
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    df: reactive.Value[pd.DataFrame] = reactive.Value()
+    df: reactive.value[pd.DataFrame] = reactive.value()
 
     @reactive.effect
     def update_df():

--- a/examples/dataframe/app.py
+++ b/examples/dataframe/app.py
@@ -57,7 +57,7 @@ def light_dark_switcher(dark):
 def server(input: Inputs, output: Outputs, session: Session):
     df: reactive.Value[pd.DataFrame] = reactive.Value()
 
-    @reactive.Effect
+    @reactive.effect
     def update_df():
         return df.set(sns.load_dataset(req(input.dataset())))
 
@@ -82,7 +82,7 @@ def server(input: Inputs, output: Outputs, session: Session):
                 row_selection_mode=input.selection_mode(),
             )
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.grid_cell_edit)
     def handle_edit():
         edit = input.grid_cell_edit()

--- a/examples/duckdb/app.py
+++ b/examples/duckdb/app.py
@@ -67,7 +67,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input, output, session):
-    mod_counter = reactive.Value(0)
+    mod_counter = reactive.value(0)
 
     query_output_server("initial_query", con=con, remove_id="initial_query")
 

--- a/examples/duckdb/app.py
+++ b/examples/duckdb/app.py
@@ -71,7 +71,7 @@ def server(input, output, session):
 
     query_output_server("initial_query", con=con, remove_id="initial_query")
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.add_query)
     def _():
         counter = mod_counter.get() + 1
@@ -84,7 +84,7 @@ def server(input, output, session):
         )
         query_output_server(id, con=con, remove_id=id)
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.show_meta)
     def _():
         counter = mod_counter.get() + 1
@@ -99,7 +99,7 @@ def server(input, output, session):
         )
         query_output_server(id, con=con, remove_id=id)
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.rmv)
     def _():
         ui.remove_ui(selector="div:has(> #txt)")

--- a/examples/duckdb/query.py
+++ b/examples/duckdb/query.py
@@ -57,7 +57,7 @@ def query_output_server(
 
         return result
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.rmv)
     def _():
         ui.remove_ui(selector=f"div#{remove_id}")

--- a/examples/event/app.py
+++ b/examples/event/app.py
@@ -27,17 +27,17 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.btn)
     def _():
         print("@effect() event: ", str(input.btn()))
 
-    @reactive.Calc
+    @reactive.calc
     @reactive.event(input.btn)
     def btn() -> int:
         return input.btn()
 
-    @reactive.Effect
+    @reactive.effect
     def _():
         print("@calc() event:   ", str(btn()))
 
@@ -49,19 +49,19 @@ def server(input: Inputs, output: Outputs, session: Session):
     # -----------------------------------------------------------------------------
     # Async
     # -----------------------------------------------------------------------------
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.btn_async)
     async def _():
         await asyncio.sleep(0)
         print("async @effect() event: ", str(input.btn_async()))
 
-    @reactive.Calc
+    @reactive.calc
     @reactive.event(input.btn_async)
     async def btn_async_r() -> int:
         await asyncio.sleep(0)
         return input.btn_async()
 
-    @reactive.Effect
+    @reactive.effect
     async def _():
         val = await btn_async_r()
         print("async @calc() event:   ", str(val))

--- a/examples/express/shared.py
+++ b/examples/express/shared.py
@@ -16,4 +16,4 @@ with session.session_context(None):
     # This reactive value can be used by multiple sessions; if it is invalidated (in
     # other words, if the value is changed), it will trigger invalidations in all of
     # those sessions.
-    rv = reactive.Value(50)
+    rv = reactive.value(50)

--- a/examples/express/shared_app.py
+++ b/examples/express/shared_app.py
@@ -20,7 +20,7 @@ def histogram():
 ui.input_slider("n", "N", 1, 100, 50)
 
 
-@reactive.Effect
+@reactive.effect
 def _():
     shared.rv.set(input.n())
 

--- a/examples/inputs-update/app.py
+++ b/examples/inputs-update/app.py
@@ -88,7 +88,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Effect
+    @reactive.effect
     def _():
         # We'll use these multiple times, so use short var names for
         # convenience.

--- a/examples/model-score/app.py
+++ b/examples/model-score/app.py
@@ -134,7 +134,7 @@ def app_ui(req):
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Calc
+    @reactive.calc
     def recent_df():
         """
         Returns the most recent rows from the database, at the refresh interval
@@ -152,7 +152,7 @@ def server(input: Inputs, output: Outputs, session: Session):
             with reactive.isolate():
                 return df()
 
-    @reactive.Calc
+    @reactive.calc
     def timeframe_df():
         """
         Returns rows from the database within the specified time range. Notice that we
@@ -162,7 +162,7 @@ def server(input: Inputs, output: Outputs, session: Session):
         start, end = input.timerange()
         return read_time_period(start, end)
 
-    @reactive.Calc
+    @reactive.calc
     def filtered_df():
         """
         Return the data frame that should be displayed in the app, based on the user's
@@ -174,7 +174,7 @@ def server(input: Inputs, output: Outputs, session: Session):
         # Filter the rows so we only include the desired models
         return data[data["model"].isin(input.models())]
 
-    @reactive.Calc
+    @reactive.calc
     def filtered_model_names():
         return filtered_df()["model"].unique()
 
@@ -282,7 +282,7 @@ def server(input: Inputs, output: Outputs, session: Session):
 
         return fig
 
-    @reactive.Effect
+    @reactive.effect
     def update_time_range():
         """
         Every 5 seconds, update the custom time range slider's min and max values to

--- a/examples/model-score/plotly_streaming.py
+++ b/examples/model-score/plotly_streaming.py
@@ -62,7 +62,7 @@ def render_plotly_streaming(
                 fig = func()
                 widget = go.FigureWidget(fig)
 
-            @reactive.Effect
+            @reactive.effect
             def update_plotly_data():
                 f_new = func()
                 with widget.batch_update():
@@ -85,14 +85,14 @@ def deduplicate(func):
     with reactive.isolate():
         rv = reactive.Value(func())
 
-    @reactive.Effect
+    @reactive.effect
     def update():
         x = func()
         with reactive.isolate():
             if x != rv():
                 rv.set(x)
 
-    @reactive.Calc
+    @reactive.calc
     @functools.wraps(func)
     def wrapper():
         return rv()

--- a/examples/model-score/plotly_streaming.py
+++ b/examples/model-score/plotly_streaming.py
@@ -83,7 +83,7 @@ def render_plotly_streaming(
 
 def deduplicate(func):
     with reactive.isolate():
-        rv = reactive.Value(func())
+        rv = reactive.value(func())
 
     @reactive.effect
     def update():

--- a/examples/moduleapp/app.py
+++ b/examples/moduleapp/app.py
@@ -20,7 +20,7 @@ def counter_server(
 ):
     count: reactive.Value[int] = reactive.Value(starting_value)
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.button)
     def _():
         count.set(count() + 1)

--- a/examples/moduleapp/app.py
+++ b/examples/moduleapp/app.py
@@ -18,7 +18,7 @@ def counter_ui(label: str = "Increment counter") -> ui.TagChild:
 def counter_server(
     input: Inputs, output: Outputs, session: Session, starting_value: int = 0
 ):
-    count: reactive.Value[int] = reactive.Value(starting_value)
+    count: reactive.value[int] = reactive.value(starting_value)
 
     @reactive.effect
     @reactive.event(input.button)

--- a/examples/penguins/app.py
+++ b/examples/penguins/app.py
@@ -53,7 +53,7 @@ app_ui = ui.page_sidebar(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Calc
+    @reactive.calc
     def filtered_df() -> pd.DataFrame:
         """Returns a Pandas data frame that includes only the desired rows"""
 

--- a/examples/req/app.py
+++ b/examples/req/app.py
@@ -16,7 +16,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Calc
+    @reactive.calc
     def safe_click():
         req(input.safe())
         return input.safe()
@@ -30,7 +30,7 @@ def server(input: Inputs, output: Outputs, session: Session):
         req(input.unsafe())
         raise Exception(f"Super secret number of clicks: {str(input.unsafe())}")
 
-    @reactive.Effect
+    @reactive.effect
     def _():
         req(input.unsafe())
         print("unsafe clicks:", input.unsafe())

--- a/examples/static_plots/app.py
+++ b/examples/static_plots/app.py
@@ -54,7 +54,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Calc
+    @reactive.calc
     def fake_data():
         n = 5000
         mean = [0, 0]

--- a/examples/typed_inputs/app.py
+++ b/examples/typed_inputs/app.py
@@ -20,8 +20,8 @@ app_ui = ui.page_fluid(
 # But it is possible to specify the type of the input value, by creating a subclass of
 # Inputs. We'll do that for input.n2() and input.checkbox():
 class ShinyInputs(Inputs):
-    n2: reactive.Value[int]
-    check: reactive.Value[bool]
+    n2: reactive.value[int]
+    check: reactive.value[bool]
 
 
 def server(input: Inputs, output: Outputs, session: Session):

--- a/examples/typed_inputs/app.py
+++ b/examples/typed_inputs/app.py
@@ -32,7 +32,7 @@ def server(input: Inputs, output: Outputs, session: Session):
 
     # The type checker knows that r() returns an int, which you can see if you hover
     # over it.
-    @reactive.Calc
+    @reactive.calc
     def r():
         if input.n() is None:
             return 0

--- a/shiny/api-examples/Module/app-core.py
+++ b/shiny/api-examples/Module/app-core.py
@@ -20,7 +20,7 @@ def counter_server(
 ):
     count: reactive.Value[int] = reactive.Value(starting_value)
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.button)
     def _():
         count.set(count() + 1)

--- a/shiny/api-examples/Module/app-core.py
+++ b/shiny/api-examples/Module/app-core.py
@@ -18,7 +18,7 @@ def counter_ui(label: str = "Increment counter") -> ui.TagChild:
 def counter_server(
     input: Inputs, output: Outputs, session: Session, starting_value: int = 0
 ):
-    count: reactive.Value[int] = reactive.Value(starting_value)
+    count: reactive.value[int] = reactive.value(starting_value)
 
     @reactive.effect
     @reactive.event(input.button)

--- a/shiny/api-examples/Value/app-core.py
+++ b/shiny/api-examples/Value/app-core.py
@@ -10,7 +10,7 @@ app_ui = ui.page_sidebar(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    val = reactive.Value(0)
+    val = reactive.value(0)
 
     @reactive.effect
     @reactive.event(input.minus)

--- a/shiny/api-examples/Value/app-express.py
+++ b/shiny/api-examples/Value/app-express.py
@@ -1,7 +1,7 @@
 from shiny import reactive
 from shiny.express import input, render, ui
 
-val = reactive.Value(0)
+val = reactive.value(0)
 
 
 @reactive.effect

--- a/shiny/api-examples/accordion_panel/app-core.py
+++ b/shiny/api-examples/accordion_panel/app-core.py
@@ -14,7 +14,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Effect
+    @reactive.effect
     def _():
         print(input.acc())
 

--- a/shiny/api-examples/close/app-core.py
+++ b/shiny/api-examples/close/app-core.py
@@ -19,7 +19,7 @@ def server(input: Inputs, output: Outputs, session: Session):
 
     session.on_ended(log)
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.close)
     async def _():
         await session.close()

--- a/shiny/api-examples/dynamic_route/app-core.py
+++ b/shiny/api-examples/dynamic_route/app-core.py
@@ -9,7 +9,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.serve)
     def _():
         async def my_handler(request: Request) -> JSONResponse:

--- a/shiny/api-examples/effect/app-core.py
+++ b/shiny/api-examples/effect/app-core.py
@@ -4,7 +4,7 @@ app_ui = ui.page_fluid(ui.input_action_button("btn", "Press me!"))
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.btn)
     def _():
         ui.insert_ui(

--- a/shiny/api-examples/event/app-core.py
+++ b/shiny/api-examples/event/app-core.py
@@ -6,8 +6,8 @@ app_ui = ui.page_fluid(
     ui.markdown(
         f"""
         This example demonstrates how `@reactive.event()` can be used to restrict
-        execution of: (1) a `@render` function, (2) `@reactive.Calc`, or (3)
-        `@reactive.Effect`.
+        execution of: (1) a `@render` function, (2) `@reactive.calc`, or (3)
+        `@reactive.effect`.
 
         In all three cases, the output is dependent on a random value that gets updated
         every 0.5 seconds (currently, it is {ui.output_ui("number", inline=True)}), but
@@ -38,7 +38,7 @@ def server(input: Inputs, output: Outputs, session: Session):
     # Update a random number every second
     val = reactive.Value(random.randint(0, 1000))
 
-    @reactive.Effect
+    @reactive.effect
     def _():
         reactive.invalidate_later(0.5)
         val.set(random.randint(0, 1000))
@@ -56,7 +56,7 @@ def server(input: Inputs, output: Outputs, session: Session):
     def out_out():
         return str(val.get())
 
-    @reactive.Calc
+    @reactive.calc
     @reactive.event(input.btn_calc)
     def calc():
         return 1 / val.get()
@@ -65,7 +65,7 @@ def server(input: Inputs, output: Outputs, session: Session):
     def out_calc():
         return str(calc())
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.btn_effect)
     def _():
         ui.insert_ui(

--- a/shiny/api-examples/event/app-core.py
+++ b/shiny/api-examples/event/app-core.py
@@ -36,7 +36,7 @@ app_ui = ui.page_fluid(
 
 def server(input: Inputs, output: Outputs, session: Session):
     # Update a random number every second
-    val = reactive.Value(random.randint(0, 1000))
+    val = reactive.value(random.randint(0, 1000))
 
     @reactive.effect
     def _():

--- a/shiny/api-examples/extended_task/app-express.py
+++ b/shiny/api-examples/extended_task/app-express.py
@@ -31,13 +31,13 @@ with ui.layout_sidebar():
         ui.input_task_button("btn", "Compute, slowly")
         ui.input_action_button("btn_cancel", "Cancel")
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.btn, ignore_none=False)
     def handle_click():
         # slow_compute.cancel()
         slow_compute(input.x(), input.y())
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.btn_cancel)
     def handle_cancel():
         slow_compute.cancel()

--- a/shiny/api-examples/input_file/app-core.py
+++ b/shiny/api-examples/input_file/app-core.py
@@ -16,7 +16,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Calc
+    @reactive.calc
     def parsed_file():
         file: list[FileInfo] | None = input.file1()
         if file is None:

--- a/shiny/api-examples/input_file/app-express.py
+++ b/shiny/api-examples/input_file/app-express.py
@@ -13,7 +13,7 @@ ui.input_checkbox_group(
 )
 
 
-@reactive.Calc
+@reactive.calc
 def parsed_file():
     file: list[FileInfo] | None = input.file1()
     if file is None:

--- a/shiny/api-examples/insert_accordion_panel/app-core.py
+++ b/shiny/api-examples/insert_accordion_panel/app-core.py
@@ -18,7 +18,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.add_panel)
     def _():
         ui.insert_accordion_panel("acc", make_panel(str(random.randint(0, 10000))))

--- a/shiny/api-examples/insert_ui/app-core.py
+++ b/shiny/api-examples/insert_ui/app-core.py
@@ -6,7 +6,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.add)
     def _():
         ui.insert_ui(

--- a/shiny/api-examples/insert_ui/app-express.py
+++ b/shiny/api-examples/insert_ui/app-express.py
@@ -4,7 +4,7 @@ from shiny.express import input, ui
 ui.input_action_button("add", "Add UI")
 
 
-@reactive.Effect
+@reactive.effect
 @reactive.event(input.add)
 def _():
     ui.insert_ui(

--- a/shiny/api-examples/modal/app-core.py
+++ b/shiny/api-examples/modal/app-core.py
@@ -6,7 +6,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.show)
     def _():
         m = ui.modal(

--- a/shiny/api-examples/nav_panel/app-core.py
+++ b/shiny/api-examples/nav_panel/app-core.py
@@ -66,7 +66,7 @@ app_ui = ui.page_navbar(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Effect
+    @reactive.effect
     def _():
         print("Current navbar page: ", input.navbar_id())
 

--- a/shiny/api-examples/navset_hidden/app-core.py
+++ b/shiny/api-examples/navset_hidden/app-core.py
@@ -16,7 +16,7 @@ app_ui = ui.page_sidebar(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.controller)
     def _():
         ui.update_navs("hidden_tabs", selected="panel" + str(input.controller()))

--- a/shiny/api-examples/notification_show/app-core.py
+++ b/shiny/api-examples/notification_show/app-core.py
@@ -11,7 +11,7 @@ def server(input: Inputs, output: Outputs, session: Session):
     ids: list[str] = []
     n: int = 0
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.show)
     def _():
         nonlocal ids
@@ -21,7 +21,7 @@ def server(input: Inputs, output: Outputs, session: Session):
         ids.append(id)
         n += 1
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.remove)
     def _():
         nonlocal ids

--- a/shiny/api-examples/on_ended/app-core.py
+++ b/shiny/api-examples/on_ended/app-core.py
@@ -13,7 +13,7 @@ def server(input: Inputs, output: Outputs, session: Session):
 
     session.on_ended(log)
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.close)
     async def _():
         await session.close()

--- a/shiny/api-examples/remove_accordion_panel/app-core.py
+++ b/shiny/api-examples/remove_accordion_panel/app-core.py
@@ -29,7 +29,7 @@ def server(input: Inputs, output: Outputs, session: Session):
     # Copy the list for user
     user_choices = [choice for choice in choices]
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.remove_panel)
     def _():
         if len(user_choices) == 0:

--- a/shiny/api-examples/remove_ui/app-core.py
+++ b/shiny/api-examples/remove_ui/app-core.py
@@ -7,7 +7,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.rmv)
     def _():
         ui.remove_ui(selector="div:has(> #txt)")

--- a/shiny/api-examples/remove_ui/app-express.py
+++ b/shiny/api-examples/remove_ui/app-express.py
@@ -5,7 +5,7 @@ ui.input_action_button("rmv", "Remove UI")
 ui.input_text("txt", "Click button above to remove me")
 
 
-@reactive.Effect
+@reactive.effect
 @reactive.event(input.rmv)
 def _():
     ui.remove_ui(selector="div:has(> #txt)")

--- a/shiny/api-examples/req/app-core.py
+++ b/shiny/api-examples/req/app-core.py
@@ -15,7 +15,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Calc
+    @reactive.calc
     def safe_click():
         req(input.safe())
         return input.safe()
@@ -29,7 +29,7 @@ def server(input: Inputs, output: Outputs, session: Session):
         req(input.unsafe())
         raise Exception(f"Super secret number of clicks: {str(input.unsafe())}")
 
-    @reactive.Effect
+    @reactive.effect
     def _():
         req(input.unsafe())
         print("unsafe clicks:", input.unsafe())

--- a/shiny/api-examples/send_custom_message/app-core.py
+++ b/shiny/api-examples/send_custom_message/app-core.py
@@ -19,7 +19,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.submit)
     async def _():
         await session.send_custom_message("append_msg", {"msg": input.msg()})

--- a/shiny/api-examples/todo_list/app-core.py
+++ b/shiny/api-examples/todo_list/app-core.py
@@ -28,7 +28,7 @@ def server(input, output, session):
     def cleared_tasks():
         return f"Finished tasks: {finished_tasks()}"
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.add)
     def add():
         counter = task_counter.get() + 1
@@ -47,7 +47,7 @@ def server(input, output, session):
         # event within the `add` closure, so nesting the reactive effects
         # means that we don't have to worry about conflicting with
         # finish events from other task elements.
-        @reactive.Effect
+        @reactive.effect
         @reactive.event(finish)
         def iterate_counter():
             finished_tasks.set(finished_tasks.get() + 1)
@@ -82,12 +82,12 @@ def task_server(input, output, session, text):
             style=css(text_decoration="line-through" if finished() else None),
         )
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.finish)
     def finish_task():
         finished.set(True)
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.clear)
     def clear_task():
         ui.remove_ui(selector=f"div#{session.ns('button_row')}")

--- a/shiny/api-examples/todo_list/app-core.py
+++ b/shiny/api-examples/todo_list/app-core.py
@@ -21,8 +21,8 @@ app_ui = ui.page_fixed(
 
 
 def server(input, output, session):
-    finished_tasks = reactive.Value(0)
-    task_counter = reactive.Value(0)
+    finished_tasks = reactive.value(0)
+    task_counter = reactive.value(0)
 
     @render.text
     def cleared_tasks():
@@ -65,7 +65,7 @@ def task_ui():
 
 @module.server
 def task_server(input, output, session, text):
-    finished = reactive.Value(False)
+    finished = reactive.value(False)
 
     @render.ui
     def button_row():

--- a/shiny/api-examples/update_accordion/app-core.py
+++ b/shiny/api-examples/update_accordion/app-core.py
@@ -13,7 +13,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.set_acc)
     def _():
         ui.update_accordion("acc", show=["Section A", "Section C", "Section E"])

--- a/shiny/api-examples/update_accordion_panel/app-core.py
+++ b/shiny/api-examples/update_accordion_panel/app-core.py
@@ -18,7 +18,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.update_panel)
     def _():
         txt = " (updated)" if input.update_panel() else ""

--- a/shiny/api-examples/update_action_button/app-core.py
+++ b/shiny/api-examples/update_action_button/app-core.py
@@ -14,7 +14,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Effect
+    @reactive.effect
     def _():
         req(input.update())
         # Updates goButton's label and icon

--- a/shiny/api-examples/update_action_button/app-express.py
+++ b/shiny/api-examples/update_action_button/app-express.py
@@ -11,7 +11,7 @@ with ui.layout_column_wrap():
     ui.input_action_link("goLink", "Go Link")
 
 
-@reactive.Effect
+@reactive.effect
 def _():
     req(input.update())
     # Updates goButton's label and icon

--- a/shiny/api-examples/update_checkbox/app-core.py
+++ b/shiny/api-examples/update_checkbox/app-core.py
@@ -7,7 +7,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Effect
+    @reactive.effect
     def _():
         # True if controller is odd, False if even.
         x_even = input.controller() % 2 == 1

--- a/shiny/api-examples/update_checkbox_group/app-core.py
+++ b/shiny/api-examples/update_checkbox_group/app-core.py
@@ -12,7 +12,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Effect
+    @reactive.effect
     def _():
         x = input.inCheckboxGroup()
 

--- a/shiny/api-examples/update_date/app-core.py
+++ b/shiny/api-examples/update_date/app-core.py
@@ -9,7 +9,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Effect
+    @reactive.effect
     def _():
         d = date(2013, 4, input.n())
         ui.update_date(

--- a/shiny/api-examples/update_date/app-express.py
+++ b/shiny/api-examples/update_date/app-express.py
@@ -7,7 +7,7 @@ ui.input_slider("n", "Day of month", min=1, max=30, value=10)
 ui.input_date("inDate", "Input date")
 
 
-@reactive.Effect
+@reactive.effect
 def _():
     d = date(2013, 4, input.n())
     ui.update_date(

--- a/shiny/api-examples/update_date_range/app-core.py
+++ b/shiny/api-examples/update_date_range/app-core.py
@@ -9,7 +9,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Effect
+    @reactive.effect
     def _():
         d = date(2013, 4, input.n())
         ui.update_date_range(

--- a/shiny/api-examples/update_navs/app-core.py
+++ b/shiny/api-examples/update_navs/app-core.py
@@ -12,7 +12,7 @@ app_ui = ui.page_sidebar(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Effect
+    @reactive.effect
     def _():
         ui.update_navs("inTabset", selected="panel" + str(input.controller()))
 

--- a/shiny/api-examples/update_numeric/app-core.py
+++ b/shiny/api-examples/update_numeric/app-core.py
@@ -8,7 +8,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Effect
+    @reactive.effect
     def _():
         x = input.controller()
         ui.update_numeric("inNumber", value=x)

--- a/shiny/api-examples/update_radio_buttons/app-core.py
+++ b/shiny/api-examples/update_radio_buttons/app-core.py
@@ -12,7 +12,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Effect
+    @reactive.effect
     def _():
         x = input.inRadioButtons()
 

--- a/shiny/api-examples/update_select/app-core.py
+++ b/shiny/api-examples/update_select/app-core.py
@@ -10,7 +10,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Effect
+    @reactive.effect
     def _():
         x = input.inCheckboxGroup()
 

--- a/shiny/api-examples/update_selectize/app-core.py
+++ b/shiny/api-examples/update_selectize/app-core.py
@@ -6,7 +6,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Effect
+    @reactive.effect
     def _():
         ui.update_selectize(
             "x",

--- a/shiny/api-examples/update_sidebar/app-core.py
+++ b/shiny/api-examples/update_sidebar/app-core.py
@@ -12,12 +12,12 @@ app_ui = ui.page_sidebar(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.open_sidebar)
     def _():
         ui.update_sidebar("sidebar", show=True)
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.close_sidebar)
     def _():
         ui.update_sidebar("sidebar", show=False)

--- a/shiny/reactive/_core.py
+++ b/shiny/reactive/_core.py
@@ -293,9 +293,10 @@ def lock() -> asyncio.Lock:
     """
     A lock that should be held whenever manipulating the reactive graph.
 
-    For example, :func:`~shiny.reactive.lock` makes it safe to set a :class:`~reactive.Value` and call
-    :func:`~shiny.reactive.flush` from a different :class:`~asyncio.Task` than the one that
-    is running the Shiny :class:`~shiny.Session`.
+    For example, :func:`~shiny.reactive.lock` makes it safe to set a
+    :class:`~reactive.value` and call :func:`~shiny.reactive.flush` from a different
+    :class:`~asyncio.Task` than the one that is running the Shiny
+    :class:`~shiny.Session`.
     """
     return _reactive_environment.lock
 

--- a/shiny/templates/app-templates/dashboard/app-core.py
+++ b/shiny/templates/app-templates/dashboard/app-core.py
@@ -46,7 +46,7 @@ app_ui = ui.page_sidebar(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Calc
+    @reactive.calc
     def filtered_df() -> pd.DataFrame:
         filt_df = df[df["Species"].isin(input.species())]
         filt_df = filt_df.loc[filt_df["Body Mass (g)"] > input.mass()]

--- a/shiny/templates/app-templates/dashboard/app-express.py
+++ b/shiny/templates/app-templates/dashboard/app-express.py
@@ -22,7 +22,7 @@ with ui.sidebar():
     ui.input_checkbox_group("species", "Filter by species", species, selected=species)
 
 
-@reactive.Calc
+@reactive.calc
 def filtered_df() -> pd.DataFrame:
     filt_df = df[df["Species"].isin(input.species())]
     filt_df = filt_df.loc[filt_df["Body Mass (g)"] > input.mass()]

--- a/shiny/templates/app-templates/multi-page/app-core.py
+++ b/shiny/templates/app-templates/multi-page/app-core.py
@@ -32,7 +32,7 @@ app_ui = ui.page_navbar(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @reactive.Calc()
+    @reactive.calc()
     def filtered_data() -> pd.DataFrame:
         return df.loc[df["account"] == input.account()]
 

--- a/shiny/types.py
+++ b/shiny/types.py
@@ -103,7 +103,7 @@ class SilentException(Exception):
     - Displayed to the user (as a big red error message)
         - This happens when the exception is raised from an output context (e.g., :class:`shiny.render.ui`)
     - Crashes the application
-        - This happens when the exception is raised from an :func:`shiny.reactive.Effect`
+        - This happens when the exception is raised from an :func:`shiny.reactive.effect`
 
     This exception is used to silently throw inside a reactive context, meaning that
     execution is paused, and no output is shown to users (or the python console).

--- a/tests/playwright/deploys/plotly/app.py
+++ b/tests/playwright/deploys/plotly/app.py
@@ -59,7 +59,7 @@ def server(input, output, session):
             height="100%",
         )
 
-    @reactive.Calc
+    @reactive.calc
     def filtered_df():
         req(summary_data.input_selected_rows())
 
@@ -116,7 +116,7 @@ def synchronize_size(output_id):
     def wrapper(func):
         input = session.get_current_session().input
 
-        @reactive.Effect
+        @reactive.effect
         def size_updater():
             func(
                 input[f".clientdata_output_{output_id}_width"](),

--- a/tests/playwright/shiny/bugs/0696-resolve-id/app.py
+++ b/tests/playwright/shiny/bugs/0696-resolve-id/app.py
@@ -498,7 +498,7 @@ def server(input: Inputs, output: Outputs, session: Session):
 
     # # ## Debug
 
-    # @reactive.Effect
+    # @reactive.effect
     # def _():
     #     print("here")
     #     reactive.invalidate_later(1)

--- a/tests/playwright/shiny/inputs/input_task_button/app.py
+++ b/tests/playwright/shiny/inputs/input_task_button/app.py
@@ -37,19 +37,19 @@ with ui.layout_sidebar():
         ui.input_task_button("btn_block", "Block compute", label_busy="Blocking...")
         ui.input_action_button("btn_cancel", "Cancel")
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.btn_task, ignore_none=False)
     def handle_click():
         # slow_compute.cancel()
         slow_compute(input.x(), input.y())
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.btn_block, ignore_none=False)
     async def handle_click2():
         # slow_compute.cancel()
         await slow_input_compute(input.x(), input.y())
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.btn_cancel)
     def handle_cancel():
         slow_compute.cancel()

--- a/tests/playwright/shiny/inputs/input_task_button2/app.py
+++ b/tests/playwright/shiny/inputs/input_task_button2/app.py
@@ -13,7 +13,7 @@ def button_ui():
 
 @module.server
 def button_server(input: Inputs, output: Outputs, session: Session):
-    counter = reactive.Value(0)
+    counter = reactive.value(0)
 
     @render.text
     def text_counter():


### PR DESCRIPTION
Closes #823. This PR updates examples to use lower-case `calc`, `effect`, and `value`.

There was some discussion in #822 whether we should use lower-case `value` for the examples. I went ahead and did it here, in a separate commit, but it can be easily reversed.
