### PR TITLE
chore(CI): Fix failing CI tests

### DIFF
--- a/shiny/express/_run.py
+++ b/shiny/express/_run.py
@@ -130,9 +130,7 @@ def run_express(file: Path) -> Tag | TagList:
                 )
             else:
                 exec(
-                    compile(
-                        ast.Interactive([node], type_ignores=[]), file_path, "single"
-                    ),
+                    compile(ast.Interactive([node]), file_path, "single"),
                     var_context,
                     var_context,
                 )


### PR DESCRIPTION
Fixes:
* Remove extra param `type_ignores` from `ast.Interactive` call
	* Added in https://github.com/posit-dev/py-shiny/pull/767/files#diff-8c4d6194dce915462e220ab012cb9a00199777d2176077a7b5669215009a0e67R142. 
	* Not found in type definition: https://docs.python.org/3/library/ast.html#ast.Interactive
	   > `class ast.Interactive(body)`
	* But is found in `ast.Module` in lines above
	   > `class ast.Module(body, type_ignores)`