### PR TITLE
Fix datetime input in airmass example app

### DIFF
--- a/examples/airmass/app.py
+++ b/examples/airmass/app.py
@@ -76,9 +76,10 @@ def server(input: Inputs, output: Outputs, session: Session):
         req(input.date())
         lat, long = loc()
         sun = suntime.Sun(lat, long)
+        day = datetime.datetime.combine(input.date(), datetime.time())
         return (
-            sun.get_sunset_time(input.date()),
-            sun.get_sunrise_time(input.date() + datetime.timedelta(days=1)),
+            sun.get_sunset_time(day),
+            sun.get_sunrise_time(day + datetime.timedelta(days=1)),
         )
 
     @reactive.calc


### PR DESCRIPTION
I believe a recent release of `suntime` changed the expected input type of `get_sunrise_time()` and `get_sunset_time()`. https://github.com/SatAgro/suntime/releases/tag/v1.3.0