### PR TITLE
bug: Set min version of typing-extensions to 4.10.0 for `TypeIs` support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ include_package_data = True
 setup_requires =
     setuptools
 install_requires =
-    typing-extensions>=4.0.1
+    typing-extensions>=4.10.0
     uvicorn>=0.16.0;platform_system!="Emscripten"
     starlette
     websockets>=10.0


### PR DESCRIPTION
Originally added in https://github.com/posit-dev/py-shiny/pull/1502/files#diff-edcbc472de7b775474e270c5dbdd2f1d942ed49635d21677717847f0d50b5013R50