### PR TITLE
feat(layout_columns): Use `sm` as the default `col_widths` breakpoint

### DIFF
--- a/shiny/ui/_layout_columns.py
+++ b/shiny/ui/_layout_columns.py
@@ -259,12 +259,8 @@ def row_heights_attrs(
     # Remove any None values from x
     x_complete = {k: v for k, v in x.items() if v is not None}
 
-    # We use classes to activate CSS variables at the right breakpoints. Note: Mobile
-    # row height is derived from xs or defaults to auto in the CSS, so we don't need the
-    # class to activate it
-    classes = [
-        f"bslib-grid--row-heights--{brk}" for brk in x_complete.keys() if brk != "xs"
-    ]
+    # We use classes to activate CSS variables at the right breakpoints.
+    classes = [f"bslib-grid--row-heights--{brk}" for brk in x_complete.keys()]
 
     # Create CSS variables, treating numeric values as fractional units, passing strings
     css_vars: Dict[str, str] = {}

--- a/shiny/ui/_layout_columns.py
+++ b/shiny/ui/_layout_columns.py
@@ -153,7 +153,7 @@ def as_col_spec(
         return None
 
     if not isinstance(col_widths, Dict):
-        return {"md": validate_col_width(col_widths, n_kids, "md")}
+        return {"sm": validate_col_width(col_widths, n_kids, "sm")}
 
     ret: BreakpointsOptional[int] = {}
     col_widths_items = cast(BreakpointsSoft[int], col_widths).items()


### PR DESCRIPTION
Companion PR to https://github.com/rstudio/bslib/pull/1014

1. `col_widths=(12, 6, 6)` now becomes `col_widths={"sm": (12, 6, 6)}` where we previously used `md` as the default breakpoint. This update aligns with the intuitive expectation that `col_widths` of a single value is the column widths at all breakpoints (except mobile where we do something completely different).

2. While here I noticed that we actually _do need_ to include the `xs`-specific class that activates its corresponding CSS variable. Without this change,`row_heights={"xs": ...}` doesn't work as expected.