### PR TITLE
chore: update shiny-vscode extension ID

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
 	"recommendations": [
-    "posit.shiny-python",
+    "posit.shiny",
 		"esbenp.prettier-vscode",
     "ms-python.black-formatter",
 	]


### PR DESCRIPTION
We've moved the `Posit.shiny-python` extension to `Posit.shiny`. 

See https://shiny.posit.co/blog/posts/shiny-vscode-1.0.0/ for more details about the updates in this release.