### PR TITLE
CI(debug): Print full stdout/stderr when command fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,14 +149,21 @@ clean-js: FORCE
 SUB_FILE:=
 PYTEST_BROWSERS:= --browser webkit --browser firefox --browser chromium
 PYTEST_DEPLOYS_BROWSERS:= --browser chromium
+
+# Full test path to playwright tests
+TEST_FILE:=tests/playwright/$(SUB_FILE)
+# Default `make` values that shouldn't be directly used; (Use `TEST_FILE` instead!)
+DEPLOYS_TEST_FILE:=tests/playwright/deploys$(SUB_FILE)
+SHINY_TEST_FILE:=tests/playwright/shiny/$(SUB_FILE)
+EXAMPLES_TEST_FILE:=tests/playwright/examples/$(SUB_FILE)
+
 install-playwright: FORCE
 	playwright install --with-deps
 
 install-rsconnect: FORCE
 	pip install git+https://github.com/rstudio/rsconnect-python.git#egg=rsconnect-python
 
-# Full test path to playwright tests
-TEST_FILE:="tests/playwright/$(SUB_FILE)"
+
 # All end-to-end tests with playwright
 playwright: install-playwright ## All end-to-end tests with playwright; (TEST_FILE="" from root of repo)
 	pytest $(TEST_FILE) $(PYTEST_BROWSERS)
@@ -169,20 +176,18 @@ playwright-show-trace: ## Show trace of failed tests
 
 # end-to-end tests with playwright; (SUB_FILE="" within tests/playwright/shiny/)
 playwright-shiny: FORCE
-	$(MAKE) playwright TEST_FILE="tests/playwright/shiny/$(SUB_FILE)"
+	$(MAKE) playwright TEST_FILE="$(SHINY_TEST_FILE)"
 
 # end-to-end tests on deployed apps with playwright; (SUB_FILE="" within tests/playwright/deploys/)
 playwright-deploys: FORCE
-	$(MAKE) playwright PYTEST_BROWSERS="$(PYTEST_DEPLOYS_BROWSERS)" TEST_FILE="$(TEST_FILE)"
-playwright-deploys-legacy: FORCE
-	$(MAKE) playwright TEST_FILE="tests/playwright/deploys/$(SUB_FILE)" PYTEST_BROWSERS="$(PYTEST_DEPLOYS_BROWSERS)"
+	$(MAKE) playwright PYTEST_BROWSERS="$(PYTEST_DEPLOYS_BROWSERS)" TEST_FILE="$(DEPLOYS_TEST_FILE)"
 
 # end-to-end tests on all py-shiny examples with playwright; (SUB_FILE="" within tests/playwright/examples/)
 playwright-examples: FORCE
-	$(MAKE) playwright TEST_FILE="tests/playwright/examples/$(SUB_FILE)"
+	$(MAKE) playwright TEST_FILE="$(EXAMPLES_TEST_FILE)"
 
 coverage: FORCE ## check combined code coverage (must run e2e last)
-	pytest --cov-report term-missing --cov=shiny tests/pytest/ tests/playwright/shiny/$(SUB_FILE) $(PYTEST_BROWSERS)
+	pytest --cov-report term-missing --cov=shiny tests/pytest/ $(SHINY_TEST_FILE) $(PYTEST_BROWSERS)
 	coverage html
 	$(BROWSER) htmlcov/index.html
 

--- a/tests/playwright/utils/deploy_utils.py
+++ b/tests/playwright/utils/deploy_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -70,12 +71,31 @@ def skip_on_webkit(fn: CallableT) -> CallableT:
 def run_command(cmd: str) -> str:
     output = subprocess.run(
         cmd,
-        check=True,
+        check=False,
         capture_output=True,
         text=True,
         shell=True,
     )
+    if output.returncode != 0:
+        print(
+            "Failed to run command!",
+            "\nstdout:",
+            output.stdout,
+            "\nstderr:",
+            output.stderr,
+            file=sys.stderr,
+            sep="\n",
+        )
+        raise RuntimeError(f"Failed to run command: {redact_api_key(cmd)}")
     return output.stdout
+
+
+def redact_api_key(cmd: str) -> str:
+    # Redact the value of the `--api-key` CLI argument, replace it with `***`
+    # Create a regex that replaces the argument following `--api-key`
+    # with `***` (e.g. `--api-key my-api-key` -> `--api-key ***`)
+
+    return re.sub(r"(--api-key\s+)(\S+)", r"\1***", cmd)
 
 
 def deploy_to_connect(app_name: str, app_dir: str) -> str:


### PR DESCRIPTION
* Better stderr/stdout output for #1658 
* Fix bug where `make playwright-deploys` was testing all playwright tests, not just `./playwright/deploys` tests