### PR TITLE
Yield to give "synchronous" writes a chance to complete

### DIFF
--- a/shiny/reactive/_reactives.py
+++ b/shiny/reactive/_reactives.py
@@ -15,6 +15,7 @@ __all__ = (
     "event",
 )
 
+import asyncio
 import functools
 import traceback
 import warnings
@@ -575,6 +576,10 @@ class Effect_:
             try:
                 with ctx():
                     await self._fn()
+
+                    # Yield so that messages can be sent to the client if necessary.
+                    # https://github.com/posit-dev/py-shiny/issues/1381
+                    await asyncio.sleep(0)
             except SilentException:
                 # It's OK for SilentException to cause an Effect to stop running
                 pass

--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 __all__ = ("Session", "Inputs", "Outputs")
 
+import asyncio
 import contextlib
 import dataclasses
 import enum
@@ -652,6 +653,12 @@ class AppSession(Session):
                             raise ProtocolError(
                                 f"Unrecognized method {message_obj['method']}"
                             )
+
+                        # Progress messages (of the "{binding: {id: xxx}}"" variety) may
+                        # have queued up at this point; let them drain before we send
+                        # the next message.
+                        # https://github.com/posit-dev/py-shiny/issues/1381
+                        await asyncio.sleep(0)
 
                         self._request_flush()
 

--- a/tests/pytest/mocktime.py
+++ b/tests/pytest/mocktime.py
@@ -67,6 +67,16 @@ class MockTime:
         self._i += 1
         # Oldest first
         self._sleepers.sort()
+
+        # This is necessary for some tests that call logic that internally awaits on
+        # asyncio.sleep(0). Without this, they hang.
+        #
+        # Another potential workaround would've been to check if delay <= 0 and just
+        # return. But this solution has the nice property of actually yielding control
+        # (I think...!), which is the whole point of asyncio.sleep(0).
+        if not self._is_advancing:
+            await self.advance_time(0)
+
         await wake.wait()
 
 


### PR DESCRIPTION
Fixes #1381

During a synchronous phase of the event loop, we can build up network messages that need to get to the client. Because writes are naturally async, we do some weird stuff to semi-execute them which usually but doesn't always succeed. In the case where the write doesn't succeed, they're held at least until the next time the current task yields; before this commit, that could be a long time indeed, if the app is written synchronously (as about 100% of Shiny apps are).

This change yields to the event loop after invalidating the session, which gives the writes a chance to complete. This should take care of the observed problem of progress messages not making it (issue #1381). It also yields after each successful `@effect`, in case insert_ui, custom messages, etc. were sent during the `@effect`, and also so outputs' automatic progress messages can propagate to the client.

## Repro steps

Reproduced on Windows, Python 3.11 and 3.12. (Did NOT reproduce on macOS.)

- `shiny run examples\busy_indicators\app.py` -- do NOT use the `--reload` flag nor the VS Code play button
- After the app loads, press the button

Without this fix, only one box shows progress. With this fix, they all do.