### PR TITLE
For Express, emit message if need to upgrade rsconnect-python

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ install_requires =
     linkify-it-py>=1.0
     appdirs>=1.4.4
     asgiref>=3.5.2
+    packaging>=20.9
     watchfiles>=0.18.0;platform_system!="Emscripten"
     questionary>=2.0.0;platform_system!="Emscripten"
     # This is needed to address a DoS issue. In the future, when we are able to upgrade

--- a/shiny/_main.py
+++ b/shiny/_main.py
@@ -10,7 +10,7 @@ import re
 import sys
 import types
 from pathlib import Path
-from typing import Any, Literal, Optional
+from typing import Any, Optional
 
 import click
 import uvicorn

--- a/shiny/_main.py
+++ b/shiny/_main.py
@@ -663,7 +663,6 @@ def _verify_rsconnect_version() -> None:
 
     try:
         package_version = version(PACKAGE_NAME)
-        print(package_version)
         if _compare_package_versions(package_version, MIN_VERSION) < 0:
             print(
                 f"Warning: rsconnect-python {package_version} is installed, but it does not support deploying Shiny Express applications. "

--- a/shiny/_main.py
+++ b/shiny/_main.py
@@ -632,40 +632,22 @@ class ReloadArgs(TypedDict):
 
 
 # Check that the version of rsconnect supports Shiny Express; can be removed in the
-# future once this version of rsconnect is widely used. (Added 2024-03)
+# future once this version of rsconnect is widely used. The dependency on "packaging"
+# can also be removed then, because it is only used here. (Added 2024-03)
 def _verify_rsconnect_version() -> None:
     PACKAGE_NAME = "rsconnect-python"
     MIN_VERSION = "1.22.0"
 
     from importlib.metadata import PackageNotFoundError, version
 
-    def _safe_int(x: str) -> int:
-        try:
-            return int(x)
-        except ValueError:
-            return 0
-
-    def _compare_package_versions(version1: str, version2: str) -> Literal[-1, 0, 1]:
-        parts1 = [_safe_int(x) for x in version1.split(".")]
-        parts2 = [_safe_int(x) for x in version2.split(".")]
-
-        max_length = max(len(parts1), len(parts2))
-        parts1 += [0] * (max_length - len(parts1))
-        parts2 += [0] * (max_length - len(parts2))
-
-        for part1, part2 in zip(parts1, parts2):
-            if part1 > part2:
-                return 1
-            elif part1 < part2:
-                return -1
-
-        return 0
+    from packaging.version import parse
 
     try:
-        package_version = version(PACKAGE_NAME)
-        if _compare_package_versions(package_version, MIN_VERSION) < 0:
+        installed_version = parse(version(PACKAGE_NAME))
+        required_version = parse(MIN_VERSION)
+        if installed_version < required_version:
             print(
-                f"Warning: rsconnect-python {package_version} is installed, but it does not support deploying Shiny Express applications. "
+                f"Warning: rsconnect-python {installed_version} is installed, but it does not support deploying Shiny Express applications. "
                 f"Please upgrade to at least version {MIN_VERSION}. "
                 "If you are using pip, you can run `pip install --upgrade rsconnect-python`",
                 file=sys.stderr,


### PR DESCRIPTION
Addresses #1232.

When a user runs `shiny run app.py` on a Shiny Express app, this checks the version of the rsconnect-python package.

If (A) rsconnect-python is installed and (B), the version is less than 1.22.0, then this will print a message to stderr like this, and then it will run the app as usual.

```
Warning: rsconnect-python 1.21.0 is installed, but it does not support deploying Shiny Express applications. Please upgrade to at least version 1.22.0. If you are using pip, you can run `pip install --upgrade rsconnect-python
```

