### PR TITLE
ci(remove future behavior warning): Set the `asyncio_default_fixture_loop_scope` to `fixture`

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,7 @@
 [pytest]
 asyncio_mode=strict
+# Used for ./tests/pytest/asyncio_prevent.py
+asyncio_default_fixture_loop_scope=fixture
 testpaths=tests/pytest/
 ; Note: Browsers are set within `./Makefile`
 addopts = --strict-markers --durations=6 --durations-min=5.0 --numprocesses auto


### PR DESCRIPTION
Related: https://github.com/pytest-dev/pytest-asyncio/commit/c74d1c3fba1afac0b8316763257c915bfba5f5e3