### PR TITLE
bug(notification): Allow for duration to be `None` and passed to client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
-* An empty `input_date()` value no longer crashes Shiny. (#1528)
+* An empty `ui.input_date()` value no longer crashes Shiny. (#1528)
 
 * Fixed bug where calling `.update_filter(None)` on a data frame renderer did not visually reset non-numeric column filters. (It did reset the column's filtering, just not the label). Now it resets filter's label. (#1557)
 
 * Require shinyswatch >= 0.7.0 and updated examples accordingly. (#1558)
 
-* `input_text_area(autoresize=True)` now resizes properly even when it's not visible when initially rendered (e.g. in a closed accordion or a hidden tab). (#1560)
+* `ui.input_text_area(autoresize=True)` now resizes properly even when it's not visible when initially rendered (e.g. in a closed accordion or a hidden tab). (#1560)
+
+* `ui.notification_show(duration=None)` now persists the notification until the app user closes it. (#1577)
 
 ### Bug fixes
 

--- a/shiny/ui/_notification.py
+++ b/shiny/ui/_notification.py
@@ -85,7 +85,9 @@ def notification_show(
         "type": type,
     }
 
-    if duration:
+    if duration is None:
+        payload.update({"duration": None})
+    elif duration:
         payload.update({"duration": duration * 1000})
 
     session._send_message_sync({"notification": {"type": "show", "message": payload}})


### PR DESCRIPTION
Working on R side: [shinylive link](https://shinylive.io/r/editor/#code=NobwRAdghgtgpmAXGKAHVA6ASmANGAYwHsIAXOMpMAZwAsBLCATwEF0AKAHQgAIeBXejwC8PAGYAbQQBMAClADmcLrz48oBUvRIAhfqVIkuNWkQDunPD0sBlUxbABKbn0e4XPanABOANx8i4vwQmtoQ7Iyo+rg8RPpRpI48IB58RABGXn5wAKL+ZBEQCQAkdOYxKapqnvYAckRaYvQEUFpGlgCycNTUinA85AAepJbuVdXqoSSBUOy03nBigZYAVlC+UNQE3vSopIgSRC1tEBgLh1DS7I4A3KPWYFhwF9I8qH2WbqkTP7980vxvK0woFagBVAAyEO+rm+AF9nKo4dxHGA4QBdIA)

Reprex app: [shinylive link](https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXGKAHVA6VBPMAaMAYwHsIAXOcpMAMwCdiYACAZwAsBLCbDOAD1R04LFkw4xUxOmSYBXDgB0ISjgHMIUuEwC8cjhg1kONDoShHSAfXbEA7gAolTZ0wVgAKp1E3ZAGwAmTIZM-hwsaKhwUHRMUDQUMQCsLACEbnhOLmTYkdpucHQMdOmZzv6ydOYcpNoAcqRwGRAAlEoqElIyAFYspG0Qglxk9j2kGOUSLPbA9RBwALrNrRBgAL7zQA)

```python
from shiny.express import ui

ignore = ui.notification_show(
    "This should not disappear after 5s!",
    type="error",
    duration=None,
)
```
