### PR TITLE
Send busy/idle at the right times

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -93,6 +93,7 @@ test =
     folium
     palmerpenguins
     faicons
+    ridgeplot
 dev =
     black>=24.0
     flake8>=6.0.0

--- a/shiny/express/_stub_session.py
+++ b/shiny/express/_stub_session.py
@@ -119,6 +119,12 @@ class ExpressStubSession(Session):
     def _send_message_sync(self, message: dict[str, object]) -> None:
         return
 
+    def _increment_busy_count(self) -> None:
+        return
+
+    def _decrement_busy_count(self) -> None:
+        return
+
     def on_flush(
         self,
         fn: Callable[[], None] | Callable[[], Awaitable[None]],

--- a/shiny/reactive/_reactives.py
+++ b/shiny/reactive/_reactives.py
@@ -547,7 +547,7 @@ class Effect_:
             def _continue() -> None:
                 ctx.add_pending_flush(self._priority)
                 if self._session:
-                    self._session._send_message_sync({"busy": "busy"})
+                    self._session._increment_busy_count()
 
             if self._suspended:
                 self._on_resume = _continue
@@ -558,7 +558,7 @@ class Effect_:
             if not self._destroyed:
                 await self._run()
             if self._session:
-                self._session._send_message_sync({"busy": "idle"})
+                self._session._decrement_busy_count()
 
         ctx.on_invalidate(on_invalidate_cb)
         ctx.on_flush(on_flush_cb)

--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -471,6 +471,12 @@ class Session(ABC):
             namespaced when used with a session proxy.
         """
 
+    @abstractmethod
+    def _increment_busy_count(self) -> None: ...
+
+    @abstractmethod
+    def _decrement_busy_count(self) -> None: ...
+
 
 # ======================================================================================
 # AppSession
@@ -493,6 +499,7 @@ class AppSession(Session):
         self.id: str = id
         self._conn: Connection = conn
         self._debug: bool = debug
+        self._busy_count: int = 0
         self._message_handlers: dict[
             str,
             tuple[Callable[..., Awaitable[Jsonifiable]], Session],
@@ -785,11 +792,11 @@ class AppSession(Session):
     async def _handle_request(
         self, request: Request, action: str, subpath: Optional[str]
     ) -> ASGIApp:
-        self._send_message_sync({"busy": "busy"})
+        self._increment_busy_count()
         try:
             return await self._handle_request_impl(request, action, subpath)
         finally:
-            self._send_message_sync({"busy": "idle"})
+            self._decrement_busy_count()
 
     async def _handle_request_impl(
         self, request: Request, action: str, subpath: Optional[str]
@@ -1011,6 +1018,16 @@ class AppSession(Session):
             with session_context(self):
                 await self._flushed_callbacks.invoke()
 
+    def _increment_busy_count(self) -> None:
+        self._busy_count += 1
+        if self._busy_count == 1:
+            self._send_message_sync({"busy": "busy"})
+
+    def _decrement_busy_count(self) -> None:
+        self._busy_count -= 1
+        if self._busy_count == 0:
+            self._send_message_sync({"busy": "idle"})
+
     # ==========================================================================
     # On session ended
     # ==========================================================================
@@ -1190,6 +1207,12 @@ class SessionProxy(Session):
 
     async def send_custom_message(self, type: str, message: dict[str, object]) -> None:
         await self._parent.send_custom_message(type, message)
+
+    def _increment_busy_count(self) -> None:
+        self._parent._increment_busy_count()
+
+    def _decrement_busy_count(self) -> None:
+        self._parent._decrement_busy_count()
 
     def set_message_handler(
         self,

--- a/tests/playwright/examples/example_apps.py
+++ b/tests/playwright/examples/example_apps.py
@@ -33,7 +33,7 @@ def get_apps(path: str) -> typing.List[str]:
     return app_paths
 
 
-app_idle_wait = {"duration": 300, "timeout": 5 * 1000}
+app_idle_wait = {"duration": 300, "timeout": 30 * 1000}
 app_hard_wait: typing.Dict[str, int] = {
     "examples/brownian": 250,
     "examples/ui-func": 250,

--- a/tests/pytest/test_poll.py
+++ b/tests/pytest/test_poll.py
@@ -39,6 +39,12 @@ class OnEndedSessionCallbacks:
     def _send_message_sync(self, message: Dict[str, object]) -> None:
         pass
 
+    def _increment_busy_count(self) -> None:
+        pass
+
+    def _decrement_busy_count(self) -> None:
+        pass
+
     async def __aenter__(self):
         self._session_context.__enter__()
 


### PR DESCRIPTION
Previously, busy/idle messages were sent for each output/effect. That isn't correct, those messages are only supposed to be sent when the session as a whole becomes busy/idle.

Fixes #1379 