### PR TITLE
Make autoreload work on codespaces

### DIFF
--- a/shiny/_autoreload.py
+++ b/shiny/_autoreload.py
@@ -200,6 +200,11 @@ async def _coro_main(
     ) -> Optional[tuple[http.HTTPStatus, websockets.datastructures.HeadersLike, bytes]]:
         # If there's no Upgrade header, it's not a WebSocket request.
         if request_headers.get("Upgrade") is None:
+            # For some unknown reason, this fixes a tendency on GitHub Codespaces to
+            # correctly proxy through this request, but give a 404 when the redirect is
+            # followed and app_url is requested. With the sleep, both requests tend to
+            # succeed reliably.
+            await asyncio.sleep(1)
             return (http.HTTPStatus.MOVED_PERMANENTLY, [("Location", app_url)], b"")
 
     async with websockets.serve(

--- a/shiny/_hostenv.py
+++ b/shiny/_hostenv.py
@@ -65,6 +65,7 @@ def get_proxy_url(url: str) -> str:
         return _get_proxy_url_workbench(parts, port) or url
     if is_codespaces():
         return _get_proxy_url_codespaces(parts, port) or url
+    return url
 
 
 def _get_proxy_url_codespaces(parts: ParseResult, port: int) -> str | None:

--- a/shiny/_hostenv.py
+++ b/shiny/_hostenv.py
@@ -7,24 +7,34 @@ import typing
 from ipaddress import ip_address
 from subprocess import run
 from typing import Pattern
-from urllib.parse import urlparse
+from urllib.parse import ParseResult, urlparse
 
 
 def is_workbench() -> bool:
     return bool(os.getenv("RS_SERVER_URL") and os.getenv("RS_SESSION_URL"))
 
 
+def is_codespaces() -> bool:
+    # See https://docs.github.com/en/codespaces/developing-in-a-codespace/default-environment-variables-for-your-codespace
+    return bool(
+        os.getenv("CODESPACES")
+        and os.getenv("CODESPACE_NAME")
+        and os.getenv("GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN")
+    )
+
+
 def is_proxy_env() -> bool:
-    return is_workbench()
+    return is_workbench() or is_codespaces()
 
 
 port_cache: dict[int, str] = {}
 
 
 def get_proxy_url(url: str) -> str:
-    if not is_workbench():
+    if not is_proxy_env():
         return url
 
+    # Regardless of proxying strategy, we don't want to proxy URLs that are not loopback
     parts = urlparse(url)
     is_loopback = parts.hostname == "localhost"
     if not is_loopback:
@@ -35,6 +45,44 @@ def get_proxy_url(url: str) -> str:
     if not is_loopback:
         return url
 
+    # Regardless of proxying strategy, we need to know the port, whether explicit or
+    # implicit (from the scheme)
+    if parts.port is not None:
+        if parts.port == 0:
+            # Not sure if this is even legal but we're definitely not going to succeed
+            # in proxying it
+            return url
+        port = parts.port
+    elif parts.scheme.lower() in ["ws", "http"]:
+        port = 80
+    elif parts.scheme.lower() in ["wss", "https"]:
+        port = 443
+    else:
+        # No idea what kind of URL this is
+        return url
+
+    if is_workbench():
+        return _get_proxy_url_workbench(parts, port) or url
+    if is_codespaces():
+        return _get_proxy_url_codespaces(parts, port) or url
+
+
+def _get_proxy_url_codespaces(parts: ParseResult, port: int) -> str | None:
+    # See https://docs.github.com/en/codespaces/developing-in-a-codespace/default-environment-variables-for-your-codespace
+    codespace_name = os.getenv("CODESPACE_NAME")
+    port_forwarding_domain = os.getenv("GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN")
+    netloc = f"{codespace_name}-{port}.{port_forwarding_domain}"
+    if parts.scheme.lower() in ["ws", "wss"]:
+        scheme = "wss"
+    elif parts.scheme.lower() in ["http", "https"]:
+        scheme = "https"
+    else:
+        return None
+
+    return parts._replace(scheme=scheme, netloc=netloc).geturl()
+
+
+def _get_proxy_url_workbench(parts: ParseResult, port: int) -> str | None:
     path = parts.path or "/"
 
     server_url = os.getenv("RS_SERVER_URL", "")
@@ -44,18 +92,6 @@ def get_proxy_url(url: str) -> str:
         server_url = re.sub("^http", "ws", server_url)
     server_url = re.sub("/$", "", server_url)
     session_url = re.sub("^/", "", session_url)
-
-    port = (
-        parts.port
-        if parts.port
-        else (
-            80
-            if parts.scheme in ["ws", "http"]
-            else 443 if parts.scheme in ["wss", "https"] else 0
-        )
-    )
-    if port == 0:
-        return url
 
     if port in port_cache:
         ptoken = port_cache[port]
@@ -67,9 +103,9 @@ def get_proxy_url(url: str) -> str:
                 encoding="ascii",
             )
         except FileNotFoundError:
-            return url
+            return None
         if res.returncode != 0:
-            return url
+            return None
         ptoken = res.stdout
         port_cache[port] = ptoken
 

--- a/shiny/_main.py
+++ b/shiny/_main.py
@@ -310,6 +310,19 @@ def run_app(
             shinypath = Path(inspect.getfile(shiny)).parent
             reload_dirs.append(str(shinypath))
 
+        # This is necessary for GitHub Codespaces. The autoreload port must be public,
+        # which can't be controlled from here--it must be done in devcontainer.json and
+        # then we use that port. Private ports are authenticated in one of two ways:
+        # either visit the proxied host over https in a browser (which sets cookies) or
+        # attach an X-Github-Token HTTP header, neither of which we have the ability to
+        # do for our autoreload port.
+        #
+        # This is only a problem for our autoreload endpoint, not our normal Shiny app
+        # endpoint, because the former never makes a regular HTTP request, only WS;
+        # whereas the latter always browses to an HTTP page first.
+        if autoreload_port == 0 and os.getenv("SHINY_AUTORELOAD_PORT", "").isdecimal():
+            autoreload_port = int(os.getenv("SHINY_AUTORELOAD_PORT", ""))
+
         if autoreload_port == 0:
             autoreload_port = _utils.random_port(host=host)
 

--- a/shiny/_main.py
+++ b/shiny/_main.py
@@ -310,19 +310,6 @@ def run_app(
             shinypath = Path(inspect.getfile(shiny)).parent
             reload_dirs.append(str(shinypath))
 
-        # This is necessary for GitHub Codespaces. The autoreload port must be public,
-        # which can't be controlled from here--it must be done in devcontainer.json and
-        # then we use that port. Private ports are authenticated in one of two ways:
-        # either visit the proxied host over https in a browser (which sets cookies) or
-        # attach an X-Github-Token HTTP header, neither of which we have the ability to
-        # do for our autoreload port.
-        #
-        # This is only a problem for our autoreload endpoint, not our normal Shiny app
-        # endpoint, because the former never makes a regular HTTP request, only WS;
-        # whereas the latter always browses to an HTTP page first.
-        if autoreload_port == 0 and os.getenv("SHINY_AUTORELOAD_PORT", "").isdecimal():
-            autoreload_port = int(os.getenv("SHINY_AUTORELOAD_PORT", ""))
-
         if autoreload_port == 0:
             autoreload_port = _utils.random_port(host=host)
 


### PR DESCRIPTION
This PR makes Shiny detect that it's running on Codespaces, where the browser can't just point to `http://127.0.0.1:{autoreload-port}` and expect to succeed. Instead, a proxy URL is used. See [Forwarding ports in your codespace](https://docs.github.com/en/codespaces/developing-in-a-codespace/forwarding-ports-in-your-codespace).

Note that this alone is not enough to make autoreload work quite right on codespaces. The Shiny app will try to connect to the autoreload websocket server and fail. This is because Codespace's forwarded ports are private by default, and need you to access each proxy hostname via HTTP document load first so it can set some cookies and whatnot. A forthcoming PR for pyshiny-vscode will try to address this.

**Update:** Here's the corresponding pyshiny-vscode PR https://github.com/posit-dev/pyshiny-vscode/pull/27