### PR TITLE
Remove redundant checks in GHA workflow

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -31,22 +31,26 @@ jobs:
       - name: Run unit tests
         if: steps.install.outcome == 'success' && (success() || failure())
         run: |
-          make test
+          make check-tests
 
       - name: Type check with pyright
         if: steps.install.outcome == 'success' && (success() || failure())
         run: |
-          make pyright
+          make check-types
 
       - name: Lint with flake8
         if: steps.install.outcome == 'success' && (success() || failure())
         run: |
-          make lint
+          make check-lint
 
-      - name: black and isort
+      - name: black
         if: steps.install.outcome == 'success' && (success() || failure())
         run: |
           make check-black
+
+      - name: isort
+        if: steps.install.outcome == 'success' && (success() || failure())
+        run: |
           make check-isort
 
   playwright-shiny:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -46,7 +46,8 @@ jobs:
       - name: black and isort
         if: steps.install.outcome == 'success' && (success() || failure())
         run: |
-          make check
+          make check-black
+          make check-isort
 
   playwright-shiny:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Prior to this change, we were running pytest, pyright, and flake8 twice in our GHA workflow, because `make check` runs all of those things, and we ran them individually above.

The reason that I did _not_ simply delete the others steps in the workflow and only keep `make check` is because if there is a failure in any one of the steps, a `make check` will exit without running subsequent steps. However, with the steps separate, and the `if:  steps.install.outcome == 'success' && (success() || failure())` condition that we have, it will run all of the check steps (assuming successful installation), even if one of the steps fails.

One more note: I don't really love that I added `make check-black; make check-isort` to the workflow, while the other steps are just `make test` and `make pyright`; the inconsistency feels a little weird so I'm open to suggestions about renaming things.