### PR TITLE
chore: More minor type changes in prep for py-htmltools updates

### DIFF
--- a/shiny/types.py
+++ b/shiny/types.py
@@ -209,7 +209,7 @@ class NavSetArg(Protocol):
         """
         ...
 
-    def get_value(self) -> Optional[str]:
+    def get_value(self) -> str | None:
         """
         Get the value of this navigation item (if any).
 

--- a/shiny/ui/_navs.py
+++ b/shiny/ui/_navs.py
@@ -91,11 +91,14 @@ class NavPanel:
 
         return nav, content
 
-    def get_value(self) -> str | HTML | None:
+    def get_value(self) -> str | None:
         if self.content is None:
             return None
         a_tag = cast(Tag, self.nav.children[0])
-        return a_tag.attrs.get("data-value", None)
+        data_value_attr = a_tag.attrs.get("data-value", None)
+        if isinstance(data_value_attr, HTML):
+            data_value_attr = str(data_value_attr)
+        return data_value_attr
 
     def tagify(self) -> None:
         raise NotImplementedError(
@@ -279,7 +282,7 @@ class NavMenu:
             content.children,
         )
 
-    def get_value(self) -> Optional[str]:
+    def get_value(self) -> str | None:
         for x in self.nav_controls:
             val = x.get_value()
             if val:


### PR DESCRIPTION
The nav panel value is currently given as a `str`. I believe we should not allow for it to be an `HTML()` object. 

So, keeping the types as `str`, the final retrieved attribute value should be str (and not `HTML()`). If there somehow happens to have an HTML value, we will convert it to a str at retrieval time

Related #1692 