### PR TITLE
websockets 14.0 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Branded theming via `ui.Theme.from_brand()` now correctly applies monospace inline and block font family choices. (#1762)
 
-* Compatibility with `websockets>=14.0`, which has changed its public APIs (#1769).
+* Compatibility with `websockets>=14.0`, which has changed its public APIs. Shiny now requires websockets 13 or later (#1769).
 
 
 ## [1.2.0] - 2024-10-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Branded theming via `ui.Theme.from_brand()` now correctly applies monospace inline and block font family choices. (#1762)
 
+* Compatibility with `websockets>=14.0`, which has changed its public APIs (#1769).
+
 
 ## [1.2.0] - 2024-10-29
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "typing-extensions>=4.10.0",
     "uvicorn>=0.16.0;platform_system!='Emscripten'",
     "starlette",
-    "websockets>=10.0",
+    "websockets>=13.0",
     "python-multipart",
     "htmltools>=0.6.0",
     "click>=8.1.4;platform_system!='Emscripten'",

--- a/shiny/_autoreload.py
+++ b/shiny/_autoreload.py
@@ -186,10 +186,7 @@ def start_server(port: int, app_port: int, launch_browser: bool):
     # Run on a background thread so our event loop doesn't interfere with uvicorn.
     # Set daemon=True because we don't want to keep the process alive with this thread.
     threading.Thread(
-        None,
-        _thread_main,
-        args=[port, app_url, secret, launch_browser],
-        daemon=True,
+        None, _thread_main, args=[port, app_url, secret, launch_browser], daemon=True
     ).start()
 
 


### PR DESCRIPTION
See #1766

The websockets package released 14.0 which breaks us when using `shiny run --reload`.

* As @gadenbuie noticed, the [`process_requests` callback has changed](https://websockets.readthedocs.io/en/stable/howto/upgrade.html#arguments-of-serve).
* Even with that fixed (as in this PR's first commit), it prints a scary looking error message: `EOFError: stream ends after 0 bytes, before end of line` and `EOFError: connection closed while reading HTTP request line`. I think this is happening because Shiny's VS Code extension connects via a raw socket just to see if a newly launched Shiny process is listening for requests yet, and if the connection is successful, it immediately closes the connection. The new websockets seems not to like this.

Once we get this working, I think we also need to decide whether to require 14.0, or to allow older versions and adapt to whatever version is being used.