### PR TITLE
fix(selectize): Accept jsonifiable values in `options` dictionary

### DIFF
--- a/shiny/ui/_input_select.py
+++ b/shiny/ui/_input_select.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from shiny.types import Jsonifiable
+from ..types import Jsonifiable
 
 __all__ = (
     "input_select",

--- a/shiny/ui/_input_select.py
+++ b/shiny/ui/_input_select.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from shiny.types import Jsonifiable
+
 __all__ = (
     "input_select",
     "input_selectize",
@@ -57,7 +59,7 @@ def input_selectize(
     multiple: bool = False,
     width: Optional[str] = None,
     remove_button: Optional[bool] = None,
-    options: Optional[dict[str, str | float | JSEval]] = None,
+    options: Optional[dict[str, Jsonifiable | JSEval]] = None,
 ) -> Tag:
     """
     Create a select list that can be used to choose a single or multiple items from a
@@ -137,7 +139,7 @@ def input_select(
     width: Optional[str] = None,
     size: Optional[str] = None,
     remove_button: Optional[bool] = None,
-    options: Optional[dict[str, str | float | JSEval]] = None,
+    options: Optional[dict[str, Jsonifiable | JSEval]] = None,
 ) -> Tag:
     """
     Create a select list that can be used to choose a single or multiple items from a


### PR DESCRIPTION
This updates the type annotation for `input_selectize(options=)` where dictionary values can be `Jsonifiable` objects.

This doesn't affect behavior, just removes the red squiggle on apps like this

![image](https://github.com/posit-dev/py-shiny/assets/5420529/57a32e2a-283c-4d8a-aa50-c3754f5ecf4c)

```python
from shiny.express import input, render, ui

ui.input_selectize(
    "filter",
    "Filter by",
    choices={
        "": "",
        "first": "First Choice",
        "second": "Second Choice",
    },
    options={
        # Previously we'd need to do this to avoid type errors
        # "plugins": ui.js_eval("['clear_button']")
        "plugins": ["clear_button"]
    },
)


@render.text
def txt():
    if input.filter():
        return f"Data is filtered by your {input.filter()} choice."
    else:
        return "The data is not fitered."
```