### PR TITLE
Replace `.get_latest_stream_result()` with a more general `.get_message_stream()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The `ui.Chat()` component also gains the following:
     * The `.on_user_submit()` decorator method now passes the user input to the decorated function. This makes it a bit easier to access the user input. See the new templates (mentioned below) for examples. (#1801)
     * The assistant icon is now configurable via `ui.chat_ui()` (or the `ui.Chat.ui()` method in Shiny Express) or for individual messages in the `.append_message()` and `.append_message_stream()` methods of `ui.Chat()`. (#1853)
-    * A new `get_message_stream()` method was added for an easy way to reactive read the stream's status, result, and also cancel an in progress stream. (#1846)
+    * A new `get_message_stream()` method was added for an easy way to reactively read the stream's status, result, and also cancel an in progress stream. (#1846)
     * The `.append_message_stream()` method now returns the `reactive.extended_task` instance that it launches. (#1846)
     * The `ui.Chat()` component's `.update_user_input()` method gains `submit` and `focus` options that allow you to submit the input on behalf of the user and to choose whether the input receives focus after the update. (#1851)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The `ui.Chat()` component also gains the following:
     * The `.on_user_submit()` decorator method now passes the user input to the decorated function. This makes it a bit easier to access the user input. See the new templates (mentioned below) for examples. (#1801)
     * The assistant icon is now configurable via `ui.chat_ui()` (or the `ui.Chat.ui()` method in Shiny Express) or for individual messages in the `.append_message()` and `.append_message_stream()` methods of `ui.Chat()`. (#1853)
-    * A new `get_latest_stream_result()` method was added for an easy way to access the final result of the stream when it completes. (#1846)
+    * A new `get_message_stream()` method was added for an easy way to reactive read the stream's status, result, and also cancel an in progress stream. (#1846)
     * The `.append_message_stream()` method now returns the `reactive.extended_task` instance that it launches. (#1846)
     * The `ui.Chat()` component's `.update_user_input()` method gains `submit` and `focus` options that allow you to submit the input on behalf of the user and to choose whether the input receives focus after the update. (#1851)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The `ui.Chat()` component also gains the following:
     * The `.on_user_submit()` decorator method now passes the user input to the decorated function. This makes it a bit easier to access the user input. See the new templates (mentioned below) for examples. (#1801)
     * The assistant icon is now configurable via `ui.chat_ui()` (or the `ui.Chat.ui()` method in Shiny Express) or for individual messages in the `.append_message()` and `.append_message_stream()` methods of `ui.Chat()`. (#1853)
-    * A new `get_message_stream()` method was added for an easy way to reactively read the stream's status, result, and also cancel an in progress stream. (#1846)
+    * A new `latest_message_stream` property was added for an easy way to reactively read the stream's status, result, and also cancel an in progress stream. (#1846)
     * The `.append_message_stream()` method now returns the `reactive.extended_task` instance that it launches. (#1846)
     * The `ui.Chat()` component's `.update_user_input()` method gains `submit` and `focus` options that allow you to submit the input on behalf of the user and to choose whether the input receives focus after the update. (#1851)
 

--- a/shiny/ui/_chat.py
+++ b/shiny/ui/_chat.py
@@ -673,11 +673,12 @@ class Chat:
 
         return _stream_task
 
-    def get_message_stream(self) -> reactive.ExtendedTask[[], str]:
+    @property
+    def latest_message_stream(self) -> reactive.ExtendedTask[[], str]:
         """
         React to changes in the latest message stream.
 
-        Reactively reads for the latest :class:`~shiny.reactive.ExtendedTask` behind the
+        Reactively reads for the :class:`~shiny.reactive.ExtendedTask` behind the
         latest message stream.
 
         From the return value (i.e., the extended task), you can then:
@@ -695,10 +696,9 @@ class Chat:
 
         Note
         ----
-        If no stream has yet been started when this method is called, then a "mock" task
-        is returned. This mock task behaves much like a stream that hasn't yet completed,
-        except it has a `.status()` of "initial" instead of "running", and `.cancel()`
-        is a no-op.
+        If no stream has yet been started when this method is called, then it returns an
+        extended task with `.status()` of `"initial"` and that it status doesn't change
+        state until a message is streamed.
         """
         return self._latest_stream()
 

--- a/tests/playwright/shiny/components/chat/stream-result/app.py
+++ b/tests/playwright/shiny/components/chat/stream-result/app.py
@@ -20,5 +20,5 @@ async def _(message: str):
 
 
 @render.code
-async def stream_result_ui():
-    return chat.get_latest_stream_result()
+async def stream_result():
+    return chat.get_message_stream().result()

--- a/tests/playwright/shiny/components/chat/stream-result/app.py
+++ b/tests/playwright/shiny/components/chat/stream-result/app.py
@@ -21,4 +21,4 @@ async def _(message: str):
 
 @render.code
 async def stream_result():
-    return chat.get_message_stream().result()
+    return chat.latest_message_stream.result()

--- a/tests/playwright/shiny/components/chat/stream-result/test_chat_stream_result.py
+++ b/tests/playwright/shiny/components/chat/stream-result/test_chat_stream_result.py
@@ -12,7 +12,7 @@ def test_validate_chat_stream_result(page: Page, local_app: ShinyAppProc) -> Non
     page.goto(local_app.url)
 
     chat = controller.Chat(page, "chat")
-    stream_result_ui = controller.OutputCode(page, "stream_result_ui")
+    stream_result = controller.OutputCode(page, "stream_result")
 
     expect(chat.loc).to_be_visible(timeout=10 * 1000)
 
@@ -34,4 +34,4 @@ def test_validate_chat_stream_result(page: Page, local_app: ShinyAppProc) -> Non
     chat.expect_messages(re.compile(r"\s*".join(messages)), timeout=30 * 1000)
 
     # Verify that the stream result is as expected
-    stream_result_ui.expect.to_contain_text("Message 9")
+    stream_result.expect.to_contain_text("Message 9")


### PR DESCRIPTION
Follow up to #1846

Coming back to write about this, I changed my mind about  `get_latest_stream_result()`. Having a more general `.get_message_stream()` is better, especially once I realized returning a "mock" `ExtendedTask` could get rid of some of the `None`/`req(False)` awkwardness.

Here's that same example from #1846 with the new API. It also adds status reporting and cancelling

```python
import asyncio

from shiny import reactive
from shiny.express import input, render, ui

ui.input_action_button("cancel", "Cancel stream")

chat = ui.Chat("chat")

chat.ui()
chat.update_user_input(value="Press Enter to start the stream")


async def stream_generator():
    for i in range(10):
        await asyncio.sleep(0.25)
        yield f"Message {i} \n\n"


@chat.on_user_submit
async def _(message: str):
    await chat.append_message_stream(stream_generator())


@render.code
def _():
    return f"Status: {chat.get_message_stream().status()}"

@render.code
async def stream_result_ui():
    return f"Result: {chat.get_message_stream().result()}"


@reactive.effect
@reactive.event(input.cancel)
def _():
    chat.get_message_stream().cancel()
```