### PR TITLE
Use more consistent types for `static_assets`

### DIFF
--- a/shiny/_app.py
+++ b/shiny/_app.py
@@ -148,7 +148,7 @@ class App:
         else:
             static_assets_map = {"/": Path(static_assets)}
 
-        for mount_point, static_asset_path in static_assets_map.items():
+        for _, static_asset_path in static_assets_map.items():
             if not static_asset_path.is_absolute():
                 raise ValueError(
                     f'static_assets must be an absolute path: "{static_asset_path}".'

--- a/shiny/express/_run.py
+++ b/shiny/express/_run.py
@@ -79,7 +79,7 @@ def wrap_express_app(file: Path) -> App:
     app = App(
         app_ui,
         express_server,
-        **app_opts,
+        **app_opts,  # pyright: ignore[reportArgumentType]
     )
 
     return app


### PR DESCRIPTION
This switches away from `os.PathLike[str]` to `Path`.  I'm not really sure why we used `os.PathLike[str]` in the first place, and it's not entirely clear to me what counts as `PathLike`, so I just went with `Path` to keep things simple.

If the user passes in a dictionary, it also allows the values to be strings, and not just `Path`s.

Previously, when the user passes in a dictionary, the code did not check if the paths were absolute, which could cause problems when running the application. (It only checked for absoluteness if the user passed in a string or Pathlike object.)

Now when a dictionary is passed in, it does check if those paths are absolute.

It also now prints a more useful error message if a path is not absolute:


```
ValueError: static_assets must be an absolute path: "foo". Consider using one of the following:
  os.path.join(__file__, "foo")  OR  pathlib.Path(__file__).parent/"foo"
```