### PR TITLE
Ignore type error in test introduced by ollama 0.4.2

### DIFF
--- a/tests/pytest/test_chat.py
+++ b/tests/pytest/test_chat.py
@@ -476,7 +476,11 @@ def test_as_ollama_message():
     import ollama
     from ollama import Message as OllamaMessage
 
-    assert "ollama._types.Message" in str(ollama.chat.__annotations__["messages"])
+    # ollama 0.4.2 added Callable to the type hints, but pyright complains about
+    # missing arguments to the Callable type. We'll ignore this for now.
+    chat = ollama.chat  # type: ignore
+
+    assert "ollama._types.Message" in str(chat.__annotations__["messages"])
 
     from shiny.ui._chat_provider_types import as_ollama_message
 

--- a/tests/pytest/test_chat.py
+++ b/tests/pytest/test_chat.py
@@ -478,6 +478,7 @@ def test_as_ollama_message():
 
     # ollama 0.4.2 added Callable to the type hints, but pyright complains about
     # missing arguments to the Callable type. We'll ignore this for now.
+    # https://github.com/ollama/ollama-python/commit/b50a65b
     chat = ollama.chat  # type: ignore
 
     assert "ollama._types.Message" in str(chat.__annotations__["messages"])


### PR DESCRIPTION
Gets `pyright` passing on CI.

ollama must not use `pyright` for type checking because `ollama.chat` doesn't have valid `pyright` type hints

https://github.com/ollama/ollama-python/commit/b50a65b27d6c4e5bac42fcf763234e6a4be128b6