### PR TITLE
Follow up to #1508: move dotenv complexity to `app_utils.py` module

### DIFF
--- a/examples/chat/enterprise/aws-bedrock-anthropic/app.py
+++ b/examples/chat/enterprise/aws-bedrock-anthropic/app.py
@@ -4,18 +4,17 @@
 # To get started, follow the instructions at https://aws.amazon.com/bedrock/claude/
 # as well as https://github.com/anthropics/anthropic-sdk-python#aws-bedrock
 # ------------------------------------------------------------------------------------
-from pathlib import Path
-
 from anthropic import AnthropicBedrock
-from dotenv import load_dotenv
 
 from shiny.express import ui
+
+# In Shiny Core, do `from app_utils import load_dotenv`
+from .app_utils import load_dotenv
 
 # Either explicitly set the AWS environment variables before launching the app, or set
 # them in a file named `.env`. The `python-dotenv` package will load `.env` as
 # environment variables which can be read by `os.getenv()`.
-_ = load_dotenv(Path(__file__).parent / ".env")
-
+load_dotenv()
 llm = AnthropicBedrock(
     # aws_secret_key=os.getenv("AWS_SECRET_KEY"),
     # aws_access_key=os.getenv("AWS_ACCESS_KEY"),

--- a/examples/chat/enterprise/aws-bedrock-anthropic/app_utils.py
+++ b/examples/chat/enterprise/aws-bedrock-anthropic/app_utils.py
@@ -1,0 +1,27 @@
+import os
+from pathlib import Path
+
+app_dir = Path(__file__).parent
+env_file = app_dir / ".env"
+
+
+def load_dotenv(dotenv_path: os.PathLike[str] = env_file, **kwargs) -> None:
+    """
+    A convenience wrapper around `dotenv.load_dotenv` that warns if `dotenv` is not installed.
+    It also returns `None` to make it easier to ignore the return value.
+    """
+    try:
+        import dotenv
+
+        _ = dotenv.load_dotenv(dotenv_path=dotenv_path, **kwargs)
+        return None
+    except ImportError:
+        import warnings
+
+        warnings.warn(
+            "Could not import `dotenv`. If you want to use `.env` files to "
+            "load environment variables, please install it using "
+            "`pip install python-dotenv`.",
+            stacklevel=2,
+        )
+        return

--- a/examples/chat/enterprise/aws-bedrock-anthropic/app_utils.py
+++ b/examples/chat/enterprise/aws-bedrock-anthropic/app_utils.py
@@ -13,8 +13,7 @@ def load_dotenv(dotenv_path: os.PathLike[str] = env_file, **kwargs) -> None:
     try:
         import dotenv
 
-        _ = dotenv.load_dotenv(dotenv_path=dotenv_path, **kwargs)
-        return None
+        dotenv.load_dotenv(dotenv_path=dotenv_path, **kwargs)
     except ImportError:
         import warnings
 
@@ -24,4 +23,3 @@ def load_dotenv(dotenv_path: os.PathLike[str] = env_file, **kwargs) -> None:
             "`pip install python-dotenv`.",
             stacklevel=2,
         )
-        return

--- a/examples/chat/enterprise/aws-bedrock-anthropic/requirements.txt
+++ b/examples/chat/enterprise/aws-bedrock-anthropic/requirements.txt
@@ -1,0 +1,4 @@
+shiny
+python-dotenv
+tokenizers
+anthropic

--- a/examples/chat/enterprise/azure-openai/app.py
+++ b/examples/chat/enterprise/azure-openai/app.py
@@ -5,12 +5,10 @@
 # ------------------------------------------------------------------------------------
 import os
 
+from app_utils import load_dotenv
 from openai import AzureOpenAI
 
 from shiny.express import ui
-
-# In Shiny Core, do `from app_utils import load_dotenv`
-from .app_utils import load_dotenv
 
 # Either explicitly set the AZURE_OPENAI_API_KEY and AZURE_OPENAI_ENDPOINT environment
 # variables before launching the app, or set them in a file named `.env`. The

--- a/examples/chat/enterprise/azure-openai/app.py
+++ b/examples/chat/enterprise/azure-openai/app.py
@@ -4,18 +4,19 @@
 # To get setup, follow the instructions at https://learn.microsoft.com/en-us/azure/ai-services/openai/quickstart?tabs=command-line%2Cpython-new&pivots=programming-language-python#create-a-new-python-application
 # ------------------------------------------------------------------------------------
 import os
-from pathlib import Path
 
-import dotenv
 from openai import AzureOpenAI
 
 from shiny.express import ui
+
+# In Shiny Core, do `from app_utils import load_dotenv`
+from .app_utils import load_dotenv
 
 # Either explicitly set the AZURE_OPENAI_API_KEY and AZURE_OPENAI_ENDPOINT environment
 # variables before launching the app, or set them in a file named `.env`. The
 # `python-dotenv` package will load `.env` as environment variables which can later be
 # read by `os.getenv()`.
-dotenv.load_dotenv(Path(__file__).parent / ".env")
+load_dotenv()
 
 llm = AzureOpenAI(
     api_key=os.getenv("AZURE_OPENAI_API_KEY"),

--- a/examples/chat/enterprise/azure-openai/app_utils.py
+++ b/examples/chat/enterprise/azure-openai/app_utils.py
@@ -1,0 +1,27 @@
+import os
+from pathlib import Path
+
+app_dir = Path(__file__).parent
+env_file = app_dir / ".env"
+
+
+def load_dotenv(dotenv_path: os.PathLike[str] = env_file, **kwargs) -> None:
+    """
+    A convenience wrapper around `dotenv.load_dotenv` that warns if `dotenv` is not installed.
+    It also returns `None` to make it easier to ignore the return value.
+    """
+    try:
+        import dotenv
+
+        _ = dotenv.load_dotenv(dotenv_path=dotenv_path, **kwargs)
+        return None
+    except ImportError:
+        import warnings
+
+        warnings.warn(
+            "Could not import `dotenv`. If you want to use `.env` files to "
+            "load environment variables, please install it using "
+            "`pip install python-dotenv`.",
+            stacklevel=2,
+        )
+        return

--- a/examples/chat/enterprise/azure-openai/app_utils.py
+++ b/examples/chat/enterprise/azure-openai/app_utils.py
@@ -13,8 +13,7 @@ def load_dotenv(dotenv_path: os.PathLike[str] = env_file, **kwargs) -> None:
     try:
         import dotenv
 
-        _ = dotenv.load_dotenv(dotenv_path=dotenv_path, **kwargs)
-        return None
+        dotenv.load_dotenv(dotenv_path=dotenv_path, **kwargs)
     except ImportError:
         import warnings
 
@@ -24,4 +23,3 @@ def load_dotenv(dotenv_path: os.PathLike[str] = env_file, **kwargs) -> None:
             "`pip install python-dotenv`.",
             stacklevel=2,
         )
-        return

--- a/examples/chat/enterprise/azure-openai/requirements.txt
+++ b/examples/chat/enterprise/azure-openai/requirements.txt
@@ -1,0 +1,4 @@
+shiny
+python-dotenv
+tokenizers
+openai

--- a/examples/chat/hello-providers/anthropic/app.py
+++ b/examples/chat/hello-providers/anthropic/app.py
@@ -4,18 +4,18 @@
 # To get one, follow the instructions at https://docs.anthropic.com/en/api/getting-started
 # ------------------------------------------------------------------------------------
 import os
-from pathlib import Path
 
 from anthropic import AsyncAnthropic
-from dotenv import load_dotenv
 
 from shiny.express import ui
+
+# In Shiny Core, do `from app_utils import load_dotenv`
+from .app_utils import load_dotenv
 
 # Either explicitly set the ANTHROPIC_API_KEY environment variable before launching the
 # app, or set them in a file named `.env`. The `python-dotenv` package will load `.env`
 # as environment variables which can later be read by `os.getenv()`.
-_ = load_dotenv(Path(__file__).parent / ".env")
-
+load_dotenv()
 llm = AsyncAnthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
 
 # Set some Shiny page options

--- a/examples/chat/hello-providers/anthropic/app.py
+++ b/examples/chat/hello-providers/anthropic/app.py
@@ -6,11 +6,9 @@
 import os
 
 from anthropic import AsyncAnthropic
+from app_utils import load_dotenv
 
 from shiny.express import ui
-
-# In Shiny Core, do `from app_utils import load_dotenv`
-from .app_utils import load_dotenv
 
 # Either explicitly set the ANTHROPIC_API_KEY environment variable before launching the
 # app, or set them in a file named `.env`. The `python-dotenv` package will load `.env`

--- a/examples/chat/hello-providers/anthropic/app_utils.py
+++ b/examples/chat/hello-providers/anthropic/app_utils.py
@@ -1,0 +1,27 @@
+import os
+from pathlib import Path
+
+app_dir = Path(__file__).parent
+env_file = app_dir / ".env"
+
+
+def load_dotenv(dotenv_path: os.PathLike[str] = env_file, **kwargs) -> None:
+    """
+    A convenience wrapper around `dotenv.load_dotenv` that warns if `dotenv` is not installed.
+    It also returns `None` to make it easier to ignore the return value.
+    """
+    try:
+        import dotenv
+
+        _ = dotenv.load_dotenv(dotenv_path=dotenv_path, **kwargs)
+        return None
+    except ImportError:
+        import warnings
+
+        warnings.warn(
+            "Could not import `dotenv`. If you want to use `.env` files to "
+            "load environment variables, please install it using "
+            "`pip install python-dotenv`.",
+            stacklevel=2,
+        )
+        return

--- a/examples/chat/hello-providers/anthropic/app_utils.py
+++ b/examples/chat/hello-providers/anthropic/app_utils.py
@@ -13,8 +13,7 @@ def load_dotenv(dotenv_path: os.PathLike[str] = env_file, **kwargs) -> None:
     try:
         import dotenv
 
-        _ = dotenv.load_dotenv(dotenv_path=dotenv_path, **kwargs)
-        return None
+        dotenv.load_dotenv(dotenv_path=dotenv_path, **kwargs)
     except ImportError:
         import warnings
 
@@ -24,4 +23,3 @@ def load_dotenv(dotenv_path: os.PathLike[str] = env_file, **kwargs) -> None:
             "`pip install python-dotenv`.",
             stacklevel=2,
         )
-        return

--- a/examples/chat/hello-providers/anthropic/requirements.txt
+++ b/examples/chat/hello-providers/anthropic/requirements.txt
@@ -1,0 +1,4 @@
+shiny
+python-dotenv
+tokenizers
+anthropic

--- a/examples/chat/hello-providers/gemini/app.py
+++ b/examples/chat/hello-providers/gemini/app.py
@@ -3,12 +3,10 @@
 # To run it, you'll need a Google API key.
 # To get one, follow the instructions at https://ai.google.dev/gemini-api/docs/get-started/tutorial?lang=python
 # ------------------------------------------------------------------------------------
+from app_utils import load_dotenv
 from google.generativeai import GenerativeModel
 
 from shiny.express import ui
-
-# In Shiny Core, do `from app_utils import load_dotenv`
-from .app_utils import load_dotenv
 
 # Either explicitly set the GOOGLE_API_KEY environment variable before launching the
 # app, or set them in a file named `.env`. The `python-dotenv` package will load `.env`

--- a/examples/chat/hello-providers/gemini/app.py
+++ b/examples/chat/hello-providers/gemini/app.py
@@ -3,19 +3,17 @@
 # To run it, you'll need a Google API key.
 # To get one, follow the instructions at https://ai.google.dev/gemini-api/docs/get-started/tutorial?lang=python
 # ------------------------------------------------------------------------------------
-
-from pathlib import Path
-
-from dotenv import load_dotenv
 from google.generativeai import GenerativeModel
 
 from shiny.express import ui
 
+# In Shiny Core, do `from app_utils import load_dotenv`
+from .app_utils import load_dotenv
+
 # Either explicitly set the GOOGLE_API_KEY environment variable before launching the
 # app, or set them in a file named `.env`. The `python-dotenv` package will load `.env`
 # as environment variables which can later be read by `os.getenv()`.
-_ = load_dotenv(Path(__file__).parent / ".env")
-
+load_dotenv()
 llm = GenerativeModel()
 
 # Set some Shiny page options

--- a/examples/chat/hello-providers/gemini/app_utils.py
+++ b/examples/chat/hello-providers/gemini/app_utils.py
@@ -1,0 +1,27 @@
+import os
+from pathlib import Path
+
+app_dir = Path(__file__).parent
+env_file = app_dir / ".env"
+
+
+def load_dotenv(dotenv_path: os.PathLike[str] = env_file, **kwargs) -> None:
+    """
+    A convenience wrapper around `dotenv.load_dotenv` that warns if `dotenv` is not installed.
+    It also returns `None` to make it easier to ignore the return value.
+    """
+    try:
+        import dotenv
+
+        _ = dotenv.load_dotenv(dotenv_path=dotenv_path, **kwargs)
+        return None
+    except ImportError:
+        import warnings
+
+        warnings.warn(
+            "Could not import `dotenv`. If you want to use `.env` files to "
+            "load environment variables, please install it using "
+            "`pip install python-dotenv`.",
+            stacklevel=2,
+        )
+        return

--- a/examples/chat/hello-providers/gemini/app_utils.py
+++ b/examples/chat/hello-providers/gemini/app_utils.py
@@ -13,8 +13,7 @@ def load_dotenv(dotenv_path: os.PathLike[str] = env_file, **kwargs) -> None:
     try:
         import dotenv
 
-        _ = dotenv.load_dotenv(dotenv_path=dotenv_path, **kwargs)
-        return None
+        dotenv.load_dotenv(dotenv_path=dotenv_path, **kwargs)
     except ImportError:
         import warnings
 
@@ -24,4 +23,3 @@ def load_dotenv(dotenv_path: os.PathLike[str] = env_file, **kwargs) -> None:
             "`pip install python-dotenv`.",
             stacklevel=2,
         )
-        return

--- a/examples/chat/hello-providers/gemini/requirements.txt
+++ b/examples/chat/hello-providers/gemini/requirements.txt
@@ -1,0 +1,4 @@
+shiny
+python-dotenv
+tokenizers
+google-generativeai

--- a/examples/chat/hello-providers/langchain/app.py
+++ b/examples/chat/hello-providers/langchain/app.py
@@ -6,12 +6,10 @@
 # ------------------------------------------------------------------------------------
 import os
 
+from app_utils import load_dotenv
 from langchain_openai import ChatOpenAI
 
 from shiny.express import ui
-
-# In Shiny Core, do `from app_utils import load_dotenv`
-from .app_utils import load_dotenv
 
 # Either explicitly set the OPENAI_API_KEY environment variable before launching the
 # app, or set them in a file named `.env`. The `python-dotenv` package will load `.env`

--- a/examples/chat/hello-providers/langchain/app.py
+++ b/examples/chat/hello-providers/langchain/app.py
@@ -5,18 +5,18 @@
 # To use other providers/models via LangChain, see https://python.langchain.com/v0.1/docs/modules/model_io/chat/quick_start/
 # ------------------------------------------------------------------------------------
 import os
-from pathlib import Path
 
-from dotenv import load_dotenv
 from langchain_openai import ChatOpenAI
 
 from shiny.express import ui
 
+# In Shiny Core, do `from app_utils import load_dotenv`
+from .app_utils import load_dotenv
+
 # Either explicitly set the OPENAI_API_KEY environment variable before launching the
 # app, or set them in a file named `.env`. The `python-dotenv` package will load `.env`
 # as environment variables which can later be read by `os.getenv()`.
-_ = load_dotenv(Path(__file__).parent / ".env")
-
+load_dotenv()
 llm = ChatOpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 
 # Set some Shiny page options
@@ -37,6 +37,6 @@ async def _():
     # Get messages currently in the chat
     messages = chat.messages()
     # Create a response message stream
-    response = llm.astream(messages)
+    response = llm.astream(messages)  # type: ignore
     # Append the response stream into the chat
     await chat.append_message_stream(response)

--- a/examples/chat/hello-providers/langchain/app_utils.py
+++ b/examples/chat/hello-providers/langchain/app_utils.py
@@ -1,0 +1,27 @@
+import os
+from pathlib import Path
+
+app_dir = Path(__file__).parent
+env_file = app_dir / ".env"
+
+
+def load_dotenv(dotenv_path: os.PathLike[str] = env_file, **kwargs) -> None:
+    """
+    A convenience wrapper around `dotenv.load_dotenv` that warns if `dotenv` is not installed.
+    It also returns `None` to make it easier to ignore the return value.
+    """
+    try:
+        import dotenv
+
+        _ = dotenv.load_dotenv(dotenv_path=dotenv_path, **kwargs)
+        return None
+    except ImportError:
+        import warnings
+
+        warnings.warn(
+            "Could not import `dotenv`. If you want to use `.env` files to "
+            "load environment variables, please install it using "
+            "`pip install python-dotenv`.",
+            stacklevel=2,
+        )
+        return

--- a/examples/chat/hello-providers/langchain/app_utils.py
+++ b/examples/chat/hello-providers/langchain/app_utils.py
@@ -13,8 +13,7 @@ def load_dotenv(dotenv_path: os.PathLike[str] = env_file, **kwargs) -> None:
     try:
         import dotenv
 
-        _ = dotenv.load_dotenv(dotenv_path=dotenv_path, **kwargs)
-        return None
+        dotenv.load_dotenv(dotenv_path=dotenv_path, **kwargs)
     except ImportError:
         import warnings
 
@@ -24,4 +23,3 @@ def load_dotenv(dotenv_path: os.PathLike[str] = env_file, **kwargs) -> None:
             "`pip install python-dotenv`.",
             stacklevel=2,
         )
-        return

--- a/examples/chat/hello-providers/langchain/requirements.txt
+++ b/examples/chat/hello-providers/langchain/requirements.txt
@@ -1,0 +1,4 @@
+shiny
+python-dotenv
+tokenizers
+langchain-openai

--- a/examples/chat/hello-providers/ollama/requirements.txt
+++ b/examples/chat/hello-providers/ollama/requirements.txt
@@ -1,0 +1,3 @@
+shiny
+tokenizers
+ollama

--- a/examples/chat/hello-providers/openai/app.py
+++ b/examples/chat/hello-providers/openai/app.py
@@ -5,12 +5,10 @@
 # ------------------------------------------------------------------------------------
 import os
 
+from app_utils import load_dotenv
 from openai import AsyncOpenAI
 
 from shiny.express import ui
-
-# In Shiny Core, do `from app_utils import load_dotenv`
-from .app_utils import load_dotenv
 
 # Either explicitly set the OPENAI_API_KEY environment variable before launching the
 # app, or set them in a file named `.env`. The `python-dotenv` package will load `.env`

--- a/examples/chat/hello-providers/openai/app.py
+++ b/examples/chat/hello-providers/openai/app.py
@@ -4,18 +4,18 @@
 # To get setup, follow the instructions at https://platform.openai.com/docs/quickstart
 # ------------------------------------------------------------------------------------
 import os
-from pathlib import Path
 
-from dotenv import load_dotenv
 from openai import AsyncOpenAI
 
 from shiny.express import ui
 
+# In Shiny Core, do `from app_utils import load_dotenv`
+from .app_utils import load_dotenv
+
 # Either explicitly set the OPENAI_API_KEY environment variable before launching the
 # app, or set them in a file named `.env`. The `python-dotenv` package will load `.env`
 # as environment variables which can later be read by `os.getenv()`.
-_ = load_dotenv(Path(__file__).parent / ".env")
-
+load_dotenv()
 llm = AsyncOpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 
 # Set some Shiny page options

--- a/examples/chat/hello-providers/openai/app_utils.py
+++ b/examples/chat/hello-providers/openai/app_utils.py
@@ -1,0 +1,27 @@
+import os
+from pathlib import Path
+
+app_dir = Path(__file__).parent
+env_file = app_dir / ".env"
+
+
+def load_dotenv(dotenv_path: os.PathLike[str] = env_file, **kwargs) -> None:
+    """
+    A convenience wrapper around `dotenv.load_dotenv` that warns if `dotenv` is not installed.
+    It also returns `None` to make it easier to ignore the return value.
+    """
+    try:
+        import dotenv
+
+        _ = dotenv.load_dotenv(dotenv_path=dotenv_path, **kwargs)
+        return None
+    except ImportError:
+        import warnings
+
+        warnings.warn(
+            "Could not import `dotenv`. If you want to use `.env` files to "
+            "load environment variables, please install it using "
+            "`pip install python-dotenv`.",
+            stacklevel=2,
+        )
+        return

--- a/examples/chat/hello-providers/openai/app_utils.py
+++ b/examples/chat/hello-providers/openai/app_utils.py
@@ -13,8 +13,7 @@ def load_dotenv(dotenv_path: os.PathLike[str] = env_file, **kwargs) -> None:
     try:
         import dotenv
 
-        _ = dotenv.load_dotenv(dotenv_path=dotenv_path, **kwargs)
-        return None
+        dotenv.load_dotenv(dotenv_path=dotenv_path, **kwargs)
     except ImportError:
         import warnings
 
@@ -24,4 +23,3 @@ def load_dotenv(dotenv_path: os.PathLike[str] = env_file, **kwargs) -> None:
             "`pip install python-dotenv`.",
             stacklevel=2,
         )
-        return

--- a/examples/chat/hello-providers/openai/requirements.txt
+++ b/examples/chat/hello-providers/openai/requirements.txt
@@ -1,0 +1,4 @@
+shiny
+python-dotenv
+tokenizers
+openai

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -15,5 +15,6 @@
   "reportImportCycles": "none",
   "reportUnusedFunction": "none",
   "reportPrivateUsage": "none",
-  "reportUnnecessaryIsInstance": "none"
+  "reportUnnecessaryIsInstance": "none",
+  "executionEnvironments": [{ "root": "examples/" }]
 }


### PR DESCRIPTION
This makes the `app.py` file for the `Chat` examples a bit more readable, and also doesn't crash the app if `{dotenv}` isn't installed. 