### PR TITLE
Don't use uvloop

### DIFF
--- a/shiny/_main.py
+++ b/shiny/_main.py
@@ -364,6 +364,9 @@ def run_app(
         app_dir=app_dir,
         factory=factory,
         lifespan="on",
+        # Don't allow shiny to use uvloop!
+        # https://github.com/posit-dev/py-shiny/issues/1373
+        loop="asyncio",
         **reload_args,  # pyright: ignore[reportArgumentType]
         **kwargs,
     )


### PR DESCRIPTION
Fixes #1373

There's a general problem in Shiny for Python where we start asynchronous writes to network connections, but then call code written by the Shiny app author which may block for arbitrary lengths of time, without yielding to the Python event loop. This puts us a little outside of the sweet spot of Python async (ideally you'd just not be blocking the main thread very often).

With asyncio, we generally get away with this because the kinds of messages we send without yielding are generally pretty small, and they get sent immediately. What we observed with uvloop is that it doesn't really attempt to do anything about theses writes until you yield. So the fix in this PR makes it so we never use uvloop for Shiny.

This issue is harder to repro than it was because of #1388, which is already pretty effective at masking the problem. But given how bad the uvloop behavior was compared to asyncio, I still think it's a good idea to apply this change as well.