### PR TITLE
Add back missing session methods

### DIFF
--- a/docs/_quartodoc-core.yml
+++ b/docs/_quartodoc-core.yml
@@ -235,6 +235,12 @@ quartodoc:
             - session.get_current_session
             - session.require_active_session
             - session.session_context
+            - session.send_custom_message
+            - session.send_input_message
+            - session.on_flush
+            - session.on_flushed
+            - session.on_ended
+            - session.dynamic_route
             - reactive.get_current_context
             - name: input_handler.input_handlers
               dynamic: true


### PR DESCRIPTION
Seems in the move to quartodoc, we lost documentation of these methods


https://shiny.posit.co/py/api/core/Session.html#shiny.Session