### PR TITLE
Pin syrupy to avoid pytest-rerunfailures incompatibility

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -77,8 +77,9 @@ test =
     pytest-rerunfailures
     pytest-cov
     coverage
-    # For snapshot testing
-    syrupy
+    # For snapshot testing. v4.6.3 is incompatible with pytest-rerunfailures, see
+    # https://github.com/syrupy-project/syrupy/issues/879
+    syrupy==4.6.2
     psutil
     astropy
     suntime


### PR DESCRIPTION
See https://github.com/syrupy-project/syrupy/issues/879