### PR TITLE
docs: Add double-quotes to shiny[theme]

### DIFF
--- a/shiny/ui/_theme.py
+++ b/shiny/ui/_theme.py
@@ -56,7 +56,7 @@ class Theme:
 
     **Note: Compiling custom themes requires the
     [libsass](https://pypi.org/project/libsass/) package**, which is not installed by
-    default with Shiny. Use `pip install libsass` or `pip install shiny[theme]` to
+    default with Shiny. Use `pip install libsass` or `pip install "shiny[theme]"` to
     install it.
 
     Customized themes are compiled to CSS when the theme is used. The `Theme` class
@@ -527,7 +527,7 @@ def check_libsass_installed() -> None:
     if importlib.util.find_spec("sass") is None:
         raise ImportError(
             "The 'libsass' package is required to compile custom themes. "
-            "Please install it with `pip install libsass` or `pip install shiny[theme]`.",
+            'Please install it with `pip install libsass` or `pip install "shiny[theme]"`.',
         )
 
 


### PR DESCRIPTION
Added double-quotes around `shiny[theme]`... code formatter switched from double-quotes to single-quotes in the Python code section; escaping not necessary in the docstring as it's already a triple-quote string.

Fixes #1603 