### PR TITLE
chore: Add support for Narwhals `Time` dtype in `serialize_dtype`

### DIFF
--- a/shiny/render/_data_frame_utils/_tbl_data.py
+++ b/shiny/render/_data_frame_utils/_tbl_data.py
@@ -202,7 +202,7 @@ def serialize_dtype(col: nw.Series) -> FrameDtype:
         type_ = "datetime"
     elif isinstance(dtype, nw.Duration):
         type_ = "duration"
-    elif isinstance(dtype, nw.Time):
+    elif hasattr(nw, "Time") and isinstance(dtype, nw.Time):
         type_ = "time"
     elif isinstance(dtype, nw.Object):
         type_ = "object"

--- a/shiny/render/_data_frame_utils/_tbl_data.py
+++ b/shiny/render/_data_frame_utils/_tbl_data.py
@@ -202,6 +202,8 @@ def serialize_dtype(col: nw.Series) -> FrameDtype:
         type_ = "datetime"
     elif isinstance(dtype, nw.Duration):
         type_ = "duration"
+    elif isinstance(dtype, nw.Time):
+        type_ = "time"
     elif isinstance(dtype, nw.Object):
         type_ = "object"
         if series_contains_htmltoolslike(col):

--- a/shiny/render/_data_frame_utils/_tbl_data.py
+++ b/shiny/render/_data_frame_utils/_tbl_data.py
@@ -202,7 +202,11 @@ def serialize_dtype(col: nw.Series) -> FrameDtype:
         type_ = "datetime"
     elif isinstance(dtype, nw.Duration):
         type_ = "duration"
-    elif hasattr(nw, "Time") and isinstance(dtype, nw.Time):
+    elif hasattr(nw, "Time") and isinstance(
+        dtype,
+        # https://github.com/narwhals-dev/narwhals/pull/2113
+        nw.Time,  # pyright: ignore[reportUnknownMemberType,reportAttributeAccessIssue]
+    ):
         type_ = "time"
     elif isinstance(dtype, nw.Object):
         type_ = "object"

--- a/shiny/render/_data_frame_utils/_types.py
+++ b/shiny/render/_data_frame_utils/_types.py
@@ -179,6 +179,7 @@ class FrameDtypeSubset(TypedDict):
         "boolean",
         "date",
         "datetime",
+        "time",
         "duration",
         "object",
         "unknown",


### PR DESCRIPTION
# Description

[Narwhals#2113](https://github.com/narwhals-dev/narwhals/pull/2113) is going to introduce `Time` dtype, this PR prepares for that by serializing `Time` to `"time"`

