### PR TITLE
Ensure first message is user message for anthropic

### DIFF
--- a/shiny/ui/_chat.py
+++ b/shiny/ui/_chat.py
@@ -466,7 +466,7 @@ class Chat:
 
         messages = self._messages()
         if token_limits is not None:
-            messages = self._trim_messages(messages, token_limits)
+            messages = self._trim_messages(messages, token_limits, format)
 
         res: list[ChatMessage | ProviderMessage] = []
         for i, m in enumerate(messages):
@@ -827,7 +827,8 @@ class Chat:
     @staticmethod
     def _trim_messages(
         messages: tuple[StoredMessage, ...],
-        token_limits: tuple[int, int] = (4096, 1000),
+        token_limits: tuple[int, int],
+        format: MISSING_TYPE | ProviderMessageFormat,
     ) -> tuple[StoredMessage, ...]:
 
         n_total, n_reserve = token_limits
@@ -871,6 +872,11 @@ class Chat:
             remaining_non_system_tokens -= count
             if remaining_non_system_tokens >= 0:
                 messages2.append(m)
+
+        if format == "anthropic":
+            # For anthropic, the first message must be a user message.
+            while messages2[-1]["role"] != "user":
+                messages2.pop()
 
         messages2.reverse()
 

--- a/tests/pytest/test_chat.py
+++ b/tests/pytest/test_chat.py
@@ -9,6 +9,7 @@ import pytest
 from shiny import Session
 from shiny._namespaces import ResolvedId, Root
 from shiny.session import session_context
+from shiny.types import MISSING
 from shiny.ui import Chat
 from shiny.ui._chat import as_transformed_message
 from shiny.ui._chat_normalize import normalize_message, normalize_message_chunk
@@ -66,7 +67,7 @@ def test_chat_message_trimming():
 
         # Throws since system message is too long
         with pytest.raises(ValueError):
-            chat._trim_messages(msgs, token_limits=(100, 0))
+            chat._trim_messages(msgs, token_limits=(100, 0), format=MISSING)
 
         msgs = (
             as_stored_message(
@@ -79,10 +80,10 @@ def test_chat_message_trimming():
 
         # Throws since only the system message fits
         with pytest.raises(ValueError):
-            chat._trim_messages(msgs, token_limits=(100, 0))
+            chat._trim_messages(msgs, token_limits=(100, 0), format=MISSING)
 
         # Raising the limit should allow both messages to fit
-        trimmed = chat._trim_messages(msgs, token_limits=(102, 0))
+        trimmed = chat._trim_messages(msgs, token_limits=(102, 0), format=MISSING)
         assert len(trimmed) == 2
         contents = [msg["content_server"] for msg in trimmed]
         assert contents == ["System message", "User message"]
@@ -100,7 +101,7 @@ def test_chat_message_trimming():
         )
 
         # Should discard the 1st user message
-        trimmed = chat._trim_messages(msgs, token_limits=(102, 0))
+        trimmed = chat._trim_messages(msgs, token_limits=(102, 0), format=MISSING)
         assert len(trimmed) == 2
         contents = [msg["content_server"] for msg in trimmed]
         assert contents == ["System message", "User message 2"]
@@ -121,7 +122,7 @@ def test_chat_message_trimming():
         )
 
         # Should discard the 1st user message
-        trimmed = chat._trim_messages(msgs, token_limits=(102, 0))
+        trimmed = chat._trim_messages(msgs, token_limits=(102, 0), format=MISSING)
         assert len(trimmed) == 3
         contents = [msg["content_server"] for msg in trimmed]
         assert contents == ["System message", "System message 2", "User message 2"]

--- a/tests/pytest/test_chat.py
+++ b/tests/pytest/test_chat.py
@@ -127,6 +127,21 @@ def test_chat_message_trimming():
         contents = [msg["content_server"] for msg in trimmed]
         assert contents == ["System message", "System message 2", "User message 2"]
 
+        msgs = (
+            as_stored_message(
+                {"content": "Assistant message", "role": "assistant"}, token_count=50
+            ),
+            as_stored_message(
+                {"content": "User message", "role": "user"}, token_count=10
+            ),
+        )
+
+        # Anthropic requires 1st message to be a user message
+        trimmed = chat._trim_messages(msgs, token_limits=(30, 0), format="anthropic")
+        assert len(trimmed) == 1
+        contents = [msg["content_server"] for msg in trimmed]
+        assert contents == ["User message"]
+
 
 # ------------------------------------------------------------------------------------
 # Unit tests for normalize_message() and normalize_message_chunk().


### PR DESCRIPTION
For Anthropic, the first message in a chat must have `"role": "user"`; otherwise the API will return an error.

This PR ensures that when the messages are trimmed, the first message is a `user` message.


One possibly confusing thing: Suppose you initialize the chat with something like this:

```py
chat = ui.Chat(
    "chat",
    messages=[
        {"role": "assistant", "content": "Arrgh! I am a chatbot that speaks like a pirate. How may I help ye?"},
    ],
)
```

Then when the user enters a message and the messages get sent to the LLM, this first message will get trimmed off, and so the LLM will not know that it's supposed to respond like a pirate. The problem is that the app author won't have any indication that this first message is getting trimmed, so if they expect anthropic to behave like openai (where the first message can be `assistant`), they will likely be confused as to why the first message would be ignored.