### PR TITLE
In ExpressStubSession, set 'app' and 'id'

### DIFF
--- a/docs/_quartodoc-express.yml
+++ b/docs/_quartodoc-express.yml
@@ -137,6 +137,10 @@ quartodoc:
         - express.ui.modal_remove
         - express.ui.modal_button
         - express.ui.Progress          # uses class.rst
+    - title: Modules
+      desc: ""
+      contents:
+        - express.module
     - title: UI panels
       desc: Visually group together a section of UI components.
       contents:

--- a/shiny/api-examples/express_module/app-express.py
+++ b/shiny/api-examples/express_module/app-express.py
@@ -1,0 +1,25 @@
+from shiny import reactive
+from shiny.express import module, render, ui
+
+
+@module
+def counter(input, output, session, starting_value: int = 0):
+    count = reactive.value(starting_value)
+
+    ui.input_action_button("btn", "Increment")
+
+    with ui.div():
+
+        @render.express
+        def current_count():
+            count()
+
+    @reactive.effect
+    @reactive.event(input.btn)
+    def increment():
+        count.set(count() + 1)
+
+
+counter("one")
+ui.hr()
+counter("two")

--- a/shiny/express/_module.py
+++ b/shiny/express/_module.py
@@ -1,6 +1,7 @@
 import functools
 from typing import Callable, TypeVar
 
+from .._docstring import add_example
 from .._typing_extensions import Concatenate, ParamSpec
 from ..module import Id
 from ..session._session import Inputs, Outputs, Session
@@ -14,6 +15,7 @@ R = TypeVar("R")
 __all__ = ("module",)
 
 
+@add_example(ex_dir="../api-examples/express_module")
 def module(
     fn: Callable[Concatenate[Inputs, Outputs, Session, P], R]
 ) -> Callable[Concatenate[Id, P], R]:

--- a/shiny/express/_stub_session.py
+++ b/shiny/express/_stub_session.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import textwrap
 from typing import TYPE_CHECKING, Awaitable, Callable, Literal, Optional
 
 from htmltools import TagChild
@@ -10,8 +9,6 @@ from ..session import Inputs, Outputs, Session
 from ..session._session import SessionProxy
 
 if TYPE_CHECKING:
-    from .._app import App
-    from .._typing_extensions import Never
     from ..session._session import DownloadHandler, DynamicRouteHandler, RenderedDeps
     from ..types import Jsonifiable
     from ._run import AppOpts
@@ -30,6 +27,10 @@ class ExpressStubSession(Session):
 
     def __init__(self, ns: ResolvedId = Root):
         self.ns = ns
+        # Setting self.app to None works for our uses, though in the future it may be
+        # necessary to also create a ExpressStubApp class to be a placeholder.
+        self.app = None  # pyright: ignore
+        self.id = "express_stub_session"
         self.input = Inputs({})
         self.output = Outputs(self, self.ns, outputs={})
 
@@ -45,22 +46,6 @@ class ExpressStubSession(Session):
 
     def is_stub_session(self) -> Literal[True]:
         return True
-
-    @property
-    def id(self) -> str:
-        self._not_implemented("id")
-
-    @id.setter
-    def id(self, value: str) -> None:  # pyright: ignore
-        self._not_implemented("id")
-
-    @property
-    def app(self) -> App:
-        self._not_implemented("app")
-
-    @app.setter
-    def app(self, value: App) -> None:  # pyright: ignore
-        self._not_implemented("app")
 
     async def close(self, code: int = 1001) -> None:
         return
@@ -153,14 +138,3 @@ class ExpressStubSession(Session):
         encoding: str = "utf-8",
     ) -> Callable[[DownloadHandler], None]:
         return lambda x: None
-
-    def _not_implemented(self, name: str) -> Never:
-        raise NotImplementedError(
-            textwrap.dedent(
-                f"""
-            The session attribute `{name}` is not yet available for use. Since this code
-            will run again when the session is initialized, you can use `if not session.is_stub_session():`
-            to only run this code when the session is established.
-        """
-            )
-        )


### PR DESCRIPTION
This fixes a problem with using modules in Shiny Express. Prior to the change, this app would raise an error; after the change, it works:

```py
from shiny import reactive
from shiny.express import module, render, ui


@module
def counter(input, output, session, starting_value: int=0):
    count = reactive.value(starting_value)

    ui.input_action_button("btn", "Increment")

    with ui.div():

        @render.express
        def current_count():
            count()

    @reactive.effect
    @reactive.event(input.btn)
    def increment():
        count.set(count() + 1)


counter("one")
ui.hr()
counter("two")
```

