### PR TITLE
fix(shiny create): Use `template.id` for default directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Shiny for Python will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+### Bug fixes
+
+* `shiny create` now uses the template `id` rather than the directory name as the default directory. (#1666)
+
 ## [1.1.0] - 2024-09-03
 
 ### New features

--- a/shiny/_main_create.py
+++ b/shiny/_main_create.py
@@ -657,7 +657,6 @@ def app_template_questions(
     mode: Optional[str] = None,
     dest_dir: Optional[Path] = None,
 ):
-    template_dir = template.path
     template_cli_name = cli_bold(cli_field(template.title or template.id))
 
     if mode == "express" and not template.express_available:
@@ -666,7 +665,7 @@ def app_template_questions(
         )
 
     click.echo(cli_wait(f"Creating {template_cli_name} Shiny app..."))
-    dest_dir = directory_prompt(dest_dir, template_dir.name)
+    dest_dir = directory_prompt(dest_dir, template.id)
 
     if mode is None and template.express_available:
         mode = questionary.select(


### PR DESCRIPTION
Rather than use the template's directory name, we should be using the `template.id` for the default directory in `shiny create`.

### Before

```bash
❯ shiny create
? Which template would you like to use? Basic app
… Creating Basic app Shiny app...
? Enter destination directory: ./01-basic-app
```

### After

```bash
❯ shiny create
? Which template would you like to use? Basic app
… Creating Basic app Shiny app...
? Enter destination directory: ./basic-app
```