### PR TITLE
chore(pyright): Pin pyright version to `1.1.369` to avoid CI failures

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -108,7 +108,7 @@ dev =
     flake8-bugbear>=23.2.13
     isort>=5.10.1
     libsass>=0.23.0
-    pyright>=1.1.367
+    pyright==1.1.369 # Future version: >=1.1.371;
     pre-commit>=2.15.0
     wheel
     matplotlib


### PR DESCRIPTION
Current failing output when using `pyright` 1.1.370:
```
/shiny/render/transformer/_transformer.py
  /shiny/render/transformer/_transformer.py:552:24 - error: "__getitem__" method not defined on type "UnionType" (reportIndexIssue)
  /shiny/render/transformer/_transformer.py:556:13 - error: Expected parameter type list or "..."
/shiny/ui/_layout_columns.py
  /shiny/ui/_layout_columns.py:279:41 - error: Argument type is unknown
    Argument corresponds to parameter "x" in function "maybe_fr_unit" (reportUnknownArgumentType)
  /shiny/ui/_layout_columns.py:279:48 - error: Type of "h" is unknown (reportUnknownVariableType)
  /shiny/ui/_layout_columns.py:279:53 - error: "int" is not iterable
    "__iter__" method not defined (reportGeneralTypeIssues)
  /shiny/ui/_layout_columns.py:279:53 - error: "float" is not iterable
    "__iter__" method not defined (reportGeneralTypeIssues)
```