### PR TITLE
Add return type for `_task()`

### DIFF
--- a/shiny/reactive/_core.py
+++ b/shiny/reactive/_core.py
@@ -346,7 +346,7 @@ def invalidate_later(
     # graphs from being gc'd.
     unsub: Optional[Callable[[], None]] = None
 
-    async def _task(ctx: Context, deadline: float):
+    async def _task(ctx: Context, deadline: float) -> None:
         nonlocal cancellable
         try:
             delay = deadline - time.monotonic()


### PR DESCRIPTION
This fixes an issue that is flagged by pyright 1.1.369.