### PR TITLE
chore(docs): Update dev install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ To install the latest development version:
 
 ```sh
 # First install htmltools, then shiny
-pip install https://github.com/posit-dev/py-htmltools/tarball/main
-pip install https://github.com/posit-dev/py-shiny/tarball/main
+pip install git+https://github.com/posit-dev/py-htmltools.git
+pip install git+https://github.com/posit-dev/py-shiny.git
 ```
 
 You can create and run your first application with `shiny create`, the CLI will ask you which template you would like to use. You can either run the app with the Shiny extension, or call `shiny run app.py --reload --launch-browser`.

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ To install the latest development version:
 
 ```sh
 # First install htmltools, then shiny
-pip install git+https://github.com/posit-dev/py-htmltools.git
-pip install git+https://github.com/posit-dev/py-shiny.git
+pip install git+https://github.com/posit-dev/py-htmltools.git#egg=htmltools
+pip install git+https://github.com/posit-dev/py-shiny.git#egg=shiny
 ```
 
 You can create and run your first application with `shiny create`, the CLI will ask you which template you would like to use. You can either run the app with the Shiny extension, or call `shiny run app.py --reload --launch-browser`.


### PR DESCRIPTION
Fixes #1720

`pip install https://github.com/posit-dev/py-shiny/tarball/main`
was causing errors during install.

The error message mentions:
```
      For example, if you're using pip, instead of https://github.com/user/proj/archive/master.zip use git+https://github.com/user/proj.git#egg=proj
```
running `pip install git+https://github.com/posit-dev/py-shiny.git` seem to work

see #1720 for more details.