### PR TITLE
chore: Fix `langchain_core` test that used a new `Sequence` type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,7 @@ shiny = "shiny._main:main"
 [project.entry-points.pytest11]
 shiny-test = "shiny.pytest._pytest"
 
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,6 @@ shiny = "shiny._main:main"
 [project.entry-points.pytest11]
 shiny-test = "shiny.pytest._pytest"
 
-
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 

--- a/tests/pytest/test_chat.py
+++ b/tests/pytest/test_chat.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from datetime import datetime
-from typing import Sequence, Union, cast, get_args, get_origin
+from typing import Union, cast, get_args, get_origin
 
 import pytest
 
@@ -390,6 +390,9 @@ def test_as_google_message():
 
 def test_as_langchain_message():
     from langchain_core.language_models.base import LanguageModelInput
+    from langchain_core.language_models.base import (
+        Sequence as LangchainSequence,  # pyright: ignore[reportPrivateImportUsage]
+    )
     from langchain_core.language_models.chat_models import BaseChatModel
     from langchain_core.messages import (
         AIMessage,
@@ -404,7 +407,12 @@ def test_as_langchain_message():
     assert BaseChatModel.invoke.__annotations__["input"] == "LanguageModelInput"
     assert BaseChatModel.stream.__annotations__["input"] == "LanguageModelInput"
 
-    assert is_type_in_union(Sequence[MessageLikeRepresentation], LanguageModelInput)
+    assert is_type_in_union(
+        # Use `LangchainSequence` instead of `Sequence` to avoid incorrect comparison
+        # between `typing.Sequence` and `collections.abc.Sequence`
+        LangchainSequence[MessageLikeRepresentation],
+        LanguageModelInput,
+    )
     assert is_type_in_union(BaseMessage, MessageLikeRepresentation)
 
     assert issubclass(AIMessage, BaseMessage)


### PR DESCRIPTION
`langchain_core` was updated to 0.3.2 on Sep 19th, and errors started popping up on Sept 20th 

Error being seen in CI:

```
=================================== FAILURES ===================================
__________________________ test_as_langchain_message ___________________________
[gw0] linux -- Python 3.12.6 /opt/hostedtoolcache/Python/3.12.6/x64/bin/python3

    def test_as_langchain_message():
        from langchain_core.language_models.base import LanguageModelInput
        from langchain_core.language_models.chat_models import BaseChatModel
        from langchain_core.messages import (
            AIMessage,
            BaseMessage,
            HumanMessage,
            MessageLikeRepresentation,
            SystemMessage,
        )
    
        from shiny.ui._chat_provider_types import as_langchain_message
    
        assert BaseChatModel.invoke.__annotations__["input"] == "LanguageModelInput"
        assert BaseChatModel.stream.__annotations__["input"] == "LanguageModelInput"
    
>       assert is_type_in_union(Sequence[MessageLikeRepresentation], LanguageModelInput)
E       assert False
E        +  where False = is_type_in_union(typing.Sequence[typing.Union[langchain_core.messages.base.BaseMessage, list[str], tuple[str, str], str, dict[str, typing.Any]]], typing.Union[langchain_core.prompt_values.PromptValue, str, collections.abc.Sequence[typing.Union[langchain_core.messages.base.BaseMessage, list[str], tuple[str, str], str, dict[str, typing.Any]]]])
```