### PR TITLE
Destroy `.append_message_stream()`'s error reporting effect only after it gets a chance to run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* Fixed a bug with `Chat()` sometimes silently dropping errors. (#1672)
+
 * `shiny create` now uses the template `id` rather than the directory name as the default directory. (#1666)
 
 ## [1.1.0] - 2024-09-03

--- a/shiny/ui/_chat.py
+++ b/shiny/ui/_chat.py
@@ -571,19 +571,12 @@ class Chat:
 
         # Since the task runs in the background (outside/beyond the current context,
         # if any), we need to manually raise any exceptions that occur
-        try:
-            ctx = reactive.get_current_context()
-        except Exception:
-            return
-
         @reactive.effect
         async def _handle_error():
             e = _stream_task.error()
             if e:
                 await self._raise_exception(e)
-
-        ctx.on_invalidate(_handle_error.destroy)
-        self._effects.append(_handle_error)
+            _handle_error.destroy()  # type: ignore
 
     async def _append_message_stream(self, message: AsyncIterable[Any]):
         id = _utils.private_random_id()


### PR DESCRIPTION
At least a couple times now, I've encountered situations where `.append_message_stream()` was failing to raise/report errors that occur inside of it. Here is the most recent example I came across:

```python
import litellm
from shiny.express import ui

chat = ui.Chat(id="chat")
chat.ui()

@chat.on_user_submit
async def _():
    messages = chat.messages()
    # Make sure you have OPENAI_API_KEY set in your environment
    response = litellm.completion(model="gpt-4o", messages=messages, stream=True)
    await chat.append_message_stream(response)
```

It turns out that, in this case, the effect that listens to and reports errors in the streaming task (`_handle_error`) gets invalidated before the effects gets a chance to run. In hindsight, this is an obvious mistake in the original implementation, and it'd be much better to cleanup the effect only after it runs.

With this change, when you run the code above, you'll get the error reported correctly:

<img width="654" alt="Screenshot 2024-09-05 at 1 26 22 PM" src="https://github.com/user-attachments/assets/94430b06-112d-4722-8581-8b22e5dd5f7d">