### PR TITLE
fix: Use posix paths in import statements in Sass strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Fixed a bug with `Chat()` sometimes silently dropping errors. (#1672)
 
-* `shiny create` now uses the template `id` rather than the directory name as the default directory. (#1666)
+* `shiny create` now uses the template `id` rather than the directory name as the default directory.
+(#1666)
+
+* `ui.Theme()` now works correctly on Windows when the theme requires Sass compilation. (thanks @yuuuxt, #1684)
 
 ## [1.1.0] - 2024-09-03
 

--- a/shiny/ui/_theme.py
+++ b/shiny/ui/_theme.py
@@ -510,7 +510,10 @@ def path_pkg_preset(preset: ShinyThemePreset, *args: str) -> str:
     #> "{shiny}/www/shared/sass/preset/shiny/bootstrap.min.css"
     ```
     """
-    return os.path.realpath(path_pkg_www("sass", "preset", str(preset), *args))
+    path = os.path.realpath(path_pkg_www("sass", "preset", str(preset), *args))
+    # these paths end up in strings passed to sass.compile(). Converting to POSIX means
+    # we use forward slashes to avoid needing to double-escape the Windows backslash
+    return pathlib.Path(path).as_posix()
 
 
 def check_is_valid_preset(preset: ShinyThemePreset) -> None:


### PR DESCRIPTION
Fixes #1681

We are currently relying on `os.path.join()` and `os.path.realpath()` which is usually the right choice, but because we're putting the path into another string, we need better escaping for path separators (or better path separators).

The new approach is to use `Path(path).as_posix()` to convert `c:\mydir\...\_01_functions.scss` to `c:/mydir/.../_01_functions.scss`, which then drops into the Sass strings easily.

The code below was run on Windows 11, where the problem is reproducible and highlights the core issue.

```python
from shiny.ui._theme import path_pkg_preset
import sass
import os
from pathlib import Path

path_functions = path_pkg_preset("shiny", "_01_functions.scss")
path_functions
#> 'C:\\Users\\garrick\\Documents\\external\\shiny_css_compilation_demo\\.venv\\Lib\\site-packages\\shiny\\www\\shared\\sass\\preset\\shiny\\_01_functions.scss'
f'@import "{path_functions}"'
#> '@import "C:\\Users\\garrick\\Documents\\external\\shiny_css_compilation_demo\\.venv\\Lib\\site-packages\\shiny\\www\\shared\\sass\\preset\\shiny\\_01_functions.scss"'
f'@import "{Path(path_functions).as_posix()}"'
#> '@import "C:/Users/garrick/Documents/external/shiny_css_compilation_demo/.venv/Lib/site-packages/shiny/www/shared/sass/preset/shiny/_01_functions.scss"'
```