### PR TITLE
Make sure that `Id` type is kept in type stub

### DIFF
--- a/shiny/module.py
+++ b/shiny/module.py
@@ -20,6 +20,9 @@ if TYPE_CHECKING:
 P = ParamSpec("P")
 R = TypeVar("R")
 
+# Ensure that Id type is not stripped out from .pyi file when generating type stubs
+_: Id  # type: ignore
+
 
 @no_example()
 def ui(fn: Callable[P, R]) -> Callable[Concatenate[str, P], R]:


### PR DESCRIPTION
Previously, when generating type stubs with pyright, the `Id` type would get stripped out of module.py because it was only used inside of functions in the file. This causes the pyright/pylance LSP to report the type as `Unknown` instead of as `Id`.

<img width="765" alt="image" src="https://github.com/posit-dev/py-shiny/assets/86978/e9b13dd8-42d8-422a-98ac-b38d3cb2995c">


After this change, the `Id` type is kept in `module.py`, and the LSP correctly reports the type as `Id` instead of `Unknown`.