### PR TITLE
fix(controllers): use regex pattern that matches any string (including an empty string)

### DIFF
--- a/shiny/playwright/controller/_input_buttons.py
+++ b/shiny/playwright/controller/_input_buttons.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pathlib
+import re
 from typing import Literal, Optional
 
 from playwright.sync_api import FilePayload, Locator, Page
@@ -61,7 +62,7 @@ class InputActionButton(
             The maximum time to wait for the expectation to be fulfilled. Defaults to `None`.
         """
         _expect_attribute_to_have_value(
-            self.loc, "disabled", "" if value else None, timeout=timeout
+            self.loc, "disabled", re.compile(".*") if value else None, timeout=timeout
         )
 
 


### PR DESCRIPTION
This pull request includes changes to the `shiny/playwright/controller/_input_buttons.py` file to improve functionality and maintainability. The most important changes focus on enhancing the `expect_disabled` method and updating imports.

This was done to handle the case when the `InputActionButton` could have `disabled` attribute or `disabled="disabled"` attribute for the button based on the browser.

* [`shiny/playwright/controller/_input_buttons.py`](diffhunk://#diff-8b40dcca02fe62957e4ce3693ab34cef43fa510088b61ca71cd9b20d192afbc6L64-R65): Modified the `expect_disabled` method to use a regular expression for checking the "disabled" attribute, improving the flexibility of the disabled state check.
