### PR TITLE
Fix KeyError when serving static files

### DIFF
--- a/shiny/http_staticfiles.py
+++ b/shiny/http_staticfiles.py
@@ -43,7 +43,7 @@ if "pyodide" not in sys.modules:
             **kwargs: Any,
         ) -> starlette.responses.Response:
             resp = super().file_response(full_path, *args, **kwargs)
-            if resp.headers["content-type"].startswith("text/plain"):
+            if resp.headers.get("content-type", "").startswith("text/plain"):
                 correct_type = _utils.guess_mime_type(full_path)
                 resp.headers["content-type"] = (
                     f"{correct_type}; charset={resp.charset}"


### PR DESCRIPTION
Not sure what is triggering this but it's happening intermittently for both @cpsievert and myself.

Not sure why Content-Type would ever be missing, much less intermittently.

Edit: This happens when the server returns `304 Not Modified`... makes sense.