### PR TITLE
test: remove exception swallower to make debug easier

### DIFF
--- a/tests/playwright/utils/deploy_utils.py
+++ b/tests/playwright/utils/deploy_utils.py
@@ -20,10 +20,10 @@ __all__ = (
 )
 
 # connect
-server_url = os.environ.get("DEPLOY_CONNECT_SERVER_URLE")
+server_url = os.environ.get("DEPLOY_CONNECT_SERVER_URL")
 api_key = os.environ.get("DEPLOY_CONNECT_SERVER_API_KEY")
 # shinyapps.io
-name = os.environ.get("DEPLOY_SHINYAPPS_NAMEE")
+name = os.environ.get("DEPLOY_SHINYAPPS_NAME")
 token = os.environ.get("DEPLOY_SHINYAPPS_TOKEN")
 secret = os.environ.get("DEPLOY_SHINYAPPS_SECRET")
 

--- a/tests/playwright/utils/deploy_utils.py
+++ b/tests/playwright/utils/deploy_utils.py
@@ -20,10 +20,10 @@ __all__ = (
 )
 
 # connect
-server_url = os.environ.get("DEPLOY_CONNECT_SERVER_URL")
+server_url = os.environ.get("DEPLOY_CONNECT_SERVER_URLE")
 api_key = os.environ.get("DEPLOY_CONNECT_SERVER_API_KEY")
 # shinyapps.io
-name = os.environ.get("DEPLOY_SHINYAPPS_NAME")
+name = os.environ.get("DEPLOY_SHINYAPPS_NAMEE")
 token = os.environ.get("DEPLOY_SHINYAPPS_TOKEN")
 secret = os.environ.get("DEPLOY_SHINYAPPS_SECRET")
 
@@ -94,7 +94,6 @@ def deploy_to_shinyapps(app_name: str, app_dir: str) -> str:
     # Deploy to shinyapps.io
     shinyapps_deploy = f"rsconnect deploy shiny {app_dir} --account {name} --token {token} --secret {secret} --title {app_name} --verbose"
     run_command(shinyapps_deploy)
-    run_command("exit 1")
 
     return f"https://{name}.shinyapps.io/{app_name}/"
 

--- a/tests/playwright/utils/deploy_utils.py
+++ b/tests/playwright/utils/deploy_utils.py
@@ -94,7 +94,6 @@ def deploy_to_shinyapps(app_name: str, app_dir: str) -> str:
     # Deploy to shinyapps.io
     shinyapps_deploy = f"rsconnect deploy shiny {app_dir} --account {name} --token {token} --secret {secret} --title {app_name} --verbose"
     run_command(shinyapps_deploy)
-
     return f"https://{name}.shinyapps.io/{app_name}/"
 
 

--- a/tests/playwright/utils/deploy_utils.py
+++ b/tests/playwright/utils/deploy_utils.py
@@ -94,6 +94,8 @@ def deploy_to_shinyapps(app_name: str, app_dir: str) -> str:
     # Deploy to shinyapps.io
     shinyapps_deploy = f"rsconnect deploy shiny {app_dir} --account {name} --token {token} --secret {secret} --title {app_name} --verbose"
     run_command(shinyapps_deploy)
+    run_command("exit 1")
+
     return f"https://{name}.shinyapps.io/{app_name}/"
 
 


### PR DESCRIPTION
Currently we swallow exceptions in order for secrets to not show up in the logs when a test fails.
If GitHub Actions proactively scrubs the secrets from the logs, we do not need this exception swallower step since it can make debugging deploys failure harder and only way to get around it is run those tests locally.

Verified it by intentionally causing the deploys to fail and checking the logs from GitHub Actions - 
```sh
subprocess.CalledProcessError: Command 'rsconnect content search --server None --api-key *** --title-contains express_page_sidebar' returned non-zero exit status 1.
```