### PR TITLE
ci: Run `playwright-examples` on Python 3.12 as well

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -79,7 +79,7 @@ jobs:
     if: github.event_name != 'release'
     strategy:
       matrix:
-        python-version: ["3.11", "3.10", "3.9", "3.8"]
+        python-version: ["3.12", "3.11", "3.10", "3.9", "3.8"]
         os: [ubuntu-latest]
       fail-fast: false
 


### PR DESCRIPTION
Add `3.12` to the list of Python versions for the `playwright-examples` job. (Assuming this was an oversight.)