### PR TITLE
Fix css compilation in Windows

### DIFF
--- a/shiny/ui/_theme.py
+++ b/shiny/ui/_theme.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import pathlib
+import platform
 import re
 import tempfile
 import textwrap
@@ -426,7 +427,10 @@ class Theme:
             **args,
         }
 
-        self._css = sass.compile(string=self.to_sass(), **args)
+        sass_str = self.to_sass()
+        if platform.system() == "Windows":
+            sass_str = sass_str.replace("\\", "\\\\")
+        self._css = sass.compile(string=sass_str, **args)
 
         return self._css
 


### PR DESCRIPTION
In Windows the string `self.to_sass()` generates is like `@import "some\path\in\windows..."`, which causes `CompileError: Error: File to import not found or unreadable: somepathinwindows...`, an escape character issue.

I assume a simple string replace can fix it.
