### PR TITLE
tests(video): Revert to page fixture that exists per session (not just function)

### DIFF
--- a/.github/py-shiny/pytest-browsers/action.yaml
+++ b/.github/py-shiny/pytest-browsers/action.yaml
@@ -39,7 +39,7 @@ runs:
           else
             echo "Using playwright diagnostics!"
             echo 'has-playwright-diagnostics=true' >> "$GITHUB_OUTPUT"
-            echo 'playwright-diagnostic-args=--tracing=retain-on-failure --video=retain-on-failure --screenshot=only-on-failure --full-page-screenshot --output=test-results' >> "$GITHUB_OUTPUT"
+            echo 'playwright-diagnostic-args=--tracing=retain-on-failure --screenshot=only-on-failure --full-page-screenshot --video off --output=test-results' >> "$GITHUB_OUTPUT"
           fi
 
           if [ "${{ inputs.browser }}" != "" ]; then

--- a/tests/playwright/conftest.py
+++ b/tests/playwright/conftest.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from pathlib import PurePath
 
+import pytest
+from playwright.sync_api import BrowserContext, Page
+
 from shiny.pytest import ScopeName as ScopeName
 from shiny.pytest import create_app_fixture
 
@@ -17,6 +20,39 @@ __all__ = (
 
 here = PurePath(__file__).parent
 here_root = here.parent.parent
+
+
+# Make a single page fixture that can be used by all tests
+@pytest.fixture(scope="session")
+# By using a single page, the browser is only launched once and all tests run in the same tab / page.
+def session_page(browser: BrowserContext) -> Page:
+    """
+    Create a new page within the given browser context.
+    Parameters:
+        browser (BrowserContext): The browser context in which to create the new page.
+    Returns:
+        Page: The newly created page.
+    """
+    return browser.new_page()
+
+
+@pytest.fixture(scope="function")
+# By going to `about:blank`, we _reset_ the page to a known state before each test.
+# It is not perfect, but it is faster than making a new page for each test.
+# This must be done before each test
+def page(session_page: Page) -> Page:
+    """
+    Reset the given page to a known state before each test.
+    The page is built on the session_page, which is maintained over the full session.
+    The page will visit "about:blank" to reset between apps.
+    The default viewport size is set to 1920 x 1080 (1080p) for each test function.
+    Parameters:
+        session_page (Page): The page to reset.
+    """
+    session_page.goto("about:blank")
+    # Reset screen size to 1080p
+    session_page.set_viewport_size({"width": 1920, "height": 1080})
+    return session_page
 
 
 def create_example_fixture(

--- a/tests/playwright/playwright-pytest.ini
+++ b/tests/playwright/playwright-pytest.ini
@@ -13,4 +13,4 @@ asyncio_mode=strict
 # # --headed: Headed browser testing
 # # -r P: Show extra test summary info: (f)ailed, (E)rror, (s)kipped, (x)failed, (X)passed, (p)assed, (P)assed with output, (a)ll except passed (p/P), or (A)ll. (w)arnings...
 # --maxfail=1: Stop after 1 failure has occurred
-addopts = --strict-markers --durations=6 --durations-min=5.0 --browser chromium --numprocesses auto -vvv --maxfail=1 --headed --tracing=on --video=on --slowmo=250
+addopts = --strict-markers --durations=6 --durations-min=5.0 --browser chromium --numprocesses auto -vvv --maxfail=1 --headed --tracing=on --slowmo=250


### PR DESCRIPTION
We want to remove video for debugging test failures on GitHub Actions since most debugging seems to happen locally and enabling that feature means we cannot use the same page for the duration of the session making our runs slower.