### PR TITLE
feat: support DataFrames via narwhals

### DIFF
--- a/tests/pytest/test_render_data_frame.py
+++ b/tests/pytest/test_render_data_frame.py
@@ -1,3 +1,4 @@
+import narwhals as nw
 import pandas as pd
 import pytest
 


### PR DESCRIPTION
Currently, we have code in `_tbl_data.py`, which uses generic functions to handle DataFrame logic for both pandas and polars. While this works well, it requires that we basically maintain a tiny DataFrame translation layer. This PR starts work towards using narwhals to handle the pandas and polars logic.

The big advantage of narwhals is that it translates the polars API over different DataFrame types (e.g. pandas). Wiring it up means we use our polars logic, but can apply it to pandas, etc..

* @schloerke said he'll take this and run with it (feel free to blast anything; I'm happy to try a narwhals PR if anything is needed)

(Big thanks to @MarcoGorelli for pairing w/ @schloerke, @jcheng5, and I to work on the key pieces :)