### PR TITLE
fix: Change ubuntu tag to use latest

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -154,7 +154,7 @@ jobs:
 
   playwright-examples:
     if: github.event_name != 'release'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.12", "3.11", "3.10", "3.9"]


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/pytest.yaml` file. The change updates the `runs-on` parameter to use the latest version of Ubuntu.

This is because of the deprecation warning in the console as announced in [this issue](https://github.com/actions/runner-images/issues/11101).

* [`.github/workflows/pytest.yaml`](diffhunk://#diff-038d392b404f94b2ee8e3f10b6ae76784160379d9e90638f78ee65df63353221L157-R157): Changed `runs-on` from `ubuntu-20.04` to `ubuntu-latest` for the `playwright-examples` job.