### PR TITLE
Follow up to #1736: correct markup generation for user role messages

### DIFF
--- a/shiny/ui/_chat.py
+++ b/shiny/ui/_chat.py
@@ -1084,9 +1084,12 @@ def chat_ui(
         else:
             raise ValueError("Each message must be a string or a dictionary.")
 
-        message_tags.append(
-            Tag("shiny-chat-message", content=msg["content"], role=msg["role"])
-        )
+        if msg["role"] == "user":
+            tag_name = "shiny-user-message"
+        else:
+            tag_name = "shiny-chat-message"
+
+        message_tags.append(Tag(tag_name, content=msg["content"]))
 
     res = Tag(
         "shiny-chat-container",


### PR DESCRIPTION
Follow up to #1736: fixes markup generation for user startup messages:

```python
from shiny.express import ui

chat = ui.Chat(id="chat")

chat.ui(
    messages=[
        {"content": "Foo", "role": "assistant"},
        {"content": "Bar", "role": "user"},
        {"content": "Baz", "role": "assistant"},
    ]
)
```

Before 

<img width="642" alt="Screenshot 2024-10-15 at 4 08 11 PM" src="https://github.com/user-attachments/assets/0d3e1ad0-3ab7-479a-8f4d-38af4e824638">


After

<img width="663" alt="Screenshot 2024-10-15 at 4 07 43 PM" src="https://github.com/user-attachments/assets/8346a1b6-7563-4715-8daf-978c991a5629">

