### PR TITLE
Add setuptools as an install requirement in Python 3.12 and above

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,7 @@ install_requires =
     # starlette. For more information, see:
     # https://github.com/posit-dev/py-shiny/issues/1114#issuecomment-1942757757
     python-multipart>=0.0.7;platform_system!="Emscripten"
+    setuptools;python_version>="3.12"
 tests_require =
     pytest>=3
 zip_safe = False


### PR DESCRIPTION
Our CI is currently failing since Python 3.12 no longer pre-installs setuptools in virtual environments created with venv.

https://docs.python.org/3/whatsnew/3.12.html