### PR TITLE
docs: move description list render logic into quartodoc

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -39,6 +39,7 @@ jobs:
       - name: Install dependencies
         run: |
           make ci-install-docs
+          pip install git+https://github.com/machow/quartodoc.git@main
 
       - name: Run quartodoc
         run: |

--- a/docs/_quartodoc-core.yml
+++ b/docs/_quartodoc-core.yml
@@ -9,6 +9,7 @@ quartodoc:
   renderer:
     style: _renderer.py
     show_signature_annotations: false
+    table_style: description-list
   sections:
     - title: Page containers
       desc: Create a user interface page container.
@@ -357,3 +358,4 @@ quartodoc:
           contents:
             - name: experimental.ui.card_image
               dynamic: false
+

--- a/docs/_quartodoc-express.yml
+++ b/docs/_quartodoc-express.yml
@@ -9,6 +9,7 @@ quartodoc:
   renderer:
     style: _renderer.py
     show_signature_annotations: false
+    table_style: description-list
   sections:
     - title: Input components
       desc: Gather user input.

--- a/docs/_renderer.py
+++ b/docs/_renderer.py
@@ -24,6 +24,7 @@ from plum import dispatch
 from quartodoc import MdRenderer
 from quartodoc.pandoc.blocks import DefinitionList
 from quartodoc.renderers.base import convert_rst_link_to_md, sanitize
+from quartodoc.renderers.md_renderer import ParamRow
 
 # from quartodoc.ast import preview
 
@@ -101,12 +102,12 @@ class Renderer(MdRenderer):
     # TODO-future; Can be removed once we use quartodoc 0.3.5
     # Related: https://github.com/machow/quartodoc/pull/205
     @dispatch
-    def render(self, el: DocstringAttribute):
-        row = [
-            sanitize(el.name),
-            self.render_annotation(el.annotation),
-            sanitize(el.description or "", allow_markdown=True),
-        ]
+    def render(self, el: DocstringAttribute) -> ParamRow:
+        row = ParamRow(
+            el.name,
+            el.description or "",
+            annotation=self.render_annotation(el.annotation),
+        )
         return row
 
     @dispatch
@@ -169,28 +170,6 @@ class Renderer(MdRenderer):
             return short
 
         return ""
-
-    # Consolidate the parameter type info into a single column
-    @dispatch
-    def render(self, el: DocstringParameter):
-        param = f'<span class="parameter-name">{el.name}</span>'
-        annotation = self.render_annotation(el.annotation)
-        if annotation:
-            param = f'{param}<span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">{annotation}</span>'
-        if el.default:
-            param = f'{param} <span class="parameter-default-sep">=</span> <span class="parameter-default">{el.default}</span>'
-
-        # Wrap everything in a code block to allow for links
-        param = "<code>" + param + "</code>"
-
-        return (param, el.description)
-
-    @dispatch
-    def render(self, el: DocstringSectionParameters):
-        rows = list(map(self.render, el.value))
-        # rows is a list of tuples of (<parameter>, <description>)
-
-        return str(DefinitionList(rows))
 
     @dispatch
     def signature(self, el: Function, source: Optional[Alias] = None):
@@ -279,7 +258,7 @@ def read_file(file: str | Path, root_dir: str | Path | None = None) -> FileConte
 
 
 def check_if_missing_expected_example(el, converted):
-    if re.search(r"(^|\n)#{2,6} Examples\n", converted):
+    if re.search(r"(^|\n)#{2,6} Examples", converted):
         # Manually added examples are fine
         return
 

--- a/shiny/input_handler.py
+++ b/shiny/input_handler.py
@@ -52,18 +52,6 @@ input binding. See `this article <https://shiny.posit.co/articles/js-custom-inpu
 for more information on how to create custom input bindings. (The article is about
 Shiny for R, but the JavaScript and general principles are the same.)
 
-Methods
---------
-add(type: str, force: bool = False) -> Callable[[InputHandlerType], None]
-    Register an input handler. This method returns a decorator that registers the
-    decorated function as the handler for the given ``type``. This handler should
-    accept three arguments:
-    - the input ``value``
-    - the input ``name``
-    - the :class:`~shiny.Session` object
-remove(type: str)
-    Unregister an input handler.
-
 Note
 ----
 ``add()`` ing an input handler will make it persist for the duration of the Python

--- a/shiny/input_handler.py
+++ b/shiny/input_handler.py
@@ -52,6 +52,18 @@ input binding. See `this article <https://shiny.posit.co/articles/js-custom-inpu
 for more information on how to create custom input bindings. (The article is about
 Shiny for R, but the JavaScript and general principles are the same.)
 
+Methods
+--------
+add(type: str, force: bool = False) -> Callable[[InputHandlerType], None]
+    Register an input handler. This method returns a decorator that registers the
+    decorated function as the handler for the given ``type``. This handler should
+    accept three arguments:
+    - the input ``value``
+    - the input ``name``
+    - the :class:`~shiny.Session` object
+remove(type: str)
+    Unregister an input handler.
+
 Note
 ----
 ``add()`` ing an input handler will make it persist for the duration of the Python


### PR DESCRIPTION
Recently, quartodoc cribbed the structure shiny used to render parameters in its documentation 😁. This PR attempts to take swap out the existing logic in the shiny docs renderer with quartodoc.

Note that I've set the CI to install quartodoc from main. Once everything looks good here and in [this Great Tables PR](https://github.com/posit-dev/great-tables/pull/427), I can do a quartodoc release!

Here are some critical changes:

* Introduced the ParamRow dataclass, to represent a row in a parameter table (prev just used a tuple).
* Moved sanitization into ParamRow, rather than performing in each render method
* **New!**: Added html classes to headers. E.g. "## Examples {.doc-section, .doc-section-examples}