### PR TITLE
tests(deploys): separate deploy test workflow from pytest workflow

### DIFF
--- a/.github/workflows/deploy-tests.yaml
+++ b/.github/workflows/deploy-tests.yaml
@@ -1,0 +1,89 @@
+name: Run deploy tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main", "rc-*"]
+  pull_request:
+  merge_group:
+
+jobs:
+  playwright-deploys-precheck:
+    if: github.event_name != 'release'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # Matches deploy server python version
+        python-version: ["3.10"]
+        os: [ubuntu-latest]
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup py-shiny
+        uses: ./.github/py-shiny/setup
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Test that deployable example apps work
+        timeout-minutes: 5 # ~10s locally
+        env:
+          DEPLOY_APPS: "false"
+        run: |
+          make playwright-deploys SUB_FILE=". -vv"
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: "playright-examples-${{ matrix.os }}-${{ matrix.python-version }}-results"
+          path: test-results/
+          retention-days: 5
+
+  playwright-deploys:
+    needs: [playwright-deploys-precheck]
+    if: github.event_name != 'release' && (github.event_name == 'push' || startsWith(github.head_ref, 'deploy'))
+    # Only allow one `playwright-deploys` job to run at a time. (Independent of branch / PR)
+    # Only one is allowed to run at a time because it is deploying to the same server location.
+    concurrency: playwright-deploys
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # Matches deploy server python version
+        python-version: ["3.10"]
+        os: [ubuntu-latest]
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup py-shiny
+        uses: ./.github/py-shiny/setup
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Test that deployable example apps work
+        timeout-minutes: 5 # ~10s locally
+        env:
+          DEPLOY_APPS: "false"
+        run: |
+          make playwright-deploys SUB_FILE=". -vv"
+
+      - name: Deploy apps and run tests (on `push` or `deploy**` branches)
+        env:
+          DEPLOY_APPS: "true"
+          DEPLOY_CONNECT_SERVER_URL: "https://rsc.radixu.com/"
+          DEPLOY_CONNECT_SERVER_API_KEY: "${{ secrets.DEPLOY_CONNECT_SERVER_API_KEY }}"
+          DEPLOY_SHINYAPPS_NAME: "${{ secrets.DEPLOY_SHINYAPPS_NAME }}"
+          DEPLOY_SHINYAPPS_TOKEN: "${{ secrets.DEPLOY_SHINYAPPS_TOKEN }}"
+          DEPLOY_SHINYAPPS_SECRET: "${{ secrets.DEPLOY_SHINYAPPS_SECRET }}"
+        timeout-minutes: 30
+        # Given we are waiting for external servers to finish,
+        # we can have many local processes waiting for deployment to finish
+        run: |
+          make playwright-deploys SUB_FILE=". -vv --numprocesses 12"
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: "playright-deploys-${{ matrix.os }}-${{ matrix.python-version }}-results"
+          path: test-results/
+          retention-days: 5

--- a/.github/workflows/deploy-tests.yaml
+++ b/.github/workflows/deploy-tests.yaml
@@ -8,37 +8,6 @@ on:
   merge_group:
 
 jobs:
-  playwright-deploys-precheck:
-    if: github.event_name != 'release'
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        # Matches deploy server python version
-        python-version: ["3.10"]
-        os: [ubuntu-latest]
-      fail-fast: false
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup py-shiny
-        uses: ./.github/py-shiny/setup
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Test that deployable example apps work
-        timeout-minutes: 5 # ~10s locally
-        env:
-          DEPLOY_APPS: "false"
-        run: |
-          make playwright-deploys SUB_FILE=". -vv"
-
-      - uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: "playright-examples-${{ matrix.os }}-${{ matrix.python-version }}-results"
-          path: test-results/
-          retention-days: 5
-
   playwright-deploys:
     needs: [playwright-deploys-precheck]
     if: github.event_name != 'release' && (github.event_name == 'push' || startsWith(github.head_ref, 'deploy'))

--- a/.github/workflows/deploy-tests.yaml
+++ b/.github/workflows/deploy-tests.yaml
@@ -3,14 +3,10 @@ name: Run deploy tests
 on:
   workflow_dispatch:
   push:
-    branches: ["main", "rc-*"]
-  pull_request:
-  merge_group:
+    branches: ["main", "rc-*", "deploy-**"]
 
 jobs:
   playwright-deploys:
-    needs: [playwright-deploys-precheck]
-    if: github.event_name != 'release' && (github.event_name == 'push' || startsWith(github.head_ref, 'deploy'))
     # Only allow one `playwright-deploys` job to run at a time. (Independent of branch / PR)
     # Only one is allowed to run at a time because it is deploying to the same server location.
     concurrency: playwright-deploys

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -158,55 +158,6 @@ jobs:
           path: test-results/
           retention-days: 5
 
-  playwright-deploys:
-    needs: [playwright-deploys-precheck]
-    if: github.event_name != 'release' && (github.event_name == 'push' || startsWith(github.head_ref, 'deploy'))
-    # Only allow one `playwright-deploys` job to run at a time. (Independent of branch / PR)
-    # Only one is allowed to run at a time because it is deploying to the same server location.
-    concurrency: playwright-deploys
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        # Matches deploy server python version
-        python-version: ["3.10"]
-        os: [ubuntu-latest]
-      fail-fast: false
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup py-shiny
-        uses: ./.github/py-shiny/setup
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Test that deployable example apps work
-        timeout-minutes: 5 # ~10s locally
-        env:
-          DEPLOY_APPS: "false"
-        run: |
-          make playwright-deploys SUB_FILE=". -vv"
-
-      - name: Deploy apps and run tests (on `push` or `deploy**` branches)
-        env:
-          DEPLOY_APPS: "true"
-          DEPLOY_CONNECT_SERVER_URL: "https://rsc.radixu.com/"
-          DEPLOY_CONNECT_SERVER_API_KEY: "${{ secrets.DEPLOY_CONNECT_SERVER_API_KEY }}"
-          DEPLOY_SHINYAPPS_NAME: "${{ secrets.DEPLOY_SHINYAPPS_NAME }}"
-          DEPLOY_SHINYAPPS_TOKEN: "${{ secrets.DEPLOY_SHINYAPPS_TOKEN }}"
-          DEPLOY_SHINYAPPS_SECRET: "${{ secrets.DEPLOY_SHINYAPPS_SECRET }}"
-        timeout-minutes: 30
-        # Given we are waiting for external servers to finish,
-        # we can have many local processes waiting for deployment to finish
-        run: |
-          make playwright-deploys SUB_FILE=". -vv --numprocesses 12"
-
-      - uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: "playright-deploys-${{ matrix.os }}-${{ matrix.python-version }}-results"
-          path: test-results/
-          retention-days: 5
-
   pypi:
     name: "Deploy to PyPI"
     runs-on: ubuntu-latest


### PR DESCRIPTION
We want to only run the **Deploy pre-checks** on every commit in a PR.
We will separate the deploy tests into its own workflow file from `pytest.yaml`