### PR TITLE
Remove uvicorn and click dependencies in Emscripten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Closed #1178: Removed run-time dependency on asgiref. (#1183)
 
+* The uvicorn and click packages are no longer needed when running on Emscripten. (#1187)
+
 ## [0.8.0] - 2024-03-04
 
 ### Breaking Changes

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,12 +34,12 @@ setup_requires =
     setuptools
 install_requires =
     typing-extensions>=4.0.1
-    uvicorn>=0.16.0
+    uvicorn>=0.16.0;platform_system!="Emscripten"
     starlette
     websockets>=10.0
     python-multipart
     htmltools>=0.5.1
-    click>=8.1.4
+    click>=8.1.4;platform_system!="Emscripten"
     markdown-it-py>=1.1.0
     # This is needed for markdown-it-py. Without it, when loading shiny/ui/_markdown.py,
     # Python emits the following: "UserWarning: The 'tasklists' feature of GitHub


### PR DESCRIPTION
The uvicorn and click packages are not needed when running on Emscripten.