### PR TITLE
fix(layout_columns): Fix coercion of scalar row height to list for python <= 3.9

### DIFF
--- a/shiny/ui/_layout_columns.py
+++ b/shiny/ui/_layout_columns.py
@@ -274,7 +274,9 @@ def row_heights_attrs(
     for brk, heights in x_complete.items():
         var = f"--bslib-grid--row-heights--{brk}"
 
-        if isinstance_cssunit(heights):
+        # We'd use isinstance(heights, CssUnit) (needs Python > 3.9)
+        # or isinstance_cssunit(heights) (pyright 1.1.369+ doesn't like it)
+        if isinstance(heights, (str, int, float)):
             heights = [heights]
 
         value = " ".join([maybe_fr_unit(h) for h in heights])

--- a/shiny/ui/_layout_columns.py
+++ b/shiny/ui/_layout_columns.py
@@ -11,7 +11,6 @@ from ._html_deps_shinyverse import components_dependencies
 from ._layout import wrap_all_in_gap_spaced_container
 from ._tag import consolidate_attrs
 from .css import CssUnit, as_css_unit
-from .css._css_unit import isinstance_cssunit
 from .fill import as_fill_item
 
 T = TypeVar("T")

--- a/shiny/ui/_layout_columns.py
+++ b/shiny/ui/_layout_columns.py
@@ -11,6 +11,7 @@ from ._html_deps_shinyverse import components_dependencies
 from ._layout import wrap_all_in_gap_spaced_container
 from ._tag import consolidate_attrs
 from .css import CssUnit, as_css_unit
+from .css._css_unit import isinstance_cssunit
 from .fill import as_fill_item
 
 T = TypeVar("T")
@@ -273,7 +274,7 @@ def row_heights_attrs(
     for brk, heights in x_complete.items():
         var = f"--bslib-grid--row-heights--{brk}"
 
-        if isinstance(heights, CssUnit):
+        if isinstance_cssunit(heights):
             heights = [heights]
 
         value = " ".join([maybe_fr_unit(h) for h in heights])


### PR DESCRIPTION
In Python <= 3.9, the following code throws an error

```python
from typing import Union
if isinstance(1, Union[int, str]):
    print("yes")

#> TypeError: Subscripted generics cannot be used with class and instance checks
```

We have a variant of this with `CssUnit = int | float | str` in `ui.layout_columns()`. This is fixed by using `isinstance_cssunit()`, an existing helper function created just for this scenario.