### PR TITLE
test: Add skip for airmass example on python 3.9

### DIFF
--- a/tests/playwright/examples/test_examples.py
+++ b/tests/playwright/examples/test_examples.py
@@ -54,5 +54,5 @@ def skip_airmass_on_3_9(ex_app_path: str) -> None:
         )
     except ImportError:
         pytest.skip(
-            "astropy and numpy has difficulty loading on python 3.9. Skipping example app: airmass. posit-dev/py-shiny#1651"
+            "astropy and numpy has difficulty loading on python 3.9. Skipping example app: airmass. posit-dev/py-shiny#1678"
         )

--- a/tests/playwright/examples/test_examples.py
+++ b/tests/playwright/examples/test_examples.py
@@ -54,7 +54,7 @@ def skip_airmass_on_3_9(ex_app_path: str) -> None:
         raise RuntimeError(
             "This code believes astropy and numpy have difficulty loading on python 3.9. Please remove this check if it is no longer true."
         )
-    except AttributeError as e:
+    except RuntimeError as e:
         if "numpy" in str(e) and "product" in str(e):
             pytest.skip(
                 "astropy and numpy has difficulty loading on python 3.9. Skipping example app: airmass. posit-dev/py-shiny#1678"

--- a/tests/playwright/examples/test_examples.py
+++ b/tests/playwright/examples/test_examples.py
@@ -52,7 +52,12 @@ def skip_airmass_on_3_9(ex_app_path: str) -> None:
         raise RuntimeError(
             "This code believes astropy and numpy have difficulty loading on python 3.9. Please remove this check if it is no longer true."
         )
-    except ImportError:
-        pytest.skip(
-            "astropy and numpy has difficulty loading on python 3.9. Skipping example app: airmass. posit-dev/py-shiny#1678"
-        )
+    except AttributeError as e:
+        if "numpy" in str(e) and "product" in str(e):
+            pytest.skip(
+                "astropy and numpy has difficulty loading on python 3.9. Skipping example app: airmass. posit-dev/py-shiny#1678"
+            )
+            return
+
+        # Future proofing: if the error is not what we expect, raise it
+        raise e

--- a/tests/playwright/examples/test_examples.py
+++ b/tests/playwright/examples/test_examples.py
@@ -46,7 +46,7 @@ def skip_airmass_on_3_9(ex_app_path: str) -> None:
 
     try:
         # Astropy loads `numpy` at run time
-        import astropy  # type: ignore
+        import astropy  # pyright: ignore # noqa: F401
 
         # Future proofing: if astropy is _actually_ loading, raise an error
         raise RuntimeError(

--- a/tests/playwright/examples/test_examples.py
+++ b/tests/playwright/examples/test_examples.py
@@ -33,3 +33,26 @@ def skip_on_windows_with_timezonefinder(ex_app_path: str) -> None:
         pytest.skip(
             "timezonefinder has difficulty compiling on windows. Skipping example app. posit-dev/py-shiny#1651"
         )
+
+
+def skip_airmass_on_3_9(ex_app_path: str) -> None:
+    if ex_app_path != "examples/airmass/app.py":
+        return
+
+    import sys
+
+    if sys.version_info[:2] != (3, 9):
+        return
+
+    try:
+        # Astropy loads `numpy` at run time
+        import astropy  # type: ignore
+
+        # Future proofing: if astropy is _actually_ loading, raise an error
+        raise RuntimeError(
+            "This code believes astropy and numpy have difficulty loading on python 3.9. Please remove this check if it is no longer true."
+        )
+    except ImportError:
+        pytest.skip(
+            "astropy and numpy has difficulty loading on python 3.9. Skipping example app: airmass. posit-dev/py-shiny#1651"
+        )

--- a/tests/playwright/examples/test_examples.py
+++ b/tests/playwright/examples/test_examples.py
@@ -48,7 +48,8 @@ def skip_airmass_on_3_9(ex_app_path: str) -> None:
 
     try:
         # Astropy loads `numpy` at run time
-        import astropy  # pyright: ignore # noqa: F401
+        import astropy.coordinates as _  # pyright: ignore # noqa: F401
+        import astropy.units as __  # pyright: ignore # noqa: F401
 
         # Future proofing: if astropy is _actually_ loading, raise an error
         raise RuntimeError(

--- a/tests/playwright/examples/test_examples.py
+++ b/tests/playwright/examples/test_examples.py
@@ -55,7 +55,7 @@ def skip_airmass_on_3_9(ex_app_path: str) -> None:
         raise RuntimeError(
             "This code believes astropy and numpy have difficulty loading on python 3.9. Please remove this check if it is no longer true."
         )
-    except RuntimeError as e:
+    except AttributeError as e:
         if "numpy" in str(e) and "product" in str(e):
             pytest.skip(
                 "astropy and numpy has difficulty loading on python 3.9. Skipping example app: airmass. posit-dev/py-shiny#1678"

--- a/tests/playwright/examples/test_examples.py
+++ b/tests/playwright/examples/test_examples.py
@@ -12,6 +12,7 @@ is_windows = sys.platform.startswith("win")
 def test_examples(page: Page, ex_app_path: str) -> None:
 
     skip_on_windows_with_timezonefinder(ex_app_path)
+    skip_airmass_on_3_9(ex_app_path)
 
     validate_example(page, ex_app_path)
 
@@ -36,6 +37,7 @@ def skip_on_windows_with_timezonefinder(ex_app_path: str) -> None:
 
 
 def skip_airmass_on_3_9(ex_app_path: str) -> None:
+    print(ex_app_path)
     if ex_app_path != "examples/airmass/app.py":
         return
 

--- a/tests/playwright/shiny/components/data_frame/pandas_compatible/test_df_pandas_compatible.py
+++ b/tests/playwright/shiny/components/data_frame/pandas_compatible/test_df_pandas_compatible.py
@@ -1,11 +1,16 @@
 import re
 
 from playwright.sync_api import Page
+from pytest._utils import skip_on_python_version
 
 from shiny.playwright import controller
 from shiny.run import ShinyAppProc
 
 
+@skip_on_python_version(
+    "3.9",
+    reason="Astropy (and numpy) hav difficulty loading on python 3.9. posit-dev/py-shiny#1678",
+)
 def test_data_frame_pandas_compatible(
     page: Page,
     local_app: ShinyAppProc,

--- a/tests/playwright/shiny/components/data_frame/pandas_compatible/test_df_pandas_compatible.py
+++ b/tests/playwright/shiny/components/data_frame/pandas_compatible/test_df_pandas_compatible.py
@@ -1,7 +1,7 @@
 import re
 
 from playwright.sync_api import Page
-from pytest._utils import skip_on_python_version
+from utils.deploy_utils import skip_on_python_version
 
 from shiny.playwright import controller
 from shiny.run import ShinyAppProc

--- a/tests/playwright/utils/deploy_utils.py
+++ b/tests/playwright/utils/deploy_utils.py
@@ -98,14 +98,6 @@ def skip_on_python_version(
 
         return fn
 
-    def _(fn: CallableT) -> CallableT:
-        fn = pytest.mark.skipif(
-            sys.platform.startswith("win"),
-            reason="Does not run on windows",
-        )(fn)
-
-        return fn
-
     return _
 
 

--- a/tests/playwright/utils/deploy_utils.py
+++ b/tests/playwright/utils/deploy_utils.py
@@ -9,7 +9,7 @@ import sys
 import tempfile
 import time
 import warnings
-from typing import Any, Callable, List, TypeVar
+from typing import Any, Callable, List, Optional, TypeVar
 
 import pytest
 import requests
@@ -66,6 +66,47 @@ def skip_on_webkit(fn: CallableT) -> CallableT:
     fn = pytest.mark.skip_browser("webkit")(fn)
 
     return fn
+
+
+def skip_on_python_version(
+    version: str,
+    reason: Optional[str] = None,
+) -> Callable[[CallableT], CallableT]:
+
+    reason_str = reason or f"Do not run on python {version}"
+
+    is_valid_version = (
+        re.match(r"\d+", version)
+        or re.match(r"\d+\.\d+", version)
+        or re.match(r"\d+\.\d+\.\d+", version)
+    ) is not None
+
+    assert is_valid_version
+
+    def _(fn: CallableT) -> CallableT:
+
+        versions_match = True
+        for i, v in enumerate(version.split(".")):
+            if sys.version_info[i] != int(v):
+                versions_match = False
+                break
+
+        fn = pytest.mark.skipif(
+            versions_match,
+            reason=reason_str,
+        )(fn)
+
+        return fn
+
+    def _(fn: CallableT) -> CallableT:
+        fn = pytest.mark.skipif(
+            sys.platform.startswith("win"),
+            reason="Does not run on windows",
+        )(fn)
+
+        return fn
+
+    return _
 
 
 def run_command(cmd: str) -> str:

--- a/tests/pytest/_utils.py
+++ b/tests/pytest/_utils.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import re
 import sys
-from typing import Any, Callable, TypeVar
+from typing import Any, Callable, Optional, TypeVar
 
 import pytest
 
@@ -15,3 +16,44 @@ def skip_on_windows(fn: CallableT) -> CallableT:
     )(fn)
 
     return fn
+
+
+def skip_on_python_version(
+    version: str,
+    reason: Optional[str] = None,
+) -> Callable[[CallableT], CallableT]:
+
+    reason_str = reason or f"Do not run on python {version}"
+
+    is_valid_version = (
+        re.match(r"\d+", version)
+        or re.match(r"\d+\.\d+", version)
+        or re.match(r"\d+\.\d+\.\d+", version)
+    ) is not None
+
+    assert is_valid_version
+
+    def _(fn: CallableT) -> CallableT:
+
+        versions_match = True
+        for i, v in enumerate(version.split(".")):
+            if sys.version_info[i] != int(v):
+                versions_match = False
+                break
+
+        fn = pytest.mark.skipif(
+            versions_match,
+            reason=reason_str,
+        )(fn)
+
+        return fn
+
+    def _(fn: CallableT) -> CallableT:
+        fn = pytest.mark.skipif(
+            sys.platform.startswith("win"),
+            reason="Does not run on windows",
+        )(fn)
+
+        return fn
+
+    return _

--- a/tests/pytest/_utils.py
+++ b/tests/pytest/_utils.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-import re
 import sys
-from typing import Any, Callable, Optional, TypeVar
+from typing import Any, Callable, TypeVar
 
 import pytest
 
@@ -16,44 +15,3 @@ def skip_on_windows(fn: CallableT) -> CallableT:
     )(fn)
 
     return fn
-
-
-def skip_on_python_version(
-    version: str,
-    reason: Optional[str] = None,
-) -> Callable[[CallableT], CallableT]:
-
-    reason_str = reason or f"Do not run on python {version}"
-
-    is_valid_version = (
-        re.match(r"\d+", version)
-        or re.match(r"\d+\.\d+", version)
-        or re.match(r"\d+\.\d+\.\d+", version)
-    ) is not None
-
-    assert is_valid_version
-
-    def _(fn: CallableT) -> CallableT:
-
-        versions_match = True
-        for i, v in enumerate(version.split(".")):
-            if sys.version_info[i] != int(v):
-                versions_match = False
-                break
-
-        fn = pytest.mark.skipif(
-            versions_match,
-            reason=reason_str,
-        )(fn)
-
-        return fn
-
-    def _(fn: CallableT) -> CallableT:
-        fn = pytest.mark.skipif(
-            sys.platform.startswith("win"),
-            reason="Does not run on windows",
-        )(fn)
-
-        return fn
-
-    return _


### PR DESCRIPTION
Error when trying to run `./examples/airmass/app.py`:

```
    import astropy.units as u
  File "/opt/hostedtoolcache/Python/3.9.19/x64/lib/python3.9/site-packages/astropy/units/__init__.py", line 23, in <module>
    from .quantity import *
  File "/opt/hostedtoolcache/Python/3.9.19/x64/lib/python3.9/site-packages/astropy/units/quantity.py", line 36, in <module>
    from .quantity_helper import can_have_arbitrary_unit, check_output, converters_and_unit
  File "/opt/hostedtoolcache/Python/3.9.19/x64/lib/python3.9/site-packages/astropy/units/quantity_helper/__init__.py", line 16, in <module>
    from . import erfa, function_helpers, helpers, scipy_special
  File "/opt/hostedtoolcache/Python/3.9.19/x64/lib/python3.9/site-packages/astropy/units/quantity_helper/function_helpers.py", line 79, in <module>
    np.prod, np.product, np.cumprod, np.cumproduct,
  File "/opt/hostedtoolcache/Python/3.9.19/x64/lib/python3.9/site-packages/numpy/__init__.py", line 410, in __getattr__
    raise AttributeError("module {!r} has no attribute "
AttributeError: module 'numpy' has no attribute 'product'
```

So, disabling test on python 3.9 as it is a smoke test that is covered by other python versions.

astropy is very aggressive on their min python version. Therefore, it is possible to get a not-optimal combination of packages being installed:
* `numpy` == 2.0.2
* `astropy` == 5.3.2