### PR TITLE
ci: Use latest deploy-pages

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -120,4 +120,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Saw we were behind on this version.

Since it's internal only, I'm going to merge on successful GHA.