### PR TITLE
feat: Use hash of reactive value object to determine if it has changed

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,7 @@ install_requires =
     # starlette. For more information, see:
     # https://github.com/posit-dev/py-shiny/issues/1114#issuecomment-1942757757
     python-multipart>=0.0.7;platform_system!="Emscripten"
+    xxhash>=3.4.1
 tests_require =
     pytest>=3
 zip_safe = False

--- a/shiny/reactive/_reactives.py
+++ b/shiny/reactive/_reactives.py
@@ -17,6 +17,7 @@ __all__ = (
 
 import asyncio
 import functools
+import pickle
 import traceback
 import warnings
 from typing import (
@@ -30,17 +31,27 @@ from typing import (
     overload,
 )
 
+from xxhash import xxh32_hexdigest
+
 from .. import _utils
 from .._docstring import add_example
 from .._utils import is_async_callable, run_coro_sync
 from .._validation import req
-from ..types import MISSING, MISSING_TYPE, ActionButtonValue, SilentException
+from ..types import MISSING, MISSING_TYPE, ActionButtonValue, Any, SilentException
 from ._core import Context, Dependents, ReactiveWarning, isolate
 
 if TYPE_CHECKING:
     from .. import Session
 
 T = TypeVar("T")
+
+
+def is_immutable(x: Any) -> bool:
+    return isinstance(x, (int, float, str, tuple, frozenset, bool))
+
+
+def hash_digest(x: Any) -> str:
+    return xxh32_hexdigest(pickle.dumps(x, protocol=pickle.HIGHEST_PROTOCOL))
 
 
 # ==============================================================================
@@ -116,6 +127,7 @@ class Value(Generic[T]):
         self._read_only: bool = read_only
         self._value_dependents: Dependents = Dependents()
         self._is_set_dependents: Dependents = Dependents()
+        self._hash: str | None = hash_digest(value) if not is_immutable(value) else None
 
     def __call__(self) -> T:
         return self.get()
@@ -172,14 +184,22 @@ class Value(Generic[T]):
     # The ._set() method allows setting read-only Value objects. This is used when the
     # Value is part of a session.Inputs object, and the session wants to set it.
     def _set(self, value: T) -> bool:
-        if self._value is value:
+        value_hash = None
+        if is_immutable(value) and value == self._value:
             return False
+        elif isinstance(self._value, MISSING_TYPE) and isinstance(value, MISSING_TYPE):
+            return False
+        else:
+            value_hash = hash_digest(value)
+            if value_hash == self._hash:
+                return False
 
         if isinstance(self._value, MISSING_TYPE) != isinstance(value, MISSING_TYPE):
             self._is_set_dependents.invalidate()
 
         self._value = value
         self._value_dependents.invalidate()
+        self._hash = value_hash
         return True
 
     def unset(self) -> None:


### PR DESCRIPTION
Starting a PR to help the discussion we've had around `reactive.value` objects and mutability. 

## Before - Reactivity with mutable objects

The key problem can be seen in the example from [Reactivity | Mutable objects](https://shiny.posit.co/py/docs/reactive-mutable.html#example-1-lack-of-reactive-invalidation). In this example, currently, even if you call `.set()` on a reactive object, if the object was mutated in place `.set()` doesn't invalidate reactivity because the new value and the current value are already the same.

```python
from shiny import reactive
from shiny.express import input, render, ui

ui.input_numeric("x", "Enter a value to add to the list:", 1)
ui.input_action_button("submit", "Add Value")


@render.code
def out():
    return f"Values: {user_provided_values()}"


# Stores all the values the user has submitted so far
user_provided_values = reactive.value([])


@reactive.effect
@reactive.event(input.submit)
def add_value_to_list():
    # WATCHOUT! This doesn't work as expected!
    values = user_provided_values()
    values.append(input.x())
    user_provided_values.set(values)
```

![Kapture 2024-05-27 at 14 55 03](https://github.com/posit-dev/py-shiny/assets/5420529/8eecc173-94eb-40bc-84ec-3bacb12206d6)


The best approach for updating the reactive value is to create a new instance of the reactive value, e.g.

```
@reactive.effect
@reactive.event(input.submit)
def add_value_to_list():
    values = user_provided_values()
    user_provided_values.set([*values, input.x()])
```

This works well for lists -- once you become aware of the problem, of course -- and dictionaries, but is easy to run into with other mutable objects that might be harder to copy.

## After -- Compare new (mutable object) values by hash

This PR uses xxHash to hash mutable objects to then compare the new value with the hash of the old value when `.set()` was last called. After this change the example above works as most people would expect.

![Kapture 2024-05-27 at 14 55 50](https://github.com/posit-dev/py-shiny/assets/5420529/69853c93-684b-4261-9607-e6d85d9b9aad)
