### PR TITLE
chore(lint): Set pyright version to 1.1.365 to avoid error in 3.12 checks

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -101,7 +101,7 @@ dev =
     flake8>=6.0.0
     flake8-bugbear>=23.2.13
     isort>=5.10.1
-    pyright>=1.1.348
+    pyright==1.1.365 # must be larger than 1.1.366; https://github.com/microsoft/pyright/issues/8087
     pre-commit>=2.15.0
     wheel
     matplotlib


### PR DESCRIPTION
Related: https://github.com/microsoft/pyright/issues/8087