### PR TITLE
chore(pyright): Unlock pyright version with minimum at `1.1.383`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ dev = [
     "Flake8-pyproject>=1.2.3",
     "isort>=5.10.1",
     "libsass>=0.23.0",
-    "pyright==1.1.369",
+    "pyright>=1.1.383",
     "pre-commit>=2.15.0",
     "wheel",
     "matplotlib",

--- a/shiny/_utils.py
+++ b/shiny/_utils.py
@@ -85,7 +85,7 @@ def guess_mime_type(
     if url:
         # Work around issue #1601, some installations of Windows 10 return text/plain
         # as the mime type for .js files
-        _, ext = os.path.splitext(os.fspath(url))
+        _, ext = os.path.splitext(os.fspath(str(url)))
         if ext.lower() in [".js", ".mjs", ".cjs"]:
             return "text/javascript"
     return mimetypes.guess_type(url, strict)[0] or default

--- a/tests/playwright/shiny/components/data_frame/edit/app.py
+++ b/tests/playwright/shiny/components/data_frame/edit/app.py
@@ -89,7 +89,11 @@ def gt_styles(df_gt: gt.GT) -> list[StyleInfo]:
     ret: list[StyleInfo] = []
     for style in styles:
         location = style.locname
-        location = "body" if location == "data" else location
+        location = (
+            "body"
+            if location == "data"  # pyright: ignore[reportUnnecessaryComparison]
+            else location
+        )
         assert location == "body", f"`style.locname` is {location}, expected 'body'"
         rows = style.rownum
         assert rows is not None

--- a/tests/playwright/shiny/components/data_frame/styles/great_tables_test_utils.py
+++ b/tests/playwright/shiny/components/data_frame/styles/great_tables_test_utils.py
@@ -23,7 +23,11 @@ def gt_styles(df_gt: gt.GT) -> list[StyleInfo]:
     ret: list[StyleInfo] = []
     for style in styles:
         location = style.locname
-        location = "body" if location == "data" else location
+        location = (
+            "body"
+            if location == "data"  # pyright: ignore[reportUnnecessaryComparison]
+            else location
+        )
         assert location == "body", f"`style.locname` is {location}, expected 'body'"
         rows = style.rownum
         assert rows is not None
@@ -39,7 +43,7 @@ def gt_styles(df_gt: gt.GT) -> list[StyleInfo]:
             )
         ret.append(
             {
-                "location": location,
+                "location": location,  # pyright: ignore[reportArgumentType]
                 "rows": rows,
                 "cols": cols,
                 "style": style_obj,

--- a/tests/playwright/shiny/deprecated/output_transformer/app.py
+++ b/tests/playwright/shiny/deprecated/output_transformer/app.py
@@ -1,3 +1,9 @@
+# pyright: reportUntypedFunctionDecorator=false
+# pyright: reportUnknownParameterType=false
+# pyright: reportUnknownMemberType=false
+# pyright: reportInvalidTypeForm=false
+# pyright: reportUnknownArgumentType=false
+# pyright: reportArgumentType=false
 from __future__ import annotations
 
 import warnings

--- a/tests/playwright/shiny/server/output_transformer/app.py
+++ b/tests/playwright/shiny/server/output_transformer/app.py
@@ -1,3 +1,8 @@
+# pyright: reportUntypedFunctionDecorator=false
+# pyright: reportUnknownMemberType=false
+# pyright: reportInvalidTypeForm=false
+# pyright: reportUnknownParameterType=false
+# pyright: reportUnknownArgumentType=false
 from __future__ import annotations
 
 from typing import Optional, overload

--- a/tests/pytest/test_output_transformer.py
+++ b/tests/pytest/test_output_transformer.py
@@ -1,3 +1,9 @@
+# pyright: reportUnknownParameterType=false
+# pyright: reportUnknownMemberType=false
+# pyright: reportInvalidTypeForm=false
+# pyright: reportUntypedFunctionDecorator=false
+# pyright: reportUnknownArgumentType=false
+# pyright: reportFunctionMemberAccess=false
 from __future__ import annotations
 
 import asyncio


### PR DESCRIPTION
Errors being seen in #1720 (and other PRs)

> ```
> -------- Checking types with pyright --------
> pyright
> /home/runner/work/py-shiny/py-shiny/tests/playwright/shiny/components/data_frame/edit/app.py
>   /home/runner/work/py-shiny/py-shiny/tests/playwright/shiny/components/data_frame/edit/app.py:92:30 - error: Condition will always evaluate to False since the types "Loc" and "Literal['data']" have no overlap (reportUnnecessaryComparison)
> /home/runner/work/py-shiny/py-shiny/tests/playwright/shiny/components/data_frame/styles/great_tables_test_utils.py
>   /home/runner/work/py-shiny/py-shiny/tests/playwright/shiny/components/data_frame/styles/great_tables_test_utils.py:26:30 - error: Condition will always evaluate to False since the types "Loc" and "Literal['data']" have no overlap (reportUnnecessaryComparison)
>   /home/runner/work/py-shiny/py-shiny/tests/playwright/shiny/components/data_frame/styles/great_tables_test_utils.py:42:29 - error: Argument of type "dict[str, Loc | str | int | dict[str, Jsonifiable]]" cannot be assigned to parameter "object" of type "StyleInfo" in function "append"
>     Type "Loc | Literal['body']" is incompatible with type "Literal['body']"
>       "Loc" is incompatible with type "Literal['body']" (reportArgumentType)
> 3 errors, 0 warnings, 0 informations 
> WARNING: there is a new pyright version available (v1.1.369 -> v1.1.383).
> Please install the new version or set PYRIGHT_PYTHON_FORCE_VERSION to `latest`
> ```