### PR TITLE
Fix panel_conditional examples

### DIFF
--- a/shiny/api-examples/panel_conditional/app-core.py
+++ b/shiny/api-examples/panel_conditional/app-core.py
@@ -11,7 +11,7 @@ app_ui = ui.page_fluid(
     ),
     ui.panel_conditional(
         "input.show && input.radio === 'select'",
-        ui.input_select("slider", None, ["A", "B", "C"]),
+        ui.input_select("select", None, ["A", "B", "C"]),
     ),
 )
 

--- a/shiny/api-examples/panel_conditional/app-express.py
+++ b/shiny/api-examples/panel_conditional/app-express.py
@@ -9,4 +9,4 @@ with ui.panel_conditional("input.show && input.radio === 'slider'"):
     ui.input_slider("slider", None, min=0, max=100, value=50)
 
 with ui.panel_conditional("input.show && input.radio === 'select'"):
-    ui.input_select("slider", None, ["A", "B", "C"])
+    ui.input_select("select", None, ["A", "B", "C"])


### PR DESCRIPTION
The `panel_conditional` examples are broken as can be seen in the [doc](https://shiny.posit.co/py/api/core/ui.panel_conditional.html) (the elements are always shown whatever the condition's value):

![image](https://github.com/posit-dev/py-shiny/assets/24455641/531a95c8-c510-4f14-a65b-6c2a29d908d2)

This is simply caused by the same id "slider" being used both for the `input_select` and the `input_slider`. Using different ids fixes the issue:

![image](https://github.com/posit-dev/py-shiny/assets/24455641/83dc146f-7948-4656-ae60-e1ab8912042d)
