### PR TITLE
In README, note that tags are necessary for install

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,15 @@ You can create and run your first application with `shiny create`, the CLI will 
     * https://posit-dev.github.io/py-shiny/docs/api/express/
     * https://posit-dev.github.io/py-shiny/docs/api/core/
 
-If you want to do development on Shiny for Python:
+If you are working from a fork you may not have the git tags from the original repo.
+Git tags are required for the install to succeed. To add tags to your own fork:
+
+```sh
+git remote add upstream https://github.com/posit-dev/py-shiny.git
+git fetch --tags upstream
+```
+
+Then install:
 
 ```sh
 pip install -e ".[dev,test]"


### PR DESCRIPTION
This helped me, but maybe not having tags is an edge case you don't want to worry about. Your call.

- Fix #1857

(Still working on a install problem, but not related to the original issue so it makes sense to close.)