### PR TITLE
fix(bootstrap): Include all files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* Fixed an issue that prevented Shiny from serving the `font.css` file referenced in Shiny's Bootstrap CSS file. (#1342)
+
 ### Other changes
 
 * `Session` is now an abstract base class, and `AppSession` is a concrete subclass of it. Also, `ExpressMockSession` has been renamed `ExpressStubSession` and is a concrete subclass of `Session`. (#1331)

--- a/shiny/ui/_html_deps_external.py
+++ b/shiny/ui/_html_deps_external.py
@@ -58,6 +58,7 @@ def bootstrap_deps(include_css: bool = True) -> list[HTMLDependency]:
         script={"src": "bootstrap.bundle.min.js"},
         stylesheet={"href": "bootstrap.min.css"} if include_css else None,
         meta={"name": "viewport", "content": "width=device-width, initial-scale=1"},
+        all_files=True,
     )
     deps = [jquery_deps(), dep]
     return deps


### PR DESCRIPTION
Adds `all_files=True` to the Bootstrap dependency so that the font files in the base Bootstrap theme are correctly included in the dependency. Without this, `font.css` and the font files aren't available in the browser but show up in `bootstrap.min.css`.

Noticed in https://github.com/posit-dev/py-shiny-site/pull/140.