### PR TITLE
fix(static_assets): Need the directory containing the `app.py`, not the file itself

### DIFF
--- a/shiny/_app.py
+++ b/shiny/_app.py
@@ -153,7 +153,7 @@ class App:
                 raise ValueError(
                     f'static_assets must be an absolute path: "{static_asset_path}".'
                     " Consider using one of the following instead:\n"
-                    f'  os.path.join(__file__, "{static_asset_path}")  OR'
+                    f'  os.path.join(os.path.dirname(__file__), "{static_asset_path}")  OR'
                     f'  pathlib.Path(__file__).parent/"{static_asset_path}"'
                 )
 


### PR DESCRIPTION
Currently if you set

```python
app = App(app_ui, server, static_assets="www")
```

you'll get a helpful error message with two recommendations

```
ValueError: static_assets must be an absolute path: "www". Consider using one of the following instead:
  os.path.join(__file__, "www")  OR  pathlib.Path(__file__).parent/"www"
```

Unfortunately, the first option isn't quite right 
```python
os.path.join(__file__, "www")
```
and will try to mount `/Users/person/path/to/app/app.py/www` instead of `/Users/person/path/to/app/www`.

The fix is to use

```python
os.path.join(os.path.dirname(__file__), "www")
```