### PR TITLE
docs(navset): Add examples for navset

### DIFF
--- a/shiny/api-examples/nav_control/app-core.py
+++ b/shiny/api-examples/nav_control/app-core.py
@@ -1,0 +1,22 @@
+from shiny import App, ui
+
+app_ui = ui.page_fluid(
+    ui.navset_card_underline(
+        ui.nav_control(ui.a("Shiny", href="https://shiny.posit.co", target="_blank")),
+        ui.nav_control(
+            ui.a(
+                "Learn Shiny",
+                href="https://shiny.posit.co/py/docs/overview.html",
+                target="_blank",
+            )
+        ),
+    ),
+    id="tab",
+)
+
+
+def server(input, output, session):
+    pass
+
+
+app = App(app_ui, server)

--- a/shiny/api-examples/nav_control/app-express.py
+++ b/shiny/api-examples/nav_control/app-express.py
@@ -1,0 +1,12 @@
+from shiny.express import ui
+
+with ui.navset_card_underline(id="tab"):
+    with ui.nav_control():
+        ui.a("Shiny", href="https://shiny.posit.co", target="_blank")
+
+    with ui.nav_control():
+        ui.a(
+            "Learn Shiny",
+            href="https://shiny.posit.co/py/docs/overview.html",
+            target="_blank",
+        )

--- a/shiny/api-examples/nav_menu/app-core.py
+++ b/shiny/api-examples/nav_menu/app-core.py
@@ -1,0 +1,20 @@
+from shiny import App, ui
+
+app_ui = ui.page_fluid(
+    ui.navset_card_pill(
+        ui.nav_menu(
+            "Nav Menu items",
+            ui.nav_panel("A", "Panel A content"),
+            ui.nav_panel("B", "Panel B content"),
+            ui.nav_panel("C", "Panel C content"),
+        ),
+        id="card_pill",
+    ),
+)
+
+
+def server(input, output, session):
+    pass
+
+
+app = App(app_ui, server)

--- a/shiny/api-examples/nav_menu/app-express.py
+++ b/shiny/api-examples/nav_menu/app-express.py
@@ -8,4 +8,3 @@ with ui.navset_card_pill(id="card_pill"):
             "Page B content"
         with ui.nav_panel("C"):
             "Page C content"
-

--- a/shiny/api-examples/nav_menu/app-express.py
+++ b/shiny/api-examples/nav_menu/app-express.py
@@ -1,0 +1,11 @@
+from shiny.express import ui
+
+with ui.navset_card_pill(id="card_pill"):
+    with ui.nav_menu("Nav Menu items"):
+        with ui.nav_panel("A"):
+            "Page A content"
+        with ui.nav_panel("B"):
+            "Page B content"
+        with ui.nav_panel("C"):
+            "Page C content"
+

--- a/shiny/api-examples/nav_spacer/app-core.py
+++ b/shiny/api-examples/nav_spacer/app-core.py
@@ -1,0 +1,19 @@
+from shiny import App, ui
+
+app_ui = ui.page_fluid(
+    ui.navset_underline(
+        ui.nav_panel("A", "Panel A content"),
+        ui.nav_spacer(),
+        ui.nav_spacer(),
+        ui.nav_panel("B", "Panel B content"),
+        ui.nav_panel("C", "Panel C content"),
+        id="navset_underline",
+    )
+)
+
+
+def server(input, output, session):
+    pass
+
+
+app = App(app_ui, server)

--- a/shiny/api-examples/nav_spacer/app-express.py
+++ b/shiny/api-examples/nav_spacer/app-express.py
@@ -1,0 +1,11 @@
+from shiny.express import ui
+
+with ui.navset_underline():
+    with ui.nav_panel("Tab 1"):
+        "Tab 1 content"
+    ui.nav_spacer()
+    ui.nav_spacer()
+    with ui.nav_panel("Tab 2"):
+        "Tab 2 content"
+    with ui.nav_panel("Tab 3"):
+        "Tab 3 content"

--- a/shiny/api-examples/navset_bar/app-core.py
+++ b/shiny/api-examples/navset_bar/app-core.py
@@ -1,0 +1,27 @@
+from shiny import App, ui
+
+app_ui = ui.page_fluid(
+    ui.navset_bar(
+        ui.nav_panel("A", "Panel A content"),
+        ui.nav_panel("B", "Panel B content"),
+        ui.nav_panel("C", "Panel C content"),
+        ui.nav_menu(
+            "Other links",
+            ui.nav_panel("D", "Panel D content"),
+            "----",
+            "Description:",
+            ui.nav_control(
+                ui.a("Shiny", href="https://shiny.posit.co", target="_blank")
+            ),
+        ),
+        id="tab",
+        title="Navset Bar",
+    )
+)
+
+
+def server(input, output, session):
+    pass
+
+
+app = App(app_ui, server)

--- a/shiny/api-examples/navset_bar/app-express.py
+++ b/shiny/api-examples/navset_bar/app-express.py
@@ -1,6 +1,6 @@
 from shiny.express import ui
 
-with ui.navset_bar(id="tab"):
+with ui.navset_bar(title="Navset Bar", id="tab"):
     with ui.nav_panel("A"):
         "Panel A content"
 

--- a/shiny/api-examples/navset_bar/app-express.py
+++ b/shiny/api-examples/navset_bar/app-express.py
@@ -1,0 +1,20 @@
+from shiny.express import ui
+
+with ui.navset_bar(id="tab"):
+    with ui.nav_panel("A"):
+        "Panel A content"
+
+    with ui.nav_panel("B"):
+        "Panel B content"
+
+    with ui.nav_panel("C"):
+        "Panel C content"
+
+    with ui.nav_menu("Other links"):
+        with ui.nav_panel("D"):
+            "Page D content"
+
+        "----"
+        "Description:"
+        with ui.nav_control():
+            ui.a("Shiny", href="https://shiny.posit.co", target="_blank")

--- a/shiny/api-examples/navset_card_pill/app-core.py
+++ b/shiny/api-examples/navset_card_pill/app-core.py
@@ -1,0 +1,26 @@
+from shiny import App, ui
+
+app_ui = ui.page_fluid(
+    ui.navset_card_pill(
+        ui.nav_panel("A", "Panel A content"),
+        ui.nav_panel("B", "Panel B content"),
+        ui.nav_panel("C", "Panel C content"),
+        ui.nav_menu(
+            "Other links",
+            ui.nav_panel("D", "Panel D content"),
+            "----",
+            "Description:",
+            ui.nav_control(
+                ui.a("Shiny", href="https://shiny.posit.co", target="_blank")
+            ),
+        ),
+        id="tab",
+    )
+)
+
+
+def server(input, output, session):
+    pass
+
+
+app = App(app_ui, server)

--- a/shiny/api-examples/navset_card_pill/app-express.py
+++ b/shiny/api-examples/navset_card_pill/app-express.py
@@ -1,0 +1,20 @@
+from shiny.express import ui
+
+with ui.navset_card_pill(id="tab"):
+    with ui.nav_panel("A"):
+        "Panel A content"
+
+    with ui.nav_panel("B"):
+        "Panel B content"
+
+    with ui.nav_panel("C"):
+        "Panel C content"
+
+    with ui.nav_menu("Other links"):
+        with ui.nav_panel("D"):
+            "Page D content"
+
+        "----"
+        "Description:"
+        with ui.nav_control():
+            ui.a("Shiny", href="https://shiny.posit.co", target="_blank")

--- a/shiny/api-examples/navset_card_tab/app-core.py
+++ b/shiny/api-examples/navset_card_tab/app-core.py
@@ -1,0 +1,26 @@
+from shiny import App, ui
+
+app_ui = ui.page_fluid(
+    ui.navset_card_tab(
+        ui.nav_panel("A", "Panel A content"),
+        ui.nav_panel("B", "Panel B content"),
+        ui.nav_panel("C", "Panel C content"),
+        ui.nav_menu(
+            "Other links",
+            ui.nav_panel("D", "Panel D content"),
+            "----",
+            "Description:",
+            ui.nav_control(
+                ui.a("Shiny", href="https://shiny.posit.co", target="_blank")
+            ),
+        ),
+        id="tab",
+    )
+)
+
+
+def server(input, output, session):
+    pass
+
+
+app = App(app_ui, server)

--- a/shiny/api-examples/navset_card_tab/app-express.py
+++ b/shiny/api-examples/navset_card_tab/app-express.py
@@ -1,0 +1,20 @@
+from shiny.express import ui
+
+with ui.navset_card_tab(id="tab"):
+    with ui.nav_panel("A"):
+        "Panel A content"
+
+    with ui.nav_panel("B"):
+        "Panel B content"
+
+    with ui.nav_panel("C"):
+        "Panel C content"
+
+    with ui.nav_menu("Other links"):
+        with ui.nav_panel("D"):
+            "Page D content"
+
+        "----"
+        "Description:"
+        with ui.nav_control():
+            ui.a("Shiny", href="https://shiny.posit.co", target="_blank")

--- a/shiny/api-examples/navset_card_underline/app-core.py
+++ b/shiny/api-examples/navset_card_underline/app-core.py
@@ -1,0 +1,26 @@
+from shiny import App, ui
+
+app_ui = ui.page_fluid(
+    ui.navset_card_underline(
+        ui.nav_panel("A", "Panel A content"),
+        ui.nav_panel("B", "Panel B content"),
+        ui.nav_panel("C", "Panel C content"),
+        ui.nav_menu(
+            "Other links",
+            ui.nav_panel("D", "Panel D content"),
+            "----",
+            "Description:",
+            ui.nav_control(
+                ui.a("Shiny", href="https://shiny.posit.co", target="_blank")
+            ),
+        ),
+        id="tab",
+    )
+)
+
+
+def server(input, output, session):
+    pass
+
+
+app = App(app_ui, server)

--- a/shiny/api-examples/navset_card_underline/app-express.py
+++ b/shiny/api-examples/navset_card_underline/app-express.py
@@ -1,0 +1,20 @@
+from shiny.express import ui
+
+with ui.navset_card_underline(id="tab"):
+    with ui.nav_panel("A"):
+        "Panel A content"
+
+    with ui.nav_panel("B"):
+        "Panel B content"
+
+    with ui.nav_panel("C"):
+        "Panel C content"
+
+    with ui.nav_menu("Other links"):
+        with ui.nav_panel("D"):
+            "Page D content"
+
+        "----"
+        "Description:"
+        with ui.nav_control():
+            ui.a("Shiny", href="https://shiny.posit.co", target="_blank")

--- a/shiny/api-examples/navset_pill/app-core.py
+++ b/shiny/api-examples/navset_pill/app-core.py
@@ -1,0 +1,26 @@
+from shiny import App, ui
+
+app_ui = ui.page_fluid(
+    ui.navset_pill(
+        ui.nav_panel("A", "Panel A content"),
+        ui.nav_panel("B", "Panel B content"),
+        ui.nav_panel("C", "Panel C content"),
+        ui.nav_menu(
+            "Other links",
+            ui.nav_panel("D", "Panel D content"),
+            "----",
+            "Description:",
+            ui.nav_control(
+                ui.a("Shiny", href="https://shiny.posit.co", target="_blank")
+            ),
+        ),
+        id="tab",
+    )
+)
+
+
+def server(input, output, session):
+    pass
+
+
+app = App(app_ui, server)

--- a/shiny/api-examples/navset_pill/app-express.py
+++ b/shiny/api-examples/navset_pill/app-express.py
@@ -1,0 +1,20 @@
+from shiny.express import ui
+
+with ui.navset_pill(id="tab"):
+    with ui.nav_panel("A"):
+        "Panel A content"
+
+    with ui.nav_panel("B"):
+        "Panel B content"
+
+    with ui.nav_panel("C"):
+        "Panel C content"
+
+    with ui.nav_menu("Other links"):
+        with ui.nav_panel("D"):
+            "Page D content"
+
+        "----"
+        "Description:"
+        with ui.nav_control():
+            ui.a("Shiny", href="https://shiny.posit.co", target="_blank")

--- a/shiny/api-examples/navset_pill_list/app-core.py
+++ b/shiny/api-examples/navset_pill_list/app-core.py
@@ -1,0 +1,26 @@
+from shiny import App, ui
+
+app_ui = ui.page_fluid(
+    ui.navset_pill_list(
+        ui.nav_panel("A", "Panel A content"),
+        ui.nav_panel("B", "Panel B content"),
+        ui.nav_panel("C", "Panel C content"),
+        ui.nav_menu(
+            "Other links",
+            ui.nav_panel("D", "Panel D content"),
+            "----",
+            "Description:",
+            ui.nav_control(
+                ui.a("Shiny", href="https://shiny.posit.co", target="_blank")
+            ),
+        ),
+        id="tab",
+    )
+)
+
+
+def server(input, output, session):
+    pass
+
+
+app = App(app_ui, server)

--- a/shiny/api-examples/navset_pill_list/app-express.py
+++ b/shiny/api-examples/navset_pill_list/app-express.py
@@ -1,0 +1,20 @@
+from shiny.express import ui
+
+with ui.navset_pill_list(id="tab"):
+    with ui.nav_panel("A"):
+        "Panel A content"
+
+    with ui.nav_panel("B"):
+        "Panel B content"
+
+    with ui.nav_panel("C"):
+        "Panel C content"
+
+    with ui.nav_menu("Other links"):
+        with ui.nav_panel("D"):
+            "Page D content"
+
+        "----"
+        "Description:"
+        with ui.nav_control():
+            ui.a("Shiny", href="https://shiny.posit.co", target="_blank")

--- a/shiny/api-examples/navset_tab/app-core.py
+++ b/shiny/api-examples/navset_tab/app-core.py
@@ -1,0 +1,26 @@
+from shiny import App, ui
+
+app_ui = ui.page_fluid(
+    ui.navset_tab(
+        ui.nav_panel("A", "Panel A content"),
+        ui.nav_panel("B", "Panel B content"),
+        ui.nav_panel("C", "Panel C content"),
+        ui.nav_menu(
+            "Other links",
+            ui.nav_panel("D", "Panel D content"),
+            "----",
+            "Description:",
+            ui.nav_control(
+                ui.a("Shiny", href="https://shiny.posit.co", target="_blank")
+            ),
+        ),
+        id="tab",
+    )
+)
+
+
+def server(input, output, session):
+    pass
+
+
+app = App(app_ui, server)

--- a/shiny/api-examples/navset_tab/app-express.py
+++ b/shiny/api-examples/navset_tab/app-express.py
@@ -1,0 +1,20 @@
+from shiny.express import ui
+
+with ui.navset_tab(id="tab"):
+    with ui.nav_panel("A"):
+        "Panel A content"
+
+    with ui.nav_panel("B"):
+        "Panel B content"
+
+    with ui.nav_panel("C"):
+        "Panel C content"
+
+    with ui.nav_menu("Other links"):
+        with ui.nav_panel("D"):
+            "Page D content"
+
+        "----"
+        "Description:"
+        with ui.nav_control():
+            ui.a("Shiny", href="https://shiny.posit.co", target="_blank")

--- a/shiny/api-examples/navset_underline/app-core.py
+++ b/shiny/api-examples/navset_underline/app-core.py
@@ -1,0 +1,26 @@
+from shiny import App, ui
+
+app_ui = ui.page_fluid(
+    ui.navset_underline(
+        ui.nav_panel("A", "Panel A content"),
+        ui.nav_panel("B", "Panel B content"),
+        ui.nav_panel("C", "Panel C content"),
+        ui.nav_menu(
+            "Other links",
+            ui.nav_panel("D", "Panel D content"),
+            "----",
+            "Description:",
+            ui.nav_control(
+                ui.a("Shiny", href="https://shiny.posit.co", target="_blank")
+            ),
+        ),
+        id="tab",
+    )
+)
+
+
+def server(input, output, session):
+    pass
+
+
+app = App(app_ui, server)

--- a/shiny/api-examples/navset_underline/app-express.py
+++ b/shiny/api-examples/navset_underline/app-express.py
@@ -1,0 +1,20 @@
+from shiny.express import ui
+
+with ui.navset_underline(id="tab"):
+    with ui.nav_panel("A"):
+        "Panel A content"
+
+    with ui.nav_panel("B"):
+        "Panel B content"
+
+    with ui.nav_panel("C"):
+        "Panel C content"
+
+    with ui.nav_menu("Other links"):
+        with ui.nav_panel("D"):
+            "Page D content"
+
+        "----"
+        "Description:"
+        with ui.nav_control():
+            ui.a("Shiny", href="https://shiny.posit.co", target="_blank")

--- a/shiny/express/ui/_cm_components.py
+++ b/shiny/express/ui/_cm_components.py
@@ -726,7 +726,7 @@ def accordion_panel(
 # ======================================================================================
 
 
-@no_example()
+@add_example()
 def navset_tab(
     *,
     id: Optional[str] = None,
@@ -763,7 +763,7 @@ def navset_tab(
     )
 
 
-@no_example()
+@add_example()
 def navset_pill(
     *,
     id: Optional[str] = None,
@@ -800,7 +800,7 @@ def navset_pill(
     )
 
 
-@no_example()
+@add_example()
 def navset_underline(
     *,
     id: Optional[str] = None,
@@ -875,7 +875,7 @@ def navset_hidden(
     )
 
 
-@no_example()
+@add_example()
 def navset_card_tab(
     *,
     id: Optional[str] = None,
@@ -918,7 +918,7 @@ def navset_card_tab(
     )
 
 
-@no_example()
+@add_example()
 def navset_card_pill(
     *,
     id: Optional[str] = None,
@@ -961,7 +961,7 @@ def navset_card_pill(
     )
 
 
-@no_example()
+@add_example()
 def navset_card_underline(
     *,
     id: Optional[str] = None,
@@ -1008,7 +1008,7 @@ def navset_card_underline(
     )
 
 
-@no_example()
+@add_example()
 def navset_pill_list(
     *,
     id: Optional[str] = None,
@@ -1053,7 +1053,7 @@ def navset_pill_list(
     )
 
 
-@no_example()
+@add_example()
 def navset_bar(
     *,
     title: TagChild,

--- a/shiny/express/ui/_cm_components.py
+++ b/shiny/express/ui/_cm_components.py
@@ -1187,7 +1187,7 @@ def nav_panel(
     )
 
 
-@no_example()
+@add_example()
 def nav_control() -> RecallContextManager[NavPanel]:
     """
     Context manager for a control in the navigation container.

--- a/shiny/express/ui/_cm_components.py
+++ b/shiny/express/ui/_cm_components.py
@@ -1197,7 +1197,7 @@ def nav_control() -> RecallContextManager[NavPanel]:
     return RecallContextManager(ui.nav_control)
 
 
-@no_example()
+@add_example()
 def nav_menu(
     title: TagChild,
     *,

--- a/shiny/ui/_navs.py
+++ b/shiny/ui/_navs.py
@@ -23,7 +23,7 @@ from typing import Any, Literal, Optional, Sequence, cast
 
 from htmltools import MetadataNode, Tag, TagAttrs, TagChild, TagList, css, div, tags
 
-from .._docstring import add_example, no_example
+from .._docstring import add_example
 from .._namespaces import resolve_id_or_none
 from .._utils import private_random_int
 from ..types import NavSetArg

--- a/shiny/ui/_navs.py
+++ b/shiny/ui/_navs.py
@@ -185,7 +185,7 @@ def nav_control(*args: TagChild) -> NavPanel:
     return NavPanel(tags.li(*args))
 
 
-@no_example()
+@add_example()
 def nav_spacer() -> NavPanel:
     """
     Create space between nav items.

--- a/shiny/ui/_navs.py
+++ b/shiny/ui/_navs.py
@@ -153,7 +153,7 @@ def nav_panel(
     )
 
 
-@no_example()
+@add_example()
 def nav_control(*args: TagChild) -> NavPanel:
     """
     Place a control in the navigation container.

--- a/shiny/ui/_navs.py
+++ b/shiny/ui/_navs.py
@@ -292,7 +292,7 @@ def menu_string_as_nav(x: str | NavSetArg) -> NavSetArg:
     return NavPanel(nav)
 
 
-@no_example()
+@add_example()
 def nav_menu(
     title: TagChild,
     *args: NavPanel | str,

--- a/shiny/ui/_navs.py
+++ b/shiny/ui/_navs.py
@@ -400,7 +400,7 @@ class NavSet:
 # -----------------------------------------------------------------------------
 # Navigation containers
 # -----------------------------------------------------------------------------
-@no_example()
+@add_example()
 def navset_tab(
     *args: NavSetArg | MetadataNode | Sequence[MetadataNode],
     id: Optional[str] = None,
@@ -457,7 +457,7 @@ def navset_tab(
     )
 
 
-@no_example()
+@add_example()
 def navset_pill(
     *args: NavSetArg | MetadataNode | Sequence[MetadataNode],
     id: Optional[str] = None,
@@ -513,7 +513,7 @@ def navset_pill(
     )
 
 
-@no_example()
+@add_example()
 def navset_underline(
     *args: NavSetArg | MetadataNode | Sequence[MetadataNode],
     id: Optional[str] = None,
@@ -680,7 +680,7 @@ class NavSetCard(NavSet):
         )
 
 
-@no_example()
+@add_example()
 def navset_card_tab(
     *args: NavSetArg | MetadataNode | Sequence[MetadataNode],
     id: Optional[str] = None,
@@ -743,7 +743,7 @@ def navset_card_tab(
     )
 
 
-@no_example()
+@add_example()
 def navset_card_pill(
     *args: NavSetArg | MetadataNode | Sequence[MetadataNode],
     id: Optional[str] = None,
@@ -809,7 +809,7 @@ def navset_card_pill(
     )
 
 
-@no_example()
+@add_example()
 def navset_card_underline(
     *args: NavSetArg | MetadataNode | Sequence[MetadataNode],
     id: Optional[str] = None,
@@ -908,7 +908,7 @@ class NavSetPillList(NavSet):
         )
 
 
-@no_example()
+@add_example()
 def navset_pill_list(
     *args: NavSetArg | MetadataNode | Sequence[MetadataNode],
     id: Optional[str] = None,
@@ -1154,7 +1154,7 @@ def _make_tabs_fillable(
 
 
 # TODO-future; Content should not be indented unless when called from `page_navbar()`
-@no_example()
+@add_example()
 def navset_bar(
     *args: NavSetArg | MetadataNode | Sequence[MetadataNode],
     title: TagChild,


### PR DESCRIPTION
Add examples of the following for both `core` and `express` function reference page

- navset_bar
- navset_card_pill
- navset_card_tab
- navset_card_pill
- navset_card_tab
- navset_card_underline
- navset_pill
- navset_pill_list
- navset_underline
- nav_menu
- nav_control
- nav_spacer