### PR TITLE
Add `.latest_stream` to `ui.MarkdownStream()` and deprecate `.get_latest_stream_result()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Shiny for Python will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+### Changes
+
+* The `.get_latest_stream_result()` method on `ui.MarkdownStream()` was deprecated in favor of the new `.latest_stream` property. Call `.result()` on the property to get the latest result, `.status` to check the status, and `.cancel()` to cancel the stream.
+
 ## [1.3.0] - 2025-03-03
 
 ### New features

--- a/shiny/ui/_markdown_stream.py
+++ b/shiny/ui/_markdown_stream.py
@@ -158,7 +158,7 @@ class MarkdownStream:
         return _task
 
     @property
-    def latest_stream(self) -> reactive.ExtendedTask[[], str]:
+    def latest_stream(self):
         """
         React to changes in the latest stream.
 


### PR DESCRIPTION
Follow up to #1880.

In the course of changing the API for `Chat()`, I forgot to make a similar change for `ui.MarkdownStream()` 🤦 