### PR TITLE
Use `np.nan`

### DIFF
--- a/docs/_renderer.py
+++ b/docs/_renderer.py
@@ -280,7 +280,9 @@ def check_if_missing_expected_example(el, converted):
         return
 
     def is_no_ex_decorator(x):
-        if x == "no_example()":
+        # With griffe<0.42.0, it kept parentheses on decorators, but as of 0.42.0, it
+        # removes them. At some point in the future we can just use the no-parens case.
+        if x == "no_example()" or x == "no_example":
             return True
 
         no_ex_decorators = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -114,9 +114,9 @@ doc =
     jupyter_client < 8.0.0
     tabulate
     shinylive
-    pydantic==1.10
-    quartodoc==0.7.2
-    griffe==0.33.0
+    pydantic>=2.7.4
+    quartodoc==0.7.5
+    griffe
 
 [options.packages.find]
 include = shiny, shiny.*

--- a/shiny/plotutils.py
+++ b/shiny/plotutils.py
@@ -225,7 +225,7 @@ def near_points(
     # For no current coordinfo
     if coordinfo is None:
         if add_dist:
-            new_df["dist"] = np.NaN
+            new_df["dist"] = np.nan
 
         if all_rows:
             new_df["selected_"] = False


### PR DESCRIPTION
In numpy 2.0, they removed `np.NaN`. This PR switches to `np.nan` instead, which is available at least as far back as numpy 1.15, according to the docs.

https://numpy.org/doc/1.15/reference/constants.html#numpy.nan