### PR TITLE
chore: Use `np.nan` instead of `np.NaN`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -107,7 +107,7 @@ dev =
     matplotlib
     pandas
     pandas-stubs
-    numpy>=2.0.0
+    numpy
     shinyswatch>=0.2.4
 doc =
     jupyter

--- a/setup.cfg
+++ b/setup.cfg
@@ -107,7 +107,7 @@ dev =
     matplotlib
     pandas
     pandas-stubs
-    numpy
+    numpy>=2.0.0
     shinyswatch>=0.2.4
 doc =
     jupyter

--- a/shiny/plotutils.py
+++ b/shiny/plotutils.py
@@ -225,7 +225,7 @@ def near_points(
     # For no current coordinfo
     if coordinfo is None:
         if add_dist:
-            new_df["dist"] = np.NaN
+            new_df["dist"] = np.nan
 
         if all_rows:
             new_df["selected_"] = False


### PR DESCRIPTION
Related: https://github.com/numpy/numpy/pull/24376 ; (Removes `np.NaN` for v2.0.0 release)