### PR TITLE
ci: Adjust pytest verbosity output levels

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -76,7 +76,7 @@ jobs:
       - name: Run End-to-End tests
         timeout-minutes: 20
         run: |
-          make playwright-shiny SUB_FILE=". -vv" ${{ steps.browsers.outputs.browsers }}
+          make playwright-shiny ${{ steps.browsers.outputs.browsers }}
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
@@ -119,7 +119,7 @@ jobs:
       - name: Run example app tests
         timeout-minutes: 20
         run: |
-          make playwright-examples SUB_FILE=". -vv" ${{ steps.browsers.outputs.browsers }}
+          make playwright-examples ${{ steps.browsers.outputs.browsers }}
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
@@ -149,7 +149,7 @@ jobs:
         env:
           DEPLOY_APPS: "false"
         run: |
-          make playwright-deploys SUB_FILE=". -vv"
+          make playwright-deploys
 
       - uses: actions/upload-artifact@v4
         if: failure()

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,5 @@ asyncio_mode=strict
 testpaths=tests/pytest/
 ; Note: Browsers are set within `./Makefile`
 addopts = --strict-markers --durations=6 --durations-min=5.0 --numprocesses auto --tracing=retain-on-failure --video=retain-on-failure
+verbosity_test_cases=2
+verbosity_assertions=2


### PR DESCRIPTION
Return the summary output back to normal size.  Add [`verbosity_test_cases=2`](https://docs.pytest.org/en/stable/reference/reference.html#confval-verbosity_test_cases) and [`verbosity_assertions=2`](https://docs.pytest.org/en/stable/reference/reference.html#confval-verbosity_assertions) to increase status reporting and error debugging. 
