### PR TITLE
Easy profiling option

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -114,6 +114,8 @@ doc =
     pydantic==1.10
     quartodoc==0.7.2
     griffe==0.33.0
+profile =
+    py-spy
 
 [options.packages.find]
 include = shiny, shiny.*


### PR DESCRIPTION
The idea is to add `--profile` to your `shiny run` command, and that will run Shiny under py-spy, then launch speedscope with the resulting trace.

## TODO

- [ ] On Windows, `sys.orig_argv` has two executables in the argv array (python.exe and shiny.exe), we just need the second. Why?
- [ ] Currently pass the profiling data to speedscope.app via URL hash, need to work around the limits of URL hash sizes.