### PR TITLE
fix(test): Fix failing shinyapps.io deploy test

### DIFF
--- a/tests/playwright/deploys/plotly/rsconnect-python/plotly.json
+++ b/tests/playwright/deploys/plotly/rsconnect-python/plotly.json
@@ -4,7 +4,7 @@
         "app_url": "https://testing-apps.shinyapps.io/example_deploy_app_a1/",
         "app_id": 10800241,
         "app_guid": null,
-        "title": "example_deploy_app_A",
+        "title": "example_deploy_app_a1",
         "app_mode": "python-shiny",
         "app_store_version": 1
     }

--- a/tests/playwright/deploys/plotly/test_plotly_app.py
+++ b/tests/playwright/deploys/plotly/test_plotly_app.py
@@ -8,7 +8,7 @@ from utils.deploy_utils import (
 )
 
 TIMEOUT = 2 * 60 * 1000
-app_url = create_deploys_app_url_fixture("example_deploy_app_A")
+app_url = create_deploys_app_url_fixture("example_deploy_app_a1")
 
 
 @skip_if_not_chrome


### PR DESCRIPTION
The shinyapps.io deploy test for the `plotly` app was failing because of some issue with the existing app on shinyapps.io.
When navigating to the url, the app was stuck loading.
![Screenshot 2024-06-18 at 11 17 51 AM](https://github.com/posit-dev/py-shiny/assets/4220325/780f1d77-89f7-4c5e-a633-f5c6e65a5748)
The solution was to delete that app and use a different app id which is reflected in the changes.