### PR TITLE
fix(docs): Update path to reflect correct one

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -23,7 +23,7 @@ website:
       - text: "Core API"
         file: api/core/index.qmd
       - text: "Testing API"
-        file: api/test/index.qmd
+        file: api/testing/index.qmd
     right:
       - icon: github
         href: https://github.com/posit-dev/py-shiny


### PR DESCRIPTION
Currently https://posit-dev.github.io/py-shiny/docs/api/test/index.qmd is broken because it refers to `../api/test/index.qmd` instead of `../api/testing/index.qmd`