### PR TITLE
chore: revert check where airmass skips on python 3.9

### DIFF
--- a/tests/playwright/examples/test_examples.py
+++ b/tests/playwright/examples/test_examples.py
@@ -12,7 +12,6 @@ is_windows = sys.platform.startswith("win")
 def test_examples(page: Page, ex_app_path: str) -> None:
 
     skip_on_windows_with_timezonefinder(ex_app_path)
-    skip_airmass_on_3_9(ex_app_path)
 
     validate_example(page, ex_app_path)
 

--- a/tests/playwright/examples/test_examples.py
+++ b/tests/playwright/examples/test_examples.py
@@ -34,33 +34,3 @@ def skip_on_windows_with_timezonefinder(ex_app_path: str) -> None:
         pytest.skip(
             "timezonefinder has difficulty compiling on windows. Skipping example app. posit-dev/py-shiny#1651"
         )
-
-
-def skip_airmass_on_3_9(ex_app_path: str) -> None:
-    print(ex_app_path)
-    if ex_app_path != "examples/airmass/app.py":
-        return
-
-    import sys
-
-    if sys.version_info[:2] != (3, 9):
-        return
-
-    try:
-        # Astropy loads `numpy` at run time
-        import astropy.coordinates as _  # pyright: ignore # noqa: F401
-        import astropy.units as __  # pyright: ignore # noqa: F401
-
-        # Future proofing: if astropy is _actually_ loading, raise an error
-        raise RuntimeError(
-            "This code believes astropy and numpy have difficulty loading on python 3.9. Please remove this check if it is no longer true."
-        )
-    except AttributeError as e:
-        if "numpy" in str(e) and "product" in str(e):
-            pytest.skip(
-                "astropy and numpy has difficulty loading on python 3.9. Skipping example app: airmass. posit-dev/py-shiny#1678"
-            )
-            return
-
-        # Future proofing: if the error is not what we expect, raise it
-        raise e


### PR DESCRIPTION
Related #1678 