### PR TITLE
test(CI): Add merge queue support for faster PR testing

### DIFF
--- a/.github/py-shiny/pytest-browsers/action.yaml
+++ b/.github/py-shiny/pytest-browsers/action.yaml
@@ -1,5 +1,5 @@
 name: 'Custom merge queue browsers'
-description: 'Trim down pytest browsers to just chrome for merge_group events.'
+description: 'Trim down pytest browsers for any github event other than merge_group.'
 outputs:
   browsers:
     description: 'pytest browsers to use'
@@ -11,7 +11,7 @@ runs:
         shell: bash
         id: browsers
         run: |
-          if [ "${{ github.event_name }}" == "merge_group" ]; then
+          if [ "${{ github.event_name }}" != "merge_group" ]; then
             echo "Using chrome browser only!"
             echo 'browsers=PYTEST_BROWSER="--browser chromium"' >> "$GITHUB_OUTPUT"
           else

--- a/.github/py-shiny/pytest-browsers/action.yaml
+++ b/.github/py-shiny/pytest-browsers/action.yaml
@@ -1,0 +1,19 @@
+name: 'Custom merge queue browsers'
+description: 'Trim down pytest browsers to just chrome for merge_group events.'
+outputs:
+  browsers:
+    description: 'pytest browsers to use'
+    value: ${{ steps.browsers.outputs.browser }}
+runs:
+  using: "composite"
+  steps:
+      - name: Determine browsers to use
+        shell: bash
+        id: browsers
+        run: |
+          if [ "${{ github.event_name }}" == "merge_group" ]; then
+            echo "Using chrome browser only!"
+            echo 'browsers=PYTEST_BROWSER="--browser chromium"' >> "$GITHUB_OUTPUT"
+          else
+            echo "No custom pytest browsers"
+          fi

--- a/.github/py-shiny/pytest-browsers/action.yaml
+++ b/.github/py-shiny/pytest-browsers/action.yaml
@@ -10,7 +10,7 @@ outputs:
     description: 'pytest browsers to use'
     value: ${{ steps.browsers.outputs.browsers }}
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
       - name: Determine browsers to use
         shell: bash

--- a/.github/py-shiny/pytest-browsers/action.yaml
+++ b/.github/py-shiny/pytest-browsers/action.yaml
@@ -10,7 +10,7 @@ outputs:
     description: 'pytest browsers to use'
     value: ${{ steps.browsers.outputs.browsers }}
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
       - name: Determine browsers to use
         shell: bash
@@ -21,10 +21,10 @@ runs:
             exit 0
           fi
 
-          if [ "${{ github.event_name }}" == "merge_group" ]; then
-            echo "No custom pytest browsers for merge_group event!"
-            exit 0
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "Using chrome browser only!"
+            echo 'browsers=PYTEST_BROWSERS="--browser chromium"' >> "$GITHUB_OUTPUT"
           fi
 
-          echo "Using chrome browser only!"
-          echo 'browsers=PYTEST_BROWSER="--browser chromium"' >> "$GITHUB_OUTPUT"
+          echo "No custom pytest browsers!"
+          exit 0

--- a/.github/py-shiny/pytest-browsers/action.yaml
+++ b/.github/py-shiny/pytest-browsers/action.yaml
@@ -1,5 +1,5 @@
 name: 'Custom merge queue browsers'
-description: 'Trim down pytest browsers for any github event other than merge_group'
+description: 'Trim down pytest browsers for any github event other than merge_group.'
 inputs:
   all-browsers:
     description: 'Force all pytest browsers to used when testing'

--- a/.github/py-shiny/pytest-browsers/action.yaml
+++ b/.github/py-shiny/pytest-browsers/action.yaml
@@ -1,5 +1,5 @@
 name: 'Custom merge queue browsers'
-description: 'Trim down pytest browsers for any github event other than merge_group.'
+description: 'Trim down pytest browsers for any github event other than merge_group'
 inputs:
   all-browsers:
     description: 'Force all pytest browsers to used when testing'

--- a/.github/py-shiny/pytest-browsers/action.yaml
+++ b/.github/py-shiny/pytest-browsers/action.yaml
@@ -1,5 +1,10 @@
 name: 'Custom merge queue browsers'
 description: 'Trim down pytest browsers for any github event other than merge_group.'
+inputs:
+  all-browsers:
+    description: 'Force all pytest browsers to used when testing'
+    required: false
+    default: 'false'
 outputs:
   browsers:
     description: 'pytest browsers to use'
@@ -11,9 +16,15 @@ runs:
         shell: bash
         id: browsers
         run: |
-          if [ "${{ github.event_name }}" != "merge_group" ]; then
-            echo "Using chrome browser only!"
-            echo 'browsers=PYTEST_BROWSER="--browser chromium"' >> "$GITHUB_OUTPUT"
-          else
-            echo "No custom pytest browsers"
+          if [ "${{ inputs.all-browsers }}" == "true" ]; then
+            echo "Using all browsers!"
+            exit 0
           fi
+
+          if [ "${{ github.event_name }}" == "merge_group" ]; then
+            echo "No custom pytest browsers for merge_group event!"
+            exit 0
+          fi
+
+          echo "Using chrome browser only!"
+          echo 'browsers=PYTEST_BROWSER="--browser chromium"' >> "$GITHUB_OUTPUT"

--- a/.github/py-shiny/pytest-browsers/action.yaml
+++ b/.github/py-shiny/pytest-browsers/action.yaml
@@ -3,7 +3,7 @@ description: 'Trim down pytest browsers for any github event other than merge_gr
 outputs:
   browsers:
     description: 'pytest browsers to use'
-    value: ${{ steps.browsers.outputs.browser }}
+    value: ${{ steps.browsers.outputs.browsers }}
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches: ["main"]
   pull_request:
+  merge_group:
 
 jobs:
   build:
@@ -42,6 +43,7 @@ jobs:
           make quartodoc
 
       - name: Build site
+        if: github.event != 'merge_group'
         run: |
           cd docs
           make site
@@ -52,15 +54,14 @@ jobs:
         with:
           path: "docs/_site"
 
-
   deploy:
     if: github.ref == 'refs/heads/main'
     needs: build
 
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
+      pages: write # to deploy to Pages
+      id-token: write # to verify the deployment originates from an appropriate source
 
     # Deploy to the github-pages environment
     environment:

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -8,7 +8,7 @@ on:
   merge_group:
 
 jobs:
-  build:
+  build-docs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -43,7 +43,7 @@ jobs:
           make quartodoc
 
       - name: Build site
-        if: github.event != 'merge_group'
+        if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'docs')  }}
         run: |
           cd docs
           make site
@@ -56,7 +56,7 @@ jobs:
 
   deploy:
     if: github.ref == 'refs/heads/main'
-    needs: build
+    needs: build-docs
 
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -65,7 +65,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: ./.github/py-shiny/pytest-browers
+      - uses: ./.github/py-shiny/pytest-browsers
         id: browsers
       - name: Run End-to-End tests
         timeout-minutes: 20
@@ -105,7 +105,7 @@ jobs:
         run: |
           npm ci
 
-      - uses: ./.github/py-shiny/pytest-browers
+      - uses: ./.github/py-shiny/pytest-browsers
         id: browsers
       - name: Run example app tests
         timeout-minutes: 20

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -12,7 +12,7 @@ on:
     - cron: "0 8 * * *"
 
 jobs:
-  build:
+  check:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -70,6 +70,9 @@ jobs:
         id: browsers
         with:
           all-browsers: ${{ startsWith(github.head_ref, 'playwright') }}
+      - name: Display browser
+        shell: bash
+        run: echo '${{ steps.browsers.outputs.browsers }}'
       - name: Run End-to-End tests
         timeout-minutes: 20
         run: |
@@ -98,7 +101,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "18"
           cache: npm
@@ -208,7 +211,7 @@ jobs:
     name: "Deploy to PyPI"
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
-    needs: [build]
+    needs: [check]
     steps:
       - uses: actions/checkout@v4
       - name: "Set up Python 3.10"
@@ -264,7 +267,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "18"
           cache: npm

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -151,7 +151,7 @@ jobs:
 
   playwright-deploys:
     needs: [playwright-deploys-precheck]
-    if: github.event_name != 'release' && (github.event_name == 'push' || (github.event_name == 'pull_request' && startsWith(github.head_ref, 'deploy')))
+    if: github.event_name != 'release' && (github.event_name == 'push' || startsWith(github.head_ref, 'deploy'))
     # Only allow one `playwright-deploys` job to run at a time. (Independent of branch / PR)
     # Only one is allowed to run at a time because it is deploying to the same server location.
     concurrency: playwright-deploys
@@ -177,7 +177,7 @@ jobs:
         run: |
           make playwright-deploys SUB_FILE=". -vv"
 
-      - name: Deploy apps and run tests (on `push` or on `pull_request` w/ `deploy**` branch)
+      - name: Deploy apps and run tests (on `push` or `deploy**` branches)
         env:
           DEPLOY_APPS: "true"
           DEPLOY_CONNECT_SERVER_URL: "https://rsc.radixu.com/"
@@ -238,7 +238,7 @@ jobs:
 
   testrail-reporting-nightly:
     runs-on: ${{ matrix.os }}
-    if: ${{ github.event_name == 'schedule' || (github.event_name == 'pull_request' && startsWith(github.head_ref, 'testrail')) }}
+    if: ${{ github.event_name == 'schedule' || startsWith(github.head_ref, 'testrail') }}
     strategy:
       matrix:
         python-version:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches: ["main", "rc-*"]
   pull_request:
+  merge_group:
   release:
     types: [published]
   schedule:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -65,10 +65,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - uses: ./.github/py-shiny/pytest-browers
+        id: browsers
       - name: Run End-to-End tests
         timeout-minutes: 20
         run: |
-          make playwright-shiny SUB_FILE=". -vv"
+          make playwright-shiny SUB_FILE=". -vv" ${{ steps.browsers.outputs.browsers }}
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
@@ -103,10 +105,12 @@ jobs:
         run: |
           npm ci
 
+      - uses: ./.github/py-shiny/pytest-browers
+        id: browsers
       - name: Run example app tests
         timeout-minutes: 20
         run: |
-          make playwright-examples SUB_FILE=". -vv"
+          make playwright-examples SUB_FILE=". -vv" ${{ steps.browsers.outputs.browsers }}
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -65,8 +65,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: ./.github/py-shiny/pytest-browsers
+      - name: Determine browsers for testing
+        uses: ./.github/py-shiny/pytest-browsers
         id: browsers
+        with:
+          all-browsers: ${{ startsWith(github.head_ref, 'playwright') }}
       - name: Run End-to-End tests
         timeout-minutes: 20
         run: |
@@ -105,8 +108,11 @@ jobs:
         run: |
           npm ci
 
-      - uses: ./.github/py-shiny/pytest-browsers
+      - name: Determine browsers for testing
+        uses: ./.github/py-shiny/pytest-browsers
         id: browsers
+        with:
+          all-browsers: ${{ startsWith(github.head_ref, 'playwright') }}
       - name: Run example app tests
         timeout-minutes: 20
         run: |

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup py-shiny
         id: install
         uses: ./.github/py-shiny/setup
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup py-shiny
         uses: ./.github/py-shiny/setup
         with:
@@ -88,7 +88,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup py-shiny
         uses: ./.github/py-shiny/setup
         with:
@@ -129,7 +129,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup py-shiny
         uses: ./.github/py-shiny/setup
         with:
@@ -164,7 +164,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup py-shiny
         uses: ./.github/py-shiny/setup
         with:
@@ -204,7 +204,7 @@ jobs:
     if: github.event_name == 'release'
     needs: [build]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Set up Python 3.10"
         uses: actions/setup-python@v4
         with:
@@ -251,7 +251,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup py-shiny
         uses: ./.github/py-shiny/setup
         with:

--- a/.github/workflows/verify-js-built.yaml
+++ b/.github/workflows/verify-js-built.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches: ["main", "rc-*"]
   pull_request:
+  merge_group:
 
 jobs:
   verify_js_built:

--- a/.github/workflows/verify-js-built.yaml
+++ b/.github/workflows/verify-js-built.yaml
@@ -1,4 +1,4 @@
-name: Build
+name: Verify built assets
 
 on:
   push:

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ clean-js: FORCE
 
 # Default `SUB_FILE` to empty
 SUB_FILE:=
-
+PYTEST_BROWSERS:= --browser webkit --browser firefox --browser chromium
 install-playwright: FORCE
 	playwright install --with-deps
 
@@ -157,15 +157,15 @@ install-rsconnect: FORCE
 
 # end-to-end tests with playwright; (SUB_FILE="" within tests/playwright/shiny/)
 playwright-shiny: install-playwright
-	pytest tests/playwright/shiny/$(SUB_FILE)
+	pytest tests/playwright/shiny/$(SUB_FILE) $(PYTEST_BROWSERS)
 
 # end-to-end tests on deployed apps with playwright; (SUB_FILE="" within tests/playwright/deploys/)
 playwright-deploys: install-playwright install-rsconnect
-	pytest tests/playwright/deploys/$(SUB_FILE)
+	pytest tests/playwright/deploys/$(SUB_FILE) $(PYTEST_BROWSERS)
 
 # end-to-end tests on all py-shiny examples with playwright; (SUB_FILE="" within tests/playwright/examples/)
 playwright-examples: install-playwright
-	pytest tests/playwright/examples/$(SUB_FILE)
+	pytest tests/playwright/examples/$(SUB_FILE) $(PYTEST_BROWSERS)
 
 playwright-debug: install-playwright ## All end-to-end tests, chrome only, headed; (SUB_FILE="" within tests/playwright/)
 	pytest -c tests/playwright/playwright-pytest.ini tests/playwright/$(SUB_FILE)
@@ -175,10 +175,10 @@ playwright-show-trace: ## Show trace of failed tests
 
 # end-to-end tests with playwright and generate junit report
 testrail-junit: install-playwright install-trcli
-	pytest tests/playwright/shiny/$(SUB_FILE) --junitxml=report.xml
+	pytest tests/playwright/shiny/$(SUB_FILE) --junitxml=report.xml $(PYTEST_BROWSERS)
 
 coverage: FORCE ## check combined code coverage (must run e2e last)
-	pytest --cov-report term-missing --cov=shiny tests/pytest/ tests/playwright/shiny/$(SUB_FILE)
+	pytest --cov-report term-missing --cov=shiny tests/pytest/ tests/playwright/shiny/$(SUB_FILE) $(PYTEST_BROWSERS)
 	coverage html
 	$(BROWSER) htmlcov/index.html
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
 asyncio_mode=strict
 testpaths=tests/pytest/
-addopts = --strict-markers --durations=6 --durations-min=5.0 --browser webkit --browser firefox --browser chromium --numprocesses auto   --tracing=retain-on-failure --video=retain-on-failure
+; Note: Browsers are set within `./Makefile`
+addopts = --strict-markers --durations=6 --durations-min=5.0 --numprocesses auto --tracing=retain-on-failure --video=retain-on-failure


### PR DESCRIPTION
Must run all browser (`chrome`, `firefox`, `webkit`) tests when merging to `main` (event: `merge_group`). However, within PRs, only `chrome` will be used (event: `pull_request`).

Related: 
* https://medium.com/@kojoru/how-to-set-up-merge-queues-in-github-actions-59381e5f435a
* https://github.blog/changelog/2022-08-18-merge-group-webhook-event-and-github-actions-workflow-trigger/