### PR TITLE
build: set Narwhals 1.9.1 as minimum, remove upper bound, use narwhals.stable.v1 for dtypes and typing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "prompt-toolkit;platform_system!='Emscripten'",
     "python-multipart>=0.0.7;platform_system!='Emscripten'",
     "setuptools;python_version>='3.12'",
-    "narwhals>=1.9.0,<1.10.0",
+    "narwhals>=1.9.1",
     "orjson>=3.10.7",
 ]
 

--- a/shiny/render/_data_frame_utils/_types.py
+++ b/shiny/render/_data_frame_utils/_types.py
@@ -14,11 +14,11 @@ from typing import (
 
 import narwhals.stable.v1 as nw
 from htmltools import TagNode
-from narwhals.dtypes import DType as DType
-from narwhals.typing import DataFrameT as DataFrameT
-from narwhals.typing import IntoDataFrame as IntoDataFrame
-from narwhals.typing import IntoDataFrameT as IntoDataFrameT
-from narwhals.typing import IntoExpr as IntoExpr
+from narwhals.stable.v1.dtypes import DType as DType
+from narwhals.stable.v1.typing import DataFrameT as DataFrameT
+from narwhals.stable.v1.typing import IntoDataFrame as IntoDataFrame
+from narwhals.stable.v1.typing import IntoDataFrameT as IntoDataFrameT
+from narwhals.stable.v1.typing import IntoExpr as IntoExpr
 
 from ..._typing_extensions import Annotated, NotRequired, Required, TypedDict
 from ...types import Jsonifiable, JsonifiableDict, ListOrTuple

--- a/tests/playwright/shiny/components/data_frame/data_view_info/app.py
+++ b/tests/playwright/shiny/components/data_frame/data_view_info/app.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 # pyright: reportArgumentType = false
 # pyright: reportUnknownMemberType = false
 import polars as pl
-from narwhals.typing import IntoDataFrame
+from narwhals.stable.v1.typing import IntoDataFrame
 from palmerpenguins import load_penguins_raw
 
 from shiny import App, Inputs, Outputs, Session, module, render, ui

--- a/tests/playwright/shiny/components/data_frame/df_methods/app.py
+++ b/tests/playwright/shiny/components/data_frame/df_methods/app.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import polars as pl
 import seaborn as sns
-from narwhals.typing import IntoDataFrame
+from narwhals.stable.v1.typing import IntoDataFrame
 
 from shiny import App, Inputs, Outputs, Session, module, reactive, render, ui
 

--- a/tests/playwright/shiny/components/data_frame/row_selection/app.py
+++ b/tests/playwright/shiny/components/data_frame/row_selection/app.py
@@ -2,7 +2,7 @@ import pkgutil
 
 import palmerpenguins  # pyright: ignore[reportMissingTypeStubs]
 import polars as pl
-from narwhals.typing import IntoDataFrame
+from narwhals.stable.v1.typing import IntoDataFrame
 
 from shiny import App, Inputs, Outputs, Session, module, reactive, render, ui
 

--- a/tests/playwright/shiny/components/data_frame/styles/app.py
+++ b/tests/playwright/shiny/components/data_frame/styles/app.py
@@ -5,7 +5,7 @@ import pkgutil
 # pyright: reportMissingTypeStubs = false
 import palmerpenguins
 import polars as pl
-from narwhals.typing import IntoDataFrame
+from narwhals.stable.v1.typing import IntoDataFrame
 
 from shiny import App, Inputs, Outputs, Session, module, render, ui
 

--- a/tests/playwright/shiny/components/data_frame/validate_column_labels/app.py
+++ b/tests/playwright/shiny/components/data_frame/validate_column_labels/app.py
@@ -4,7 +4,7 @@ import pkgutil
 
 import palmerpenguins  # pyright: ignore[reportMissingTypeStubs]
 import polars as pl
-from narwhals.typing import IntoDataFrame
+from narwhals.stable.v1.typing import IntoDataFrame
 
 from shiny import Inputs, Outputs, Session
 from shiny.express import module, render, ui

--- a/tests/pytest/test_render_data_frame_tbl_data.py
+++ b/tests/pytest/test_render_data_frame_tbl_data.py
@@ -341,7 +341,7 @@ def test_subset_frame_cols_single(small_df_f: IntoDataFrame):
 def test_dtype_coverage():
     from pathlib import Path
 
-    from narwhals import dtypes as nw_dtypes
+    from narwhals.stable.v1 import dtypes as nw_dtypes
 
     # Copy from https://github.com/narwhals-dev/narwhals/blob/2c9e2e7a308ebb30c6f672e27c1da2086ebbecbc/utils/check_api_reference.py#L144-L146
     dtype_names = [


### PR DESCRIPTION
Hey - as discussed in https://github.com/posit-dev/py-shiny/pull/1570, a blocker to not upper-bounding Narwhals was that `dtypes` and `typing`  weren't available in `narwhals.stable.v1`

We have now:
- made a release which includes them
- added a downstream test in the Narwhals CI which checks that the `py-shiny` test suite + type checking keeps working on every commit

so I'd like to suggest removing the upper-bound

Thanks again for the collaboration here, it's been very rewarding to see this happen! 🤗 