### PR TITLE
Stop sending recalculated message immediately after persistent progress message

### DIFF
--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -1416,7 +1416,7 @@ class Outputs:
                     )
                     return
                 except SilentCancelOutputException:
-                    return
+                    pass
                 except SilentException:
                     session._outbound_message_queues.set_value(output_name, None)
                 except Exception as e:
@@ -1436,16 +1436,15 @@ class Outputs:
                         "type": None,
                     }
                     session._outbound_message_queues.set_error(output_name, err_message)
-                    return
-                finally:
-                    await session._send_message(
-                        {
-                            "recalculating": {
-                                "name": output_name,
-                                "status": "recalculated",
-                            }
+
+                await session._send_message(
+                    {
+                        "recalculating": {
+                            "name": output_name,
+                            "status": "recalculated",
                         }
-                    )
+                    }
+                )
 
             output_obs.on_invalidate(
                 lambda: require_real_session()._send_progress(

--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -1414,6 +1414,7 @@ class Outputs:
                     session._send_progress(
                         "binding", {"id": output_name, "persistent": True}
                     )
+                    # It's important to exit early here _without_ a recalculated message
                     return
                 except SilentCancelOutputException:
                     pass


### PR DESCRIPTION
Closes #1355. 

Seems it was an oversight in #907 that for `SilentOperationInProgressException`, we _don't_ want the `recalculated` message to be sent upon exit. For reference, that's what we do on the R side:

https://github.com/rstudio/shiny/blob/ecb591f/R/shiny.R#L1197-L1226

Note that this PR will unblock #1353, and hence #918 as well