### PR TITLE
docs: Add missing InputActionButton to testing docs

### DIFF
--- a/docs/_quartodoc-testing.yml
+++ b/docs/_quartodoc-testing.yml
@@ -24,6 +24,7 @@ quartodoc:
     - title: UI Inputs
       desc: Methods for interacting with Shiny app input value controller.
       contents:
+        - playwright.controller.InputActionButton
         - playwright.controller.InputActionLink
         - playwright.controller.InputCheckbox
         - playwright.controller.InputCheckboxGroup


### PR DESCRIPTION
Currently the [testing function reference](https://shiny.posit.co/py/api/testing/) page does not include `InputActionButton`.

This pull request includes a minor update to the `docs/_quartodoc-testing.yml` file. The change adds a new entry to the list of contents under the "UI Inputs" section.

Documentation update:

* [`docs/_quartodoc-testing.yml`](diffhunk://#diff-823fd3afe3a93f28487c37be22a0780e7ccf829e8761b5a7594b50a3f8abd6cfR27): Added `playwright.controller.InputActionButton` to the list of contents under the "UI Inputs" section.

### Preview

<img width="1645" alt="Shiny_for_Python__dev_version_" src="https://github.com/user-attachments/assets/952af4ec-9352-46e3-a8fc-43ea0d8e41ea" />

