### PR TITLE
test(deploy): Revert pinned `rsconnect` version in #1302

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ install-trcli: FORCE
 	$(if $(shell which trcli), @echo -n, $(shell pip install trcli))
 
 install-rsconnect: FORCE
-	pip install rsconnect-python
+	pip install git+https://github.com/rstudio/rsconnect-python.git#egg=rsconnect-python
 
 # end-to-end tests with playwright; (SUB_FILE="" within tests/playwright/shiny/)
 playwright-shiny: install-playwright


### PR DESCRIPTION
This reverts commit 2a19d8daee8565a6c4c7f316b2fd140088476f89.

Request: https://github.com/posit-dev/py-shiny/pull/1302#issuecomment-2050953967

Merge requirements:
- [x] https://github.com/rstudio/rsconnect-python/pull/579 is merged