### PR TITLE
Resolve path to file when running Shiny Express apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* Fixed #1440: When a Shiny Express app with a `www/` subdirectory was deployed to shinyapps.io or a Connect server, it would not start correctly. (#1442)
+
 ### Other changes
 
 ## [0.10.2] - 2024-05-28

--- a/shiny/express/_run.py
+++ b/shiny/express/_run.py
@@ -43,6 +43,8 @@ def wrap_express_app(file: Path) -> App:
         A :class:`shiny.App` object.
     """
 
+    file = file.resolve()
+
     try:
         globals_file = file.parent / "globals.py"
         if globals_file.is_file():


### PR DESCRIPTION
This closes #1440.

I was able to reproduce the problem on a Connect server, and then test that it was fixed with this change.