### PR TITLE
`make install` shouldn't assume it has `setuptools`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,6 +189,7 @@ release: dist ## package and upload a release
 	twine upload dist/*
 
 dist: clean ## builds source and wheel package
+	pip install setuptools
 	python3 setup.py sdist
 	python3 setup.py bdist_wheel
 	ls -l dist


### PR DESCRIPTION
`make dist` (which is required for `make install`) currently assumes it has setuptools, but that is no longer the case with Python 3.12.

Related #1435