### PR TITLE
fix(brand): Revert change to use hard-coded default colors in example app

### DIFF
--- a/examples/brand/app.py
+++ b/examples/brand/app.py
@@ -252,12 +252,12 @@ def server(input, output, session):
     @render.plot
     def plot1():
         colors = {
-            "foreground": theme.brand.color.foreground,
-            "background": theme.brand.color.background,
-            "primary": theme.brand.color.primary,
+            "foreground": "#000000",
+            "background": "#FFFFFF",
+            "primary": "#007BC2",
         }
 
-        if theme.brand.color:
+        if hasattr(theme, "brand") and theme.brand.color:
             colors.update(theme.brand.color.to_dict("theme"))
 
         if input.color_mode() == "dark":


### PR DESCRIPTION
Reverts [`edbae14` in #1743](https://github.com/posit-dev/py-shiny/pull/1743/commits/edbae14b1b16a60136efa77c06f8425688c7bc26). The color values were hardcoded to allow flipping between branded and default themes.