### PR TITLE
Add `chat.messages(format='internal')`

### DIFF
--- a/shiny/ui/_chat.py
+++ b/shiny/ui/_chat.py
@@ -466,7 +466,7 @@ class Chat:
 
         messages = self._messages()
         if token_limits is not None:
-            messages = self._trim_messages(messages, token_limits)
+            messages = self._trim_messages(messages, token_limits, format)
 
         res: list[ChatMessage | ProviderMessage] = []
         for i, m in enumerate(messages):
@@ -827,7 +827,8 @@ class Chat:
     @staticmethod
     def _trim_messages(
         messages: tuple[StoredMessage, ...],
-        token_limits: tuple[int, int] = (4096, 1000),
+        token_limits: tuple[int, int],
+        format: MISSING_TYPE | ProviderMessageFormat,
     ) -> tuple[StoredMessage, ...]:
 
         n_total, n_reserve = token_limits
@@ -871,6 +872,11 @@ class Chat:
             remaining_non_system_tokens -= count
             if remaining_non_system_tokens >= 0:
                 messages2.append(m)
+
+        if format == "anthropic":
+            # For anthropic, the first message must be a user message.
+            while messages2[-1]["role"] != "user":
+                messages2.pop()
 
         messages2.reverse()
 

--- a/shiny/ui/_chat.py
+++ b/shiny/ui/_chat.py
@@ -347,7 +347,7 @@ class Chat:
     def messages(
         self,
         *,
-        format: Literal["anthropic"] = "anthropic",
+        format: Literal["anthropic"],
         token_limits: tuple[int, int] | None = (4096, 1000),
         transform_user: Literal["all", "last", "none"] = "all",
         transform_assistant: bool = False,
@@ -357,7 +357,7 @@ class Chat:
     def messages(
         self,
         *,
-        format: Literal["google"] = "google",
+        format: Literal["google"],
         token_limits: tuple[int, int] | None = (4096, 1000),
         transform_user: Literal["all", "last", "none"] = "all",
         transform_assistant: bool = False,
@@ -367,7 +367,7 @@ class Chat:
     def messages(
         self,
         *,
-        format: Literal["langchain"] = "langchain",
+        format: Literal["langchain"],
         token_limits: tuple[int, int] | None = (4096, 1000),
         transform_user: Literal["all", "last", "none"] = "all",
         transform_assistant: bool = False,
@@ -377,7 +377,7 @@ class Chat:
     def messages(
         self,
         *,
-        format: Literal["openai"] = "openai",
+        format: Literal["openai"],
         token_limits: tuple[int, int] | None = (4096, 1000),
         transform_user: Literal["all", "last", "none"] = "all",
         transform_assistant: bool = False,
@@ -387,7 +387,7 @@ class Chat:
     def messages(
         self,
         *,
-        format: Literal["ollama"] = "ollama",
+        format: Literal["ollama"],
         token_limits: tuple[int, int] | None = (4096, 1000),
         transform_user: Literal["all", "last", "none"] = "all",
         transform_assistant: bool = False,
@@ -397,7 +397,7 @@ class Chat:
     def messages(
         self,
         *,
-        format: MISSING_TYPE = MISSING,
+        format: Literal["internal"],
         token_limits: tuple[int, int] | None = (4096, 1000),
         transform_user: Literal["all", "last", "none"] = "all",
         transform_assistant: bool = False,
@@ -406,7 +406,7 @@ class Chat:
     def messages(
         self,
         *,
-        format: MISSING_TYPE | ProviderMessageFormat = MISSING,
+        format: ProviderMessageFormat | Literal["internal"],
         token_limits: tuple[int, int] | None = (4096, 1000),
         transform_user: Literal["all", "last", "none"] = "all",
         transform_assistant: bool = False,
@@ -479,7 +479,7 @@ class Chat:
                 )
             content_key = m["transform_key" if transform else "pre_transform_key"]
             chat_msg = ChatMessage(content=m[content_key], role=m["role"])
-            if not isinstance(format, MISSING_TYPE):
+            if format != "internal":
                 chat_msg = as_provider_message(chat_msg, format)
             res.append(chat_msg)
 
@@ -828,7 +828,7 @@ class Chat:
     def _trim_messages(
         messages: tuple[StoredMessage, ...],
         token_limits: tuple[int, int],
-        format: MISSING_TYPE | ProviderMessageFormat,
+        format: ProviderMessageFormat | Literal["internal"],
     ) -> tuple[StoredMessage, ...]:
 
         n_total, n_reserve = token_limits

--- a/tests/pytest/test_chat.py
+++ b/tests/pytest/test_chat.py
@@ -9,7 +9,6 @@ import pytest
 from shiny import Session
 from shiny._namespaces import ResolvedId, Root
 from shiny.session import session_context
-from shiny.types import MISSING
 from shiny.ui import Chat
 from shiny.ui._chat import as_transformed_message
 from shiny.ui._chat_normalize import normalize_message, normalize_message_chunk
@@ -67,7 +66,7 @@ def test_chat_message_trimming():
 
         # Throws since system message is too long
         with pytest.raises(ValueError):
-            chat._trim_messages(msgs, token_limits=(100, 0), format=MISSING)
+            chat._trim_messages(msgs, token_limits=(100, 0), format="internal")
 
         msgs = (
             as_stored_message(
@@ -80,10 +79,9 @@ def test_chat_message_trimming():
 
         # Throws since only the system message fits
         with pytest.raises(ValueError):
-            chat._trim_messages(msgs, token_limits=(100, 0), format=MISSING)
-
+            chat._trim_messages(msgs, token_limits=(100, 0), format="internal")
         # Raising the limit should allow both messages to fit
-        trimmed = chat._trim_messages(msgs, token_limits=(102, 0), format=MISSING)
+        trimmed = chat._trim_messages(msgs, token_limits=(102, 0), format="internal")
         assert len(trimmed) == 2
         contents = [msg["content_server"] for msg in trimmed]
         assert contents == ["System message", "User message"]
@@ -101,7 +99,7 @@ def test_chat_message_trimming():
         )
 
         # Should discard the 1st user message
-        trimmed = chat._trim_messages(msgs, token_limits=(102, 0), format=MISSING)
+        trimmed = chat._trim_messages(msgs, token_limits=(102, 0), format="internal")
         assert len(trimmed) == 2
         contents = [msg["content_server"] for msg in trimmed]
         assert contents == ["System message", "User message 2"]
@@ -122,7 +120,7 @@ def test_chat_message_trimming():
         )
 
         # Should discard the 1st user message
-        trimmed = chat._trim_messages(msgs, token_limits=(102, 0), format=MISSING)
+        trimmed = chat._trim_messages(msgs, token_limits=(102, 0), format="internal")
         assert len(trimmed) == 3
         contents = [msg["content_server"] for msg in trimmed]
         assert contents == ["System message", "System message 2", "User message 2"]

--- a/tests/pytest/test_chat.py
+++ b/tests/pytest/test_chat.py
@@ -9,6 +9,7 @@ import pytest
 from shiny import Session
 from shiny._namespaces import ResolvedId, Root
 from shiny.session import session_context
+from shiny.types import MISSING
 from shiny.ui import Chat
 from shiny.ui._chat import as_transformed_message
 from shiny.ui._chat_normalize import normalize_message, normalize_message_chunk
@@ -66,7 +67,7 @@ def test_chat_message_trimming():
 
         # Throws since system message is too long
         with pytest.raises(ValueError):
-            chat._trim_messages(msgs, token_limits=(100, 0))
+            chat._trim_messages(msgs, token_limits=(100, 0), format=MISSING)
 
         msgs = (
             as_stored_message(
@@ -79,10 +80,10 @@ def test_chat_message_trimming():
 
         # Throws since only the system message fits
         with pytest.raises(ValueError):
-            chat._trim_messages(msgs, token_limits=(100, 0))
+            chat._trim_messages(msgs, token_limits=(100, 0), format=MISSING)
 
         # Raising the limit should allow both messages to fit
-        trimmed = chat._trim_messages(msgs, token_limits=(102, 0))
+        trimmed = chat._trim_messages(msgs, token_limits=(102, 0), format=MISSING)
         assert len(trimmed) == 2
         contents = [msg["content_server"] for msg in trimmed]
         assert contents == ["System message", "User message"]
@@ -100,7 +101,7 @@ def test_chat_message_trimming():
         )
 
         # Should discard the 1st user message
-        trimmed = chat._trim_messages(msgs, token_limits=(102, 0))
+        trimmed = chat._trim_messages(msgs, token_limits=(102, 0), format=MISSING)
         assert len(trimmed) == 2
         contents = [msg["content_server"] for msg in trimmed]
         assert contents == ["System message", "User message 2"]
@@ -121,7 +122,7 @@ def test_chat_message_trimming():
         )
 
         # Should discard the 1st user message
-        trimmed = chat._trim_messages(msgs, token_limits=(102, 0))
+        trimmed = chat._trim_messages(msgs, token_limits=(102, 0), format=MISSING)
         assert len(trimmed) == 3
         contents = [msg["content_server"] for msg in trimmed]
         assert contents == ["System message", "System message 2", "User message 2"]


### PR DESCRIPTION
This changes PR changes `chat.messages()` so that:

- A value for `format` is required. Previously the default value was `MISSING`.
- To get the internal/native format, the user calls it with `chat.messages(format="internal")` (instead of `format=MISSING`, which was the previously the default).

Previously, the default `MISSING` would result in it returning the messages in the internal `ChatMessage` format.  However, this format is actually the least likely format that a user would want -- it is used internally in Shiny, but is not directly usable by any LLMs out there. I think that we don't want to have a default format which is not useful.


Note that this builds on PR #1530.

Also, I'm open to ideas other than `"internal"` for the name.