### PR TITLE
feat(data frame): Add generic type support via render return value

### DIFF
--- a/shiny/_typing_extensions.py
+++ b/shiny/_typing_extensions.py
@@ -7,6 +7,7 @@ __all__ = (
     "Concatenate",
     "ParamSpec",
     "TypeGuard",
+    "TypeIs",
     "Never",
     "Required",
     "NotRequired",
@@ -43,9 +44,13 @@ else:
         assert_type,
     )
 
+if sys.version_info >= (3, 13):
+    from typing import TypeIs
+else:
+    from typing_extensions import TypeIs
 
 # The only purpose of the following line is so that pyright will put all of the
 # conditional imports into the .pyi file when generating type stubs. Without this line,
 # pyright will not include the above imports in the generated .pyi file, and it will
 # result in a lot of red squiggles in user code.
-_: 'Annotated |Concatenate[str, ParamSpec("P")] | ParamSpec | TypeGuard | NotRequired | Required | TypedDict | assert_type | Self'  # type:ignore
+_: 'Annotated |Concatenate[str, ParamSpec("P")] | ParamSpec | TypeGuard | TypeIs | NotRequired | Required | TypedDict | assert_type | Self'  # type:ignore

--- a/shiny/render/_data_frame.py
+++ b/shiny/render/_data_frame.py
@@ -777,7 +777,6 @@ class data_frame(Renderer[DataFrameResult[DataFrameLikeT]]):
 
         if not isinstance(value, AbstractTabularData):
             try:
-                print("here!")
                 value = DataGrid(value)
             except TypeError as e:
                 raise TypeError(

--- a/shiny/render/_data_frame_utils/_datagridtable.py
+++ b/shiny/render/_data_frame_utils/_datagridtable.py
@@ -165,16 +165,15 @@ class DataGrid(AbstractTabularData, Generic[DataFrameLikeT]):
         ) = None,
         row_selection_mode: RowSelectionModeDeprecated = "deprecated",
     ) -> DataGrid[DataFrameLikeT] | DataGrid[PdDataFrame]:
-        print("DataGrid.__new__", type(data))
-        # if isinstance(data, (PdDataFrame, PlDataFrame)):
+        # print("DataGrid.__new__", type(data))
 
         if is_data_frame_like(data):
-            print(" -- regular")
+            # print(" -- regular")
             ret = super().__new__(cls)
             return ret
         else:
             # PandasCompatible
-            print(" -- to_pandas()")
+            # print(" -- to_pandas()")
             pd_data = data.to_pandas()
             ret = super(DataGrid, cls).__new__(cls)
             ret.__init__(  # pyright: ignore[reportUnknownMemberType]
@@ -189,7 +188,7 @@ class DataGrid(AbstractTabularData, Generic[DataFrameLikeT]):
                 styles=styles,  # pyright: ignore[reportArgumentType]
             )
 
-            print("return __new__")
+            # print("return __new__")
             return ret
 
     def __init__(  # pyright: ignore[reportInconsistentConstructor]
@@ -371,16 +370,15 @@ class DataTable(AbstractTabularData, Generic[DataFrameLikeT]):
             | None
         ) = None,
     ) -> DataTable[DataFrameLikeT] | DataTable[PdDataFrame]:
-        print("DataTable.__new__", type(data))
-        # if isinstance(data, (PdDataFrame, PlDataFrame)):
+        # print("DataTable.__new__", type(data))
 
         if is_data_frame_like(data):
-            print(" -- regular")
+            # print(" -- regular")
             ret = super().__new__(cls)
             return ret
         else:
             # PandasCompatible
-            print(" -- to_pandas()")
+            # print(" -- to_pandas()")
             pd_data = data.to_pandas()
             ret = super(DataTable, cls).__new__(cls)
             ret.__init__(  # pyright: ignore[reportUnknownMemberType]
@@ -395,7 +393,7 @@ class DataTable(AbstractTabularData, Generic[DataFrameLikeT]):
                 styles=styles,  # pyright: ignore[reportArgumentType]
             )
 
-            print("return __new__")
+            # print("return __new__")
             return ret
 
     def __init__(  # pyright: ignore[reportInconsistentConstructor]
@@ -411,7 +409,7 @@ class DataTable(AbstractTabularData, Generic[DataFrameLikeT]):
         row_selection_mode: Literal["deprecated"] = "deprecated",
         styles: StyleInfo | list[StyleInfo] | StyleFn[DataFrameLikeT] | None = None,
     ):
-        print("DataTable.__init__", type(data))
+        # print("DataTable.__init__", type(data))
 
         if "data" in self.__dict__:
             # This is a re-initialization, so we should return early

--- a/shiny/render/_data_frame_utils/_styles.py
+++ b/shiny/render/_data_frame_utils/_styles.py
@@ -4,11 +4,11 @@ from typing import TYPE_CHECKING, Callable, List
 
 from ...types import ListOrTuple
 from ._tbl_data import frame_column_names
-from ._types import BrowserStyleInfo, DataFrameLike, StyleInfo
+from ._types import BrowserStyleInfo, DataFrameLikeT, StyleInfo
 
 if TYPE_CHECKING:
 
-    StyleFn = Callable[[DataFrameLike], List["StyleInfo"]]
+    StyleFn = Callable[[DataFrameLikeT], List["StyleInfo"]]
 
 else:
     StyleFn = Callable
@@ -164,8 +164,8 @@ def style_info_rows(
 
 
 def as_style_infos(
-    infos: StyleInfo | list[StyleInfo] | StyleFn | None,
-) -> list[StyleInfo] | StyleFn:
+    infos: StyleInfo | list[StyleInfo] | StyleFn[DataFrameLikeT] | None,
+) -> list[StyleInfo] | StyleFn[DataFrameLikeT]:
 
     if callable(infos):
         return infos
@@ -180,9 +180,9 @@ def as_style_infos(
 
 
 def as_browser_style_infos(
-    infos: list[StyleInfo] | StyleFn,
+    infos: list[StyleInfo] | StyleFn[DataFrameLikeT],
     *,
-    data: DataFrameLike,
+    data: DataFrameLikeT,
 ) -> list[BrowserStyleInfo]:
     browser_column_names = frame_column_names(data)
 

--- a/shiny/render/_data_frame_utils/_tbl_data.py
+++ b/shiny/render/_data_frame_utils/_tbl_data.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from functools import singledispatch
-from typing import Any, List, Tuple, cast
+from typing import Any, List, Tuple, cast, overload
 
 from htmltools import TagNode
 
+from ..._typing_extensions import TypeIs
 from ...session import require_active_session
 from ._html import wrap_shiny_html
 
@@ -15,6 +16,7 @@ from ._types import (
     CellPatchProcessed,
     ColsList,
     DataFrameLike,
+    DataFrameLikeT,
     FrameDtype,
     FrameJson,
     ListSeriesLike,
@@ -44,48 +46,99 @@ __all__ = (
 # as_frame -----------------------------------------------------------------------------
 
 
-@singledispatch
+# @singledispatch
+# def is_data_frame_like(
+#     data: object,
+# ) -> bool:
+#     return False
+
+
+# @is_data_frame_like.register
+# def _(data: PdDataFrame) -> bool:
+#     return True
+
+
+# @is_data_frame_like.register
+# def _(data: PlDataFrame) -> bool:
+#     return True
+
+
 def is_data_frame_like(
-    data: object,
-) -> bool:
+    data: DataFrameLikeT | object,
+) -> TypeIs[DataFrameLikeT]:
+    if isinstance(data, (PdDataFrame, PlDataFrame)):
+        return True
+
     return False
 
 
-@is_data_frame_like.register
-def _(data: PdDataFrame) -> bool:
-    return True
+# @overload
+# def as_data_frame_like(
+#     data: DataFrameLikeT,
+#     error_message_begin: str = "ignored",
+# ) -> DataFrameLikeT: ...
 
 
-@is_data_frame_like.register
-def _(data: PlDataFrame) -> bool:
-    return True
+# # @overload
+# # def as_data_frame_like(
+# #     data: PlDataFrame,
+# #     error_message_begin: str = "ignored",
+# # ) -> PlDataFrame: ...
+# # @overload
+# # def as_data_frame_like(
+# #     data: PdDataFrame,
+# #     error_message_begin: str = "ignored",
+# # ) -> PdDataFrame: ...
+# @overload
+# def as_data_frame_like(
+#     data: PandasCompatible,
+#     error_message_begin: str = "ignored",
+# ) -> PdDataFrame: ...
 
 
-@singledispatch
-def as_data_frame_like(
-    data: DataFrameLike | PandasCompatible,
-    error_message_begin: str = "Unsupported type:",
-) -> DataFrameLike:
-    raise TypeError(
-        f"{error_message_begin} {str(type(data))}\n"
-        "Please use either a `pandas.DataFrame`, a `polars.DataFrame`, "
-        "or an object that has a `.to_pandas()` method."
-    )
+# def as_data_frame_like(
+#     data: DataFrameLikeT | PandasCompatible,
+#     error_message_begin: str = "Unsupported type:",
+# ) -> DataFrameLikeT | PdDataFrame:
+#     if isinstance(data, PdDataFrame):
+#         return data
+#     if isinstance(data, PlDataFrame):
+#         return data
+#     if isinstance(data, PandasCompatible):
+#         return data.to_pandas()
+
+#     raise TypeError(
+#         f"{error_message_begin} {str(type(data))}\n"
+#         "Please use either a `pandas.DataFrame`, a `polars.DataFrame`, "
+#         "or an object that has a `.to_pandas()` method."
+#     )
 
 
-@as_data_frame_like.register
-def _(data: PdDataFrame, error_message_begin: str = "ignored") -> DataFrameLike:
-    return data
+# @singledispatch
+# def as_data_frame_like(
+#     data: DataFrameLike | PandasCompatible,
+#     error_message_begin: str = "Unsupported type:",
+# ) -> DataFrameLike:
+#     raise TypeError(
+#         f"{error_message_begin} {str(type(data))}\n"
+#         "Please use either a `pandas.DataFrame`, a `polars.DataFrame`, "
+#         "or an object that has a `.to_pandas()` method."
+#     )
 
 
-@as_data_frame_like.register
-def _(data: PlDataFrame, error_message_begin: str = "ignored") -> DataFrameLike:
-    return data
+# @as_data_frame_like.register
+# def _(data: PdDataFrame, error_message_begin: str = "ignored") -> PdDataFrame:
+#     return data
 
 
-@as_data_frame_like.register
-def _(data: PandasCompatible, error_message_begin: str = "ignored") -> DataFrameLike:
-    return data.to_pandas()
+# @as_data_frame_like.register
+# def _(data: PlDataFrame, error_message_begin: str = "ignored") -> PlDataFrame:
+#     return data
+
+
+# @as_data_frame_like.register
+# def _(data: PandasCompatible, error_message_begin: str = "ignored") -> PdDataFrame:
+#     return data.to_pandas()
 
 
 # frame_columns ------------------------------------------------------------------------

--- a/shiny/render/_data_frame_utils/_tbl_data.py
+++ b/shiny/render/_data_frame_utils/_tbl_data.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from functools import singledispatch
-from typing import Any, List, Tuple, cast, overload
+from typing import Any, List, Tuple, cast
 
 from htmltools import TagNode
 
@@ -12,7 +12,7 @@ from ...session import require_active_session
 from ._html import wrap_shiny_html
 
 # from ...types import Jsonifiable
-from ._types import (
+from ._types import (  # PandasCompatible,
     CellPatchProcessed,
     ColsList,
     DataFrameLike,
@@ -20,7 +20,6 @@ from ._types import (
     FrameDtype,
     FrameJson,
     ListSeriesLike,
-    PandasCompatible,
     PdDataFrame,
     PdSeries,
     PlDataFrame,
@@ -31,7 +30,7 @@ from ._types import (
 
 __all__ = (
     "is_data_frame_like",
-    "as_data_frame_like",
+    # "as_data_frame_like",
     "frame_columns",
     "apply_frame_patches",
     "serialize_dtype",
@@ -72,75 +71,6 @@ def is_data_frame_like(
     return False
 
 
-# @overload
-# def as_data_frame_like(
-#     data: DataFrameLikeT,
-#     error_message_begin: str = "ignored",
-# ) -> DataFrameLikeT: ...
-
-
-# # @overload
-# # def as_data_frame_like(
-# #     data: PlDataFrame,
-# #     error_message_begin: str = "ignored",
-# # ) -> PlDataFrame: ...
-# # @overload
-# # def as_data_frame_like(
-# #     data: PdDataFrame,
-# #     error_message_begin: str = "ignored",
-# # ) -> PdDataFrame: ...
-# @overload
-# def as_data_frame_like(
-#     data: PandasCompatible,
-#     error_message_begin: str = "ignored",
-# ) -> PdDataFrame: ...
-
-
-# def as_data_frame_like(
-#     data: DataFrameLikeT | PandasCompatible,
-#     error_message_begin: str = "Unsupported type:",
-# ) -> DataFrameLikeT | PdDataFrame:
-#     if isinstance(data, PdDataFrame):
-#         return data
-#     if isinstance(data, PlDataFrame):
-#         return data
-#     if isinstance(data, PandasCompatible):
-#         return data.to_pandas()
-
-#     raise TypeError(
-#         f"{error_message_begin} {str(type(data))}\n"
-#         "Please use either a `pandas.DataFrame`, a `polars.DataFrame`, "
-#         "or an object that has a `.to_pandas()` method."
-#     )
-
-
-# @singledispatch
-# def as_data_frame_like(
-#     data: DataFrameLike | PandasCompatible,
-#     error_message_begin: str = "Unsupported type:",
-# ) -> DataFrameLike:
-#     raise TypeError(
-#         f"{error_message_begin} {str(type(data))}\n"
-#         "Please use either a `pandas.DataFrame`, a `polars.DataFrame`, "
-#         "or an object that has a `.to_pandas()` method."
-#     )
-
-
-# @as_data_frame_like.register
-# def _(data: PdDataFrame, error_message_begin: str = "ignored") -> PdDataFrame:
-#     return data
-
-
-# @as_data_frame_like.register
-# def _(data: PlDataFrame, error_message_begin: str = "ignored") -> PlDataFrame:
-#     return data
-
-
-# @as_data_frame_like.register
-# def _(data: PandasCompatible, error_message_begin: str = "ignored") -> PdDataFrame:
-#     return data.to_pandas()
-
-
 # frame_columns ------------------------------------------------------------------------
 
 
@@ -161,6 +91,12 @@ def _(data: PlDataFrame) -> ListSeriesLike:
 
 
 # apply_frame_patches --------------------------------------------------------------------
+
+
+def apply_frame_patches__typed(
+    data: DataFrameLikeT, patches: List[CellPatchProcessed]
+) -> DataFrameLikeT:
+    return cast(DataFrameLikeT, apply_frame_patches(data, patches))
 
 
 @singledispatch
@@ -290,6 +226,10 @@ def _(data: PlDataFrame) -> FrameJson:
 
 
 # subset_frame -------------------------------------------------------------------------
+def subset_frame__typed(
+    data: DataFrameLikeT, *, rows: RowsList = None, cols: ColsList = None
+) -> DataFrameLikeT:
+    return cast(DataFrameLikeT, subset_frame(data, rows=rows, cols=cols))
 
 
 @singledispatch

--- a/shiny/render/_data_frame_utils/_types.py
+++ b/shiny/render/_data_frame_utils/_types.py
@@ -10,6 +10,7 @@ from typing import (
     Optional,
     Protocol,
     Tuple,
+    TypeVar,
     Union,
     cast,
     runtime_checkable,
@@ -68,6 +69,7 @@ else:
     DataFrameLike.register(PdDataFrame)
     DataFrameLike.register(PlDataFrame)
 
+DataFrameLikeT = TypeVar("DataFrameLikeT", bound=DataFrameLike)
 # ---------------------------------------------------------------------
 
 

--- a/shiny/render/_data_frame_utils/_types.py
+++ b/shiny/render/_data_frame_utils/_types.py
@@ -166,8 +166,8 @@ class FrameJson(TypedDict):
     options: NotRequired[FrameJsonOptions]
 
 
-RowsList = Optional[List[int]]
-ColsList = Optional[List[Union[str, int]]]
+RowsList = Optional[ListOrTuple[int]]
+ColsList = Optional[ListOrTuple[Union[str, int]]]
 
 
 # ---------------------------------------------------------------------

--- a/tests/playwright/deploys/express-dataframe/app.py
+++ b/tests/playwright/deploys/express-dataframe/app.py
@@ -20,5 +20,5 @@ with ui.card(id="card"):
     ui.h2("Below is a sample dataframe")
 
     @render.data_frame
-    def sample_data_frame(id: str = "dataframe"):
+    def sample_data_frame():
         return df

--- a/tests/playwright/shiny/components/busy_indicators/test_busy_indicators.py
+++ b/tests/playwright/shiny/components/busy_indicators/test_busy_indicators.py
@@ -1,6 +1,8 @@
 import os
 from urllib.parse import urlparse
 
+import pytest
+from examples.example_apps import reruns, reruns_delay
 from playwright.sync_api import Page, expect
 
 from shiny.playwright import controller
@@ -23,6 +25,7 @@ def get_pulse_computed_property(page: Page, property_name: str) -> str:
     )
 
 
+@pytest.mark.flaky(reruns=reruns, delay=reruns_delay)
 def test_busy_indicators(page: Page, local_app: ShinyAppProc) -> None:
     page.goto(local_app.url)
     spinner_type = controller.InputRadioButtons(page, "busy_indicator_type")

--- a/tests/playwright/shiny/components/data_frame/edit/app.py
+++ b/tests/playwright/shiny/components/data_frame/edit/app.py
@@ -29,6 +29,9 @@ pl_penguins = pl.read_csv(
     null_values="NA",
 )
 
+pd_asdf = render.DataTable(pd_penguins)
+pl_asdf = render.DataTable(pl_penguins)
+
 # Load the dataset
 df = pd_penguins
 

--- a/tests/playwright/shiny/components/data_frame/html_columns_df/df_organization/app.py
+++ b/tests/playwright/shiny/components/data_frame/html_columns_df/df_organization/app.py
@@ -42,7 +42,10 @@ def mod_ui():
 
 @module.server
 def mod_server(
-    input: Inputs, output: Outputs, session: Session, data: render.DataFrameLike
+    input: Inputs,
+    output: Outputs,
+    session: Session,
+    data: render._data_frame_utils._types.DataFrameLike,
 ):
     @render.text
     def df_type():

--- a/tests/playwright/shiny/components/data_frame/pandas_compatible/app.py
+++ b/tests/playwright/shiny/components/data_frame/pandas_compatible/app.py
@@ -17,7 +17,9 @@ def code_original():
     return str(type(t))
 
 
-@render.data_frame
+# @render.data_frame
+# TODO-barret; I do NOT want this to be necessary
+@render.data_frame[render._data_frame_utils._types.PdDataFrame]
 def df_astropy():
     return t
 

--- a/tests/playwright/shiny/components/data_frame/return_type/app.py
+++ b/tests/playwright/shiny/components/data_frame/return_type/app.py
@@ -1,0 +1,23 @@
+from palmerpenguins import load_penguins_raw  # pyright: ignore[reportMissingTypeStubs]
+
+from shiny.express import render
+
+
+@render.code
+def first_code():
+    return str(type(first_df.data()))
+
+
+@render.code
+def second_code():
+    return str(type(second_df.data()))
+
+
+@render.data_frame
+def first_df():
+    return render.DataGrid(data=load_penguins_raw())
+
+
+@render.data_frame
+def second_df():
+    return first_df.data_view(selected=False)

--- a/tests/pytest/test_render_data_frame.py
+++ b/tests/pytest/test_render_data_frame.py
@@ -44,7 +44,7 @@ def test_as_selection_modes_legacy():
     assert dg.selection_modes.row == SelectionModes(selection_mode_set={"rows"}).row
 
     with pytest.raises(ValueError, match="Unknown row_selection_mode: foo"):
-        render.DataGrid(
+        render.DataGrid(  # pyright: ignore[reportCallIssue]
             df,
             row_selection_mode="foo",  # pyright: ignore[reportArgumentType,reportGeneralTypeIssues]
         )


### PR DESCRIPTION

Add support for `@render.data_frame` to know what the _real_ type should be for `.data_value()`, `.data()`, and any other data related methods.

Ex: Both `first_df` and `second_df` are aware that the return value of the render method has an underlying data type of [pandas.]`DataFrame`. This also works for `polars.DataFrame`.

```python
# app.py
from palmerpenguins import load_penguins_raw  # pyright: ignore[reportMissingTypeStubs]

from shiny.express import render


@render.data_frame
def first_df():
    return render.DataGrid(data=load_penguins_raw())


@render.data_frame
def second_df():
    return first_df.data_view(selected=True)


@render.code
def code():
    return str(second_df.data())
```

![Screenshot 2024-07-09 at 2 46 55 AM](https://github.com/posit-dev/py-shiny/assets/93231/aa1a0cb9-c35c-40f1-b951-4bf026359764)
![Screenshot 2024-07-09 at 2 47 03 AM](https://github.com/posit-dev/py-shiny/assets/93231/0eca692b-e6fa-46bf-9af2-299a17e16fb9)


TODO: 
* [ ] Fix `PandasCompatible` type. The `__new__` of `DataGrid` and `DataTable` does not convey that it is converted to a `pandas.DataFrame`.
	* Workaround: Users call `df.to_pandas()` to convert their data to pandas
![Screenshot 2024-07-09 at 3 05 18 AM](https://github.com/posit-dev/py-shiny/assets/93231/128c6836-e7cf-4e14-8d89-2943881f3fa0)

	* Workaround: Give type to `@render.data_frame[PdDataFrame]`
![Screenshot 2024-07-09 at 3 03 10 AM](https://github.com/posit-dev/py-shiny/assets/93231/5e2b2e5b-c88e-4ce7-8b0a-139123919bff)
  
