### PR TITLE
Fix `express.ui.update_date` and`express.ui.update_text` links

### DIFF
--- a/docs/_quartodoc-express.yml
+++ b/docs/_quartodoc-express.yml
@@ -99,31 +99,20 @@ quartodoc:
     - title: Update inputs
       desc: Programmatically update input values.
       contents:
-        - name: express.ui.update_select
-          dynamic: true
-        - name: express.ui.update_selectize
-          dynamic: true
-        - name: express.ui.update_slider
-          dynamic: true
+        - express.ui.update_select
+        - express.ui.update_selectize
+        - express.ui.update_slider
         - express.ui.update_dark_mode
         - express.ui.update_date
-        - name: express.ui.update_date_range
-          dynamic: true
-        - name: express.ui.update_checkbox
-          dynamic: true
-        - name: express.ui.update_checkbox_group
-          dynamic: true
-        - name: express.ui.update_switch
-          dynamic: true
-        - name: express.ui.update_radio_buttons
-          dynamic: true
-        - name: express.ui.update_numeric
-          dynamic: true
+        - express.ui.update_date_range
+        - express.ui.update_checkbox
+        - express.ui.update_checkbox_group
+        - express.ui.update_switch
+        - express.ui.update_radio_buttons
+        - express.ui.update_numeric
         - express.ui.update_text
-        - name: express.ui.update_text_area
-          dynamic: "shiny.ui.update_text"
-        - name: express.ui.update_navs
-          dynamic: true
+        - express.ui.update_text_area
+        - express.ui.update_navs
         - express.ui.update_action_button
         - express.ui.update_action_link
         - express.ui.update_task_button

--- a/docs/_quartodoc-express.yml
+++ b/docs/_quartodoc-express.yml
@@ -106,7 +106,7 @@ quartodoc:
         - name: express.ui.update_slider
           dynamic: true
         - express.ui.update_dark_mode
-        - ui.update_date
+        - express.ui.update_date
         - name: express.ui.update_date_range
           dynamic: true
         - name: express.ui.update_checkbox
@@ -119,7 +119,7 @@ quartodoc:
           dynamic: true
         - name: express.ui.update_numeric
           dynamic: true
-        - ui.update_text
+        - express.ui.update_text
         - name: express.ui.update_text_area
           dynamic: "shiny.ui.update_text"
         - name: express.ui.update_navs


### PR DESCRIPTION
For the Express API docs, the `update_date` and `update_text` items point to the non-Express functions:

<img width="316" alt="image" src="https://github.com/posit-dev/py-shiny/assets/86978/ef7c0e56-c94c-42c1-b763-f25516bb98bb">


This PR fixes them, and it also simplifies the config file by removing `dynamic: true`, which I believe is no longer needed.