### PR TITLE
chore: Drop testing of python 3.8 (incomplete)

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         # "3.10" must be a string; otherwise it is interpreted as 3.1.
-        python-version: ["3.12", "3.11", "3.10", "3.9", "3.8"]
+        python-version: ["3.12", "3.11", "3.10", "3.9"]
         os: [ubuntu-latest, windows-latest, macOS-latest]
         exclude:
           - python-version: ${{ github.event.pull_request.draft && '3.11' }}
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12", "3.11", "3.10", "3.9", "3.8"]
+        python-version: ["3.12", "3.11", "3.10", "3.9"]
         browser: ["chromium", "firefox", "webkit"]
         exclude:
           - python-version: ${{ github.event.pull_request.draft && '3.11' }}
@@ -158,7 +158,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.12", "3.11", "3.10", "3.9", "3.8"]
+        python-version: ["3.12", "3.11", "3.10", "3.9"]
         browser: ["chromium", "firefox", "webkit"]
         exclude:
           - python-version: ${{ github.event.pull_request.draft && '3.11' }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,14 +15,13 @@ dynamic = ["version"]
 authors = [{ name = "Winston Chang", email = "winston@posit.co" }]
 description = "A web development framework for Python."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = { text = "MIT" }
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Full changes will come in #1711 

Related reasoning `py-htmltools` dropped py3.8 support due to bad typing support (and the python version is EOL as of next week): https://github.com/posit-dev/py-htmltools/commit/c5083e04ab40071b317fcc935a096a2e3a14aec1#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L21