### PR TITLE
Add shiny create option to choose from online template gallery

### DIFF
--- a/shiny/_main.py
+++ b/shiny/_main.py
@@ -483,6 +483,7 @@ app_template_choices = {
     "Dashboard": "dashboard",
     "Multi-page app with modules": "multi-page",
     "Custom JavaScript Component": "js-component",
+    "Choose from online gallery 🔗": "external-gallery",
 }
 
 # These are templates which produce a Python package and have content filled in at

--- a/shiny/_main.py
+++ b/shiny/_main.py
@@ -483,7 +483,7 @@ app_template_choices = {
     "Dashboard": "dashboard",
     "Multi-page app with modules": "multi-page",
     "Custom JavaScript Component": "js-component",
-    "Choose from online gallery 🔗": "external-gallery",
+    "Choose from the Shiny Templates website": "external-gallery",
 }
 
 # These are templates which produce a Python package and have content filled in at

--- a/shiny/_template_utils.py
+++ b/shiny/_template_utils.py
@@ -73,9 +73,15 @@ def template_query(
     # Define the control flow for the top level menu
     if template is None or template == "cancel":
         sys.exit(1)
+    elif template == "external-gallery":
+        url = "https://shiny.posit.co/py/templates"
+        print(f"Opening <{url}> in your browser.")
+        print("Choose a template and copy the `shiny create` command to use it.")
+        import webbrowser
+
+        webbrowser.open(url)
     elif template == "js-component":
         js_component_questions(dest_dir=dest_dir, package_name=package_name)
-        return
     elif template in package_template_choices.values():
         js_component_questions(template, dest_dir=dest_dir, package_name=package_name)
     else:

--- a/shiny/_template_utils.py
+++ b/shiny/_template_utils.py
@@ -80,8 +80,10 @@ def template_query(
         import webbrowser
 
         webbrowser.open(url)
+        sys.exit(0)
     elif template == "js-component":
         js_component_questions(dest_dir=dest_dir, package_name=package_name)
+        return
     elif template in package_template_choices.values():
         js_component_questions(template, dest_dir=dest_dir, package_name=package_name)
     else:


### PR DESCRIPTION
This PR adds another choice `shiny create` to choose from the [online gallery](https://shiny.posit.co/py/templates/)

<img width="868" alt="Screenshot 2024-04-02 at 3 29 50 PM" src="https://github.com/posit-dev/py-shiny/assets/1365941/ebc54fe6-b7fb-43ed-8776-bc4bbb4d9170">

And when chosen it opens your browser (along with a message)


