### PR TITLE
Fix API reference generation (quartodoc)

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -46,7 +46,7 @@ dev-shinylive: $(PYBIN)  ## Install development version of shinylive
 	$(PYBIN)/pip install https://github.com/posit-dev/py-shinylive/tarball/main
 
 deps: $(PYBIN) dev-htmltools dev-shinylive ## Install build dependencies
-	$(PYBIN)/pip install --force-reinstall -v "pip<24.0"
+	$(PYBIN)/pip install pip --upgrade
 	$(PYBIN)/pip install ..[doc]
 
 quartodoc: quartodoc_build_core quartodoc_build_express quartodoc_post ## Build quartodocs for express and core

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -46,7 +46,7 @@ dev-shinylive: $(PYBIN)  ## Install development version of shinylive
 	$(PYBIN)/pip install https://github.com/posit-dev/py-shinylive/tarball/main
 
 deps: $(PYBIN) dev-htmltools dev-shinylive ## Install build dependencies
-	$(PYBIN)/pip install pip --upgrade
+	$(PYBIN)/pip install --force-reinstall -v "pip<24.0"
 	$(PYBIN)/pip install -e ..[doc]
 
 quartodoc: quartodoc_build_core quartodoc_build_express quartodoc_post ## Build quartodocs for express and core

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -47,7 +47,7 @@ dev-shinylive: $(PYBIN)  ## Install development version of shinylive
 
 deps: $(PYBIN) dev-htmltools dev-shinylive ## Install build dependencies
 	$(PYBIN)/pip install --force-reinstall -v "pip<24.0"
-	$(PYBIN)/pip install -e ..[doc]
+	$(PYBIN)/pip install ..[doc]
 
 quartodoc: quartodoc_build_core quartodoc_build_express quartodoc_post ## Build quartodocs for express and core
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -114,8 +114,8 @@ doc =
     tabulate
     shinylive
     pydantic==1.10
-    quartodoc
-    griffe
+    quartodoc==0.7.2
+    griffe==0.33.0
 
 [options.packages.find]
 include = shiny, shiny.*

--- a/setup.cfg
+++ b/setup.cfg
@@ -114,8 +114,8 @@ doc =
     tabulate
     shinylive
     pydantic==1.10
-    quartodoc==0.7.2
-    griffe==0.33.0
+    quartodoc
+    griffe
 
 [options.packages.find]
 include = shiny, shiny.*


### PR DESCRIPTION
This PR fixes `make docs`

<details>
<summary>Thanks to some help from @machow:</summary>

Hmmm... debugging with

```
from quartodoc import get_object

get_object("shiny:ui.page_sidebar", dynamic=True)
```

When I go up and print out the griffe object trying to get ui, I see this:

```
ipdb> !self
Module([PosixPath('/Users/machow/repos/py-shiny/venv/bin/shiny')])
```

But I feel like that's not the right path for shiny. I wonder if there's some kind of venv thing that's putting this path too early or something... here's my sys.path

```
['/Users/machow/repos/py-shiny/venv/bin', '/Users/machow/.pyenv/versions/3.12.3/lib/python312.zip', '/Users/machow/.pyenv/versions/3.12.3/lib/python3.12', '/Users/machow/.pyenv/versions/3.12.3/lib/python3.12/lib-dynload', '', '/Users/machow/repos/py-shiny/venv/lib/python3.12/site-packages', '__editable__.shiny-0.9.0.9000.finder.__path_hook__']
```

idk if bin was always there (and it makes sense it would be early in the path), but I suspect if it weren't in the path then it would find what it needed in site-packages

It's also possible there's a pip issue going on, since there have been issues with editable installs in pip in the past, so I wonder if the passing one uses an earlier version of pip, if locking to that would fix

</details>