### PR TITLE
Use `output_code()` and `render.code()`

### DIFF
--- a/examples/dataframe/app.py
+++ b/examples/dataframe/app.py
@@ -31,7 +31,7 @@ def app_ui(req):
         ui.input_switch("fullwidth", "Take full width", True),
         ui.output_data_frame("grid"),
         ui.panel_fixed(
-            ui.output_text_verbatim("detail"),
+            ui.output_code("detail"),
             right="10px",
             bottom="10px",
         ),
@@ -97,7 +97,7 @@ def server(input: Inputs, output: Outputs, session: Session):
         df_copy.iat[edit["row"], edit["col"]] = edit["new_value"]
         df.set(df_copy)
 
-    @render.text
+    @render.code
     def detail():
         selected_rows = (grid.cell_selection() or {}).get("rows", ())
         if len(selected_rows) > 0:

--- a/examples/express/accordion_app.py
+++ b/examples/express/accordion_app.py
@@ -10,7 +10,7 @@ with ui.accordion(open=["Panel 1", "Panel 2"]):
 
     with ui.accordion_panel("Panel 2"):
 
-        @render.text
+        @render.code
         def txt():
             return f"n = {input.n()}"
 

--- a/examples/express/basic_app.py
+++ b/examples/express/basic_app.py
@@ -4,6 +4,6 @@ from shiny.express import input, ui
 ui.input_slider("n", "N", 1, 100, 50)
 
 
-@render.text()
+@render.code()
 def txt():
     return f"n = {input.n()}"

--- a/examples/express/hold_app.py
+++ b/examples/express/hold_app.py
@@ -18,11 +18,11 @@ ui.hr()
 # `ui.hold()` can be used to just suppress output
 with ui.hold():
 
-    @render.text()
+    @render.code()
     def txt():
         return f"Slider value: {input.n()}"
 
 
 ui.input_slider("n", "N", 1, 100, 50)
 
-shiny.ui.output_text("txt", inline=True)
+shiny.ui.output_code("txt", inline=True)

--- a/examples/express/shared_app.py
+++ b/examples/express/shared_app.py
@@ -25,12 +25,12 @@ def _():
     shared.rv.set(input.n())
 
 
-@render.text
+@render.code
 def rv_value():
     return f"shared.rv() = {shared.rv()}"
 
 
-@render.text
+@render.code
 def text_data():
     return "shared.data = " + str(shared.data)
 

--- a/examples/headers/app.py
+++ b/examples/headers/app.py
@@ -2,14 +2,14 @@ from shiny import App, Inputs, Outputs, Session, render, ui
 
 app_ui = ui.page_fluid(
     ui.h3("HTTP request headers"),
-    ui.output_text_verbatim("headers", placeholder=True),
+    ui.output_code("headers", placeholder=True),
     ui.h3("User and groups"),
-    ui.output_text_verbatim("user_groups", placeholder=True),
+    ui.output_code("user_groups", placeholder=True),
 )
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @render.text
+    @render.code
     def headers():
         s = ""
         for key, value in session.http_conn.headers.items():
@@ -17,7 +17,7 @@ def server(input: Inputs, output: Outputs, session: Session):
 
         return s
 
-    @render.text
+    @render.code
     def user_groups():
         return f"session.user: {session.user}\nsession.groups: {session.groups}"
 

--- a/examples/moduleapp/app.py
+++ b/examples/moduleapp/app.py
@@ -9,7 +9,7 @@ def counter_ui(label: str = "Increment counter") -> ui.TagChild:
     return ui.card(
         ui.h2("This is " + label),
         ui.input_action_button(id="button", label=label),
-        ui.output_text_verbatim(id="out"),
+        ui.output_code(id="out"),
     )
 
 
@@ -24,7 +24,7 @@ def counter_server(
     def _():
         count.set(count() + 1)
 
-    @render.text
+    @render.code
     def out() -> str:
         return f"Click count is {count()}"
 

--- a/examples/typed_inputs/app.py
+++ b/examples/typed_inputs/app.py
@@ -8,9 +8,9 @@ app_ui = ui.page_fluid(
     ui.input_numeric("n", "N", 20),
     ui.input_numeric("n2", "N2", 50),
     ui.input_checkbox("checkbox", "Checkbox", True),
-    ui.output_text_verbatim("txt", placeholder=True),
-    ui.output_text_verbatim("txt2", placeholder=True),
-    ui.output_text_verbatim("txt3", placeholder=True),
+    ui.output_code("txt", placeholder=True),
+    ui.output_code("txt2", placeholder=True),
+    ui.output_code("txt3", placeholder=True),
 )
 
 
@@ -42,19 +42,19 @@ def server(input: Inputs, output: Outputs, session: Session):
     # thinks the return type of input.n() is Any, so we don't get type checking here.
     # The function is returning the wrong value here: it returns an int instead of a
     # string, but this error is not flagged.
-    @render.text
+    @render.code
     async def txt():
         return input.n() * 2
 
     # In contrast, input.n2() is declared to return an int, so the type check does flag
-    # this error -- the `render.text()` is underlined in red.
-    @render.text
+    # this error -- the `render.code()` is underlined in red.
+    @render.code
     async def txt2():
         return input.n2() * 2
 
     # This is a corrected version of the function above. It returns a string, and is not
     # marked in red.
-    @render.text
+    @render.code
     async def txt3():
         return str(input.n2() * 2)
 


### PR DESCRIPTION
This PR updates examples to switch from `output_text_verbatim` and `render.text` to `output_code` and `render.code`.