### PR TITLE
chore: Add types and check action for py-htmltools

### DIFF
--- a/.github/py-shiny/check/action.yaml
+++ b/.github/py-shiny/check/action.yaml
@@ -1,5 +1,5 @@
 name: 'check py-shiny'
-description: 'Action that checks py-shiny in multiple steps so that any of them may fail but not prevent the others from running'
+description: 'Action that checks py-shiny in multiple steps so that any of them may fail but not prevent the others from running. Note, this action is used by py-htmltools as a way to consistently check py-shiny. If more checks are needed for py-htmltools to believe py-shiny is working, it should be added here.'
 runs:
   using: "composite"
   steps:

--- a/.github/py-shiny/check/action.yaml
+++ b/.github/py-shiny/check/action.yaml
@@ -4,31 +4,32 @@ runs:
   using: "composite"
   steps:
     - name: Run unit tests
-      if: steps.install.outcome == 'success' && (success() || failure())
       shell: bash
       run: |
+        # Run unit tests
         make check-tests
 
     - name: Type check
-      if: steps.install.outcome == 'success' && (success() || failure())
       shell: bash
       run: |
+        # Type check
         make check-types
 
     - name: Lint code
-      if: steps.install.outcome == 'success' && (success() || failure())
       shell: bash
       run: |
+        # Lint code
         make check-lint
 
     - name: Verify code formatting
-      if: steps.install.outcome == 'success' && (success() || failure())
       shell: bash
       run: |
+        # Verify code formatting
         make check-format
 
     - name: Verify code can run with mypy (not Windows)
       if: ${{ runner.os != 'Windows' }}
       shell: bash
       run: |
+        # Verify code can run with mypy (not Windows)
         make ci-check-mypy-can-run

--- a/.github/py-shiny/check/action.yaml
+++ b/.github/py-shiny/check/action.yaml
@@ -1,0 +1,34 @@
+name: 'check py-shiny'
+description: 'Action that checks py-shiny in multiple steps so that any of them may fail but not prevent the others from running'
+runs:
+  using: "composite"
+  steps:
+    - name: Run unit tests
+      if: steps.install.outcome == 'success' && (success() || failure())
+      shell: bash
+      run: |
+        make check-tests
+
+    - name: Type check
+      if: steps.install.outcome == 'success' && (success() || failure())
+      shell: bash
+      run: |
+        make check-types
+
+    - name: Lint code
+      if: steps.install.outcome == 'success' && (success() || failure())
+      shell: bash
+      run: |
+        make check-lint
+
+    - name: Verify code formatting
+      if: steps.install.outcome == 'success' && (success() || failure())
+      shell: bash
+      run: |
+        make check-format
+
+    - name: Verify code can run with mypy (not Windows)
+      if: ${{ runner.os != 'Windows' }}
+      shell: bash
+      run: |
+        make ci-check-mypy-can-run

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -3,7 +3,7 @@ name: Run tests
 on:
   workflow_dispatch:
   push:
-    branches: ["main", "rc-*", "htmltools_type_changes"]
+    branches: ["main", "rc-*"]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   release:
@@ -38,34 +38,30 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Check
+      - name: Run unit tests
         if: steps.install.outcome == 'success' && (success() || failure())
-        uses: ./.github/py-shiny/check
+        run: |
+          make check-tests
 
-      # - name: Run unit tests
-      #   if: steps.install.outcome == 'success' && (success() || failure())
-      #   run: |
-      #     make check-tests
+      - name: Type check
+        if: steps.install.outcome == 'success' && (success() || failure())
+        run: |
+          make check-types
 
-      # - name: Type check
-      #   if: steps.install.outcome == 'success' && (success() || failure())
-      #   run: |
-      #     make check-types
+      - name: Lint code
+        if: steps.install.outcome == 'success' && (success() || failure())
+        run: |
+          make check-lint
 
-      # - name: Lint code
-      #   if: steps.install.outcome == 'success' && (success() || failure())
-      #   run: |
-      #     make check-lint
+      - name: Verify code formatting
+        if: steps.install.outcome == 'success' && (success() || failure())
+        run: |
+          make check-format
 
-      # - name: Verify code formatting
-      #   if: steps.install.outcome == 'success' && (success() || failure())
-      #   run: |
-      #     make check-format
-
-      # - name: Verify code can run with mypy (not Windows)
-      #   if: steps.install.outcome == 'success' && (success() || failure()) && matrix.os != 'windows-latest'
-      #   run: |
-      #     make ci-check-mypy-can-run
+      - name: Verify code can run with mypy (not Windows)
+        if: steps.install.outcome == 'success' && (success() || failure()) && matrix.os != 'windows-latest'
+        run: |
+          make ci-check-mypy-can-run
 
   pypi:
     name: "Deploy to PyPI"

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -3,7 +3,7 @@ name: Run tests
 on:
   workflow_dispatch:
   push:
-    branches: ["main", "rc-*"]
+    branches: ["main", "rc-*", "htmltools_type_changes"]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   release:
@@ -38,30 +38,34 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Run unit tests
+      - name: Check
         if: steps.install.outcome == 'success' && (success() || failure())
-        run: |
-          make check-tests
+        uses: ./.github/py-shiny/check
 
-      - name: Type check
-        if: steps.install.outcome == 'success' && (success() || failure())
-        run: |
-          make check-types
+      # - name: Run unit tests
+      #   if: steps.install.outcome == 'success' && (success() || failure())
+      #   run: |
+      #     make check-tests
 
-      - name: Lint code
-        if: steps.install.outcome == 'success' && (success() || failure())
-        run: |
-          make check-lint
+      # - name: Type check
+      #   if: steps.install.outcome == 'success' && (success() || failure())
+      #   run: |
+      #     make check-types
 
-      - name: Verify code formatting
-        if: steps.install.outcome == 'success' && (success() || failure())
-        run: |
-          make check-format
+      # - name: Lint code
+      #   if: steps.install.outcome == 'success' && (success() || failure())
+      #   run: |
+      #     make check-lint
 
-      - name: Verify code can run with mypy (not Windows)
-        if: steps.install.outcome == 'success' && (success() || failure()) && matrix.os != 'windows-latest'
-        run: |
-          make ci-check-mypy-can-run
+      # - name: Verify code formatting
+      #   if: steps.install.outcome == 'success' && (success() || failure())
+      #   run: |
+      #     make check-format
+
+      # - name: Verify code can run with mypy (not Windows)
+      #   if: steps.install.outcome == 'success' && (success() || failure()) && matrix.os != 'windows-latest'
+      #   run: |
+      #     make ci-check-mypy-can-run
 
   pypi:
     name: "Deploy to PyPI"

--- a/shiny/ui/_navs.py
+++ b/shiny/ui/_navs.py
@@ -1,5 +1,33 @@
 from __future__ import annotations
 
+import collections.abc
+import copy
+import re
+from typing import Any, Literal, Optional, Sequence, cast
+
+from htmltools import (
+    HTML,
+    MetadataNode,
+    Tag,
+    TagAttrs,
+    TagChild,
+    TagList,
+    css,
+    div,
+    tags,
+)
+
+from .._docstring import add_example
+from .._namespaces import resolve_id_or_none
+from .._utils import private_random_int
+from ..types import NavSetArg
+from ._bootstrap import column, row
+from ._card import CardItem, WrapperCallable, card, card_body, card_footer, card_header
+from ._html_deps_shinyverse import components_dependencies
+from ._sidebar import Sidebar, layout_sidebar
+from .css import CssUnit, as_css_padding, as_css_unit
+from .fill import as_fill_item, as_fillable_container
+
 __all__ = (
     "nav_panel",
     "nav_menu",
@@ -15,24 +43,6 @@ __all__ = (
     "navset_hidden",
     "navset_bar",
 )
-
-import collections.abc
-import copy
-import re
-from typing import Any, Literal, Optional, Sequence, cast
-
-from htmltools import MetadataNode, Tag, TagAttrs, TagChild, TagList, css, div, tags
-
-from .._docstring import add_example
-from .._namespaces import resolve_id_or_none
-from .._utils import private_random_int
-from ..types import NavSetArg
-from ._bootstrap import column, row
-from ._card import CardItem, WrapperCallable, card, card_body, card_footer, card_header
-from ._html_deps_shinyverse import components_dependencies
-from ._sidebar import Sidebar, layout_sidebar
-from .css import CssUnit, as_css_padding, as_css_unit
-from .fill import as_fill_item, as_fillable_container
 
 
 # -----------------------------------------------------------------------------
@@ -81,7 +91,7 @@ class NavPanel:
 
         return nav, content
 
-    def get_value(self) -> Optional[str]:
+    def get_value(self) -> str | HTML | None:
         if self.content is None:
             return None
         a_tag = cast(Tag, self.nav.children[0])

--- a/tests/pytest/test_modules.py
+++ b/tests/pytest/test_modules.py
@@ -6,7 +6,7 @@ import asyncio
 from typing import cast
 
 import pytest
-from htmltools import Tag, TagList
+from htmltools import HTML, Tag, TagList
 
 from shiny import App, Inputs, Outputs, Session, module, reactive, ui
 from shiny._connection import MockConnection
@@ -28,7 +28,7 @@ def mod_outer_ui() -> TagList:
     return TagList(mod_inner_ui("inner"), ui.output_text("out2"))
 
 
-def get_id(x: TagList, child_idx: int = 0) -> str:
+def get_id(x: TagList, child_idx: int = 0) -> str | HTML:
     return cast(Tag, x[child_idx]).attrs["id"]
 
 
@@ -44,7 +44,7 @@ def test_module_ui():
 
 @pytest.mark.asyncio
 async def test_session_scoping():
-    sessions: dict[str, Session | str | None] = {}
+    sessions: dict[str, Session | str | HTML | None] = {}
 
     @module.server
     def inner_server(input: Inputs, output: Outputs, session: Session):


### PR DESCRIPTION
Related to #1690 and posit-dev/py-htmltools#86

Adds a new `check` action to check the local py-shiny. Note, the py-shiny repo is NOT going to utilize it as the formatting of the job steps is not ideal. However, it is good enough for htmltools' testing.