### PR TITLE
Revert API changes made in `Selected rows method` #1121

### DIFF
--- a/examples/dataframe/app.py
+++ b/examples/dataframe/app.py
@@ -92,10 +92,10 @@ def server(input: Inputs, output: Outputs, session: Session):
 
     @render.text
     def detail():
-        selected_rows = grid.input_selected_rows() or ()
+        selected_rows = input.grid_selected_rows() or ()
         if len(selected_rows) > 0:
             # "split", "records", "index", "columns", "values", "table"
-            return df().iloc[list(grid.input_selected_rows())]
+            return df().iloc[list(input.grid_selected_rows())]
 
 
 app = App(app_ui, server)

--- a/shiny/api-examples/data_frame/app-core.py
+++ b/shiny/api-examples/data_frame/app-core.py
@@ -44,11 +44,11 @@ def server(input, output, session):
 
     @reactive.calc
     def filtered_df():
-        req(summary_data.input_selected_rows())
+        req(input.summary_data_selected_rows())
 
-        # summary_data.selected_rows() is a tuple, so we must convert it to list,
+        # input.summary_data_selected_rows() is a tuple, so we must convert it to list,
         # as that's what Pandas requires for indexing.
-        selected_idx = list(summary_data.input_selected_rows())
+        selected_idx = list(input.summary_data_selected_rows())
         countries = summary_df.iloc[selected_idx]["country"]
         # Filter data for selected countries
         return df[df["country"].isin(countries)]

--- a/shiny/api-examples/data_frame/app-express.py
+++ b/shiny/api-examples/data_frame/app-express.py
@@ -3,7 +3,7 @@ import plotly.express as px
 from shinywidgets import render_widget
 
 from shiny import reactive, req
-from shiny.express import render, ui
+from shiny.express import input, render, ui
 
 # Load the Gapminder dataset
 df = px.data.gapminder()
@@ -66,12 +66,12 @@ with ui.layout_columns(col_widths=[12, 6, 6]):
 
 @reactive.calc
 def filtered_df():
-    req(summary_data.input_selected_rows())
+    req(input.summary_data_selected_rows())
 
-    # summary_data.input_selected_rows() is a tuple, so we must convert it to list,
+    # input.summary_data_selected_rows() is a tuple, so we must convert it to list,
     # as that's what Pandas requires for indexing.
 
-    selected_idx = list(summary_data.input_selected_rows())
+    selected_idx = list(input.summary_data_selected_rows())
     countries = summary_df.iloc[selected_idx]["country"]
     # Filter data for selected countries
     return df[df["country"].isin(countries)]

--- a/shiny/render/_dataframe.py
+++ b/shiny/render/_dataframe.py
@@ -2,22 +2,12 @@ from __future__ import annotations
 
 import abc
 import json
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Literal,
-    Optional,
-    Protocol,
-    Union,
-    cast,
-    runtime_checkable,
-)
+from typing import TYPE_CHECKING, Any, Literal, Protocol, Union, cast, runtime_checkable
 
 from htmltools import Tag
 
 from .. import ui
 from .._docstring import add_example, no_example
-from ..session._utils import require_active_session
 from ._dataframe_unsafe import serialize_numpy_dtypes
 from .renderer import Jsonifiable, Renderer
 
@@ -248,7 +238,8 @@ class data_frame(Renderer[DataFrameResult]):
     Row selection
     -------------
     When using the row selection feature, you can access the selected rows by using the
-    `<data_frame_renderer>.input_selected_rows()` method, where `<data_frame_renderer>` is the render function name that corresponds with the `id=` used in :func:`~shiny.ui.outout_data_frame`. Internally, this method retrieves the selected row value from session's `input.<id>_selected_rows()` value. The value returned will be `None` if no rows
+    `input.<id>_selected_rows()` function, where `<id>` is the `id` of the
+    :func:`~shiny.ui.output_data_frame`. The value returned will be `None` if no rows
     are selected, or a tuple of integers representing the indices of the selected rows.
     To filter a pandas data frame down to the selected rows, use
     `df.iloc[list(input.<id>_selected_rows())]`.
@@ -267,6 +258,8 @@ class data_frame(Renderer[DataFrameResult]):
       objects you can return from the rendering function to specify options.
     """
 
+    # `<data_frame_renderer>.input_selected_rows()` method, where `<data_frame_renderer>` is the render function name that corresponds with the `id=` used in :func:`~shiny.ui.outout_data_frame`. Internally, this method retrieves the selected row value from session's `input.<id>_selected_rows()` value. The value returned will be `None` if no rows
+
     def auto_output_ui(self) -> Tag:
         return ui.output_data_frame(id=self.output_id)
 
@@ -280,14 +273,14 @@ class data_frame(Renderer[DataFrameResult]):
             )
         return value.to_payload()
 
-    def input_selected_rows(self) -> Optional[tuple[int]]:
-        """
-        When `row_selection_mode` is set to "single" or "multiple" this will return
-        a tuple of integers representing the rows selected by a user.
-        """
+    # def input_selected_rows(self) -> Optional[tuple[int]]:
+    #     """
+    #     When `row_selection_mode` is set to "single" or "multiple" this will return
+    #     a tuple of integers representing the rows selected by a user.
+    #     """
 
-        active_session = require_active_session(None)
-        return active_session.input[self.output_id + "_selected_rows"]()
+    #     active_session = require_active_session(None)
+    #     return active_session.input[self.output_id + "_selected_rows"]()
 
 
 @runtime_checkable

--- a/tests/playwright/deploys/plotly/app.py
+++ b/tests/playwright/deploys/plotly/app.py
@@ -61,11 +61,11 @@ def server(input, output, session):
 
     @reactive.calc
     def filtered_df():
-        req(summary_data.input_selected_rows())
+        req(input.summary_data_selected_rows())
 
         # input.summary_data_selected_rows() is a tuple, so we must convert it to list,
         # as that's what Pandas requires for indexing.
-        selected_idx = list(summary_data.input_selected_rows())
+        selected_idx = list(input.summary_data_selected_rows())
         countries = summary_df.iloc[selected_idx]["country"]
         # Filter data for selected countries
         return df[df["country"].isin(countries)]

--- a/tests/playwright/shiny/bugs/0676-row-selection/app.py
+++ b/tests/playwright/shiny/bugs/0676-row-selection/app.py
@@ -33,7 +33,7 @@ def server(input: Inputs, output: Outputs, session: Session):
 
     @render.table
     def detail():
-        selected_rows = grid.input_selected_rows() or ()
+        selected_rows = input.grid_selected_rows() or ()
         if len(selected_rows) > 0:
             return df.iloc[list(selected_rows)]
 

--- a/tests/playwright/shiny/bugs/0676-row-selection/app.py
+++ b/tests/playwright/shiny/bugs/0676-row-selection/app.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import cast
+
 import pandas as pd
 
 from shiny import App, Inputs, Outputs, Session, render, ui
@@ -33,7 +37,7 @@ def server(input: Inputs, output: Outputs, session: Session):
 
     @render.table
     def detail():
-        selected_rows = input.grid_selected_rows() or ()
+        selected_rows = cast(tuple[int], input.grid_selected_rows() or ())
         if len(selected_rows) > 0:
             return df.iloc[list(selected_rows)]
 

--- a/tests/playwright/shiny/bugs/0676-row-selection/app.py
+++ b/tests/playwright/shiny/bugs/0676-row-selection/app.py
@@ -37,7 +37,7 @@ def server(input: Inputs, output: Outputs, session: Session):
 
     @render.table
     def detail():
-        selected_rows = cast(tuple[int], input.grid_selected_rows() or ())
+        selected_rows = cast("tuple[int]", input.grid_selected_rows() or ())
         if len(selected_rows) > 0:
             return df.iloc[list(selected_rows)]
 


### PR DESCRIPTION
I am not certain about `<dataframe_renderer>.input_selected_rows()`. 

With the remaining work on data frames pushed into v0.9.0, I'm reverting this change so that we do not possibly revert it right after pushing it.

The behavior (in some form) will be restored in #1135 

Related: #1135 