### PR TITLE
feat(Theme): Add `.add_sass_layer_file()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### New features
+
+* Added a new `.add_sass_layer_file()` method to `ui.Theme` that supports reading a Sass file with layer boundary comments, e.g. `/*-- scss:defaults --*/`. This format [is supported by Quarto](https://quarto.org/docs/output-formats/html-themes-more.html#bootstrap-bootswatch-layering) and makes it easier to store Sass rules and declarations that need to be woven into Shiny's Sass Bootstrap files. (#1790)
+
 ### Bug fixes
 
 * `ui.Chat()` now correctly handles new `ollama.chat()` return value introduced in `ollama` v0.4. (#1787)

--- a/shiny/ui/_theme.py
+++ b/shiny/ui/_theme.py
@@ -447,6 +447,13 @@ class Theme:
             add_method = getattr(self, f"add_{key}", None)
             if add_method:
                 add_method("".join(value))
+            else:
+                # We'd get here if we add a new layer boundary name but forget to
+                # include it in the supported `.add_{layer}()` methods.
+                raise ValueError(
+                    f"Unsupported Sass layer: {key}. Please report this issue to the "
+                    "Shiny maintainers at https://github.com/posit-dev/py-shiny."
+                )
 
         return self
 

--- a/shiny/ui/_theme.py
+++ b/shiny/ui/_theme.py
@@ -417,7 +417,9 @@ class Theme:
         layer_keys = ["uses", "functions", "defaults", "mixins", "rules"]
         rx_pattern = re.compile(rf"^/\*--\s*scss:({'|'.join(layer_keys)})\s*--\*/$")
 
-        if not any([rx_pattern.match(s) for s in src]):
+        layer_boundaries = [rx_pattern.match(line.strip()) for line in src]
+
+        if not any(layer_boundaries):
             raise ValueError(
                 f"The file {path} doesn't contain at least one layer boundary "
                 f"(/*-- scss:{{{','.join(layer_keys)}}} --*/)",
@@ -425,8 +427,8 @@ class Theme:
 
         layers: dict[str, list[str]] = {}
         layer_name: str = ""
-        for line in src:
-            layer_boundary = rx_pattern.match(line.strip())
+        for i, line in enumerate(src):
+            layer_boundary = layer_boundaries[i]
             if layer_boundary:
                 layer_name = layer_boundary.group(1)
                 continue

--- a/shiny/ui/_theme.py
+++ b/shiny/ui/_theme.py
@@ -149,6 +149,7 @@ class Theme:
                 self._include_paths.append(str(path))
 
         # User-provided Sass code
+        self._uses: list[str] = []
         self._functions: list[str] = []
         self._defaults: list[str] = []
         self._mixins: list[str] = []
@@ -247,6 +248,24 @@ class Theme:
                 values.append(f"${key}: {value}{default};")
 
         return [textwrap.dedent(x) for x in values]
+
+    def add_uses(self: T, *args: str) -> T:
+        """
+        Add custom Sass "uses" declarations to the theme.
+
+        Sass code added via this method will be placed **before** the function
+        declarations from the theme preset, allowing you to add Sass code that appears
+        before any other Sass code in the theme layer.
+
+        Parameters
+        ----------
+        *args
+            The Sass functions to add as a single or multiple strings.
+        """
+        uses = self._combine_args_kwargs(*args, kwargs={})
+        self._uses.extend(uses)
+        self._reset_css()
+        return self
 
     def add_functions(self: T, *args: str) -> T:
         """
@@ -371,6 +390,7 @@ class Theme:
         path_rules = path_pkg_preset(self._preset, "_04_rules.scss")
 
         sass_lines = [
+            *self._uses,
             f'@import "{path_functions}";',
             *self._functions,
             *self._defaults,


### PR DESCRIPTION
Follows the Quarto implementation as described in
https://quarto.org/docs/output-formats/html-themes-more.html#bootstrap-bootswatch-layering.

See also https://rstudio.github.io/sass/reference/sass_layer.html
this method is functionally equivalent to `sass::sass_layer_file()`.

Note that Quarto adds a `uses` layer that we also now support (above `functions` layer), which motivated adding an `.add_uses()` method for completeness.
