### PR TITLE
Change chat custom normalizer error message to point to correct function

### DIFF
--- a/shiny/ui/_chat_normalize.py
+++ b/shiny/ui/_chat_normalize.py
@@ -277,7 +277,7 @@ def normalize_message(message: Any) -> ChatMessage:
             return strategy.normalize(message)
     raise ValueError(
         f"Could not find a normalizer for message of type {type(message)}: {message}. "
-        "Consider registering a custom normalizer via shiny.ui._chat_types.registry.register()"
+        "Consider registering a custom normalizer via shiny.ui._chat_normalize.message_normalizer_registry.register()"
     )
 
 
@@ -288,5 +288,5 @@ def normalize_message_chunk(chunk: Any) -> ChatMessage:
             return strategy.normalize_chunk(chunk)
     raise ValueError(
         f"Could not find a normalizer for message chunk of type {type(chunk)}: {chunk}. "
-        "Consider registering a custom normalizer via shiny.ui._chat_types.registry.register()"
+        "Consider registering a custom normalizer via shiny.ui._chat_normalize.message_normalizer_registry.register()"
     )


### PR DESCRIPTION
Previously, the error message said this:

```
Consider registering a custom normalizer via shiny.ui._chat_types.registry.register()
```

But the function `shiny.ui._chat_types.registry.register()` doesn't exist. I changed it to what I think is the correct function, `shiny.ui._chat_normalize.message_normalizer_registry.register()`, but please confirm that it's right.