### PR TITLE
chore!: Make `app_opts()` args into kwargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+* Express mode's `app_opts()` requires all arguments to be keyword-only. If you are using positional arguments, you will need to update your code. (#1895)
+
 * The `.get_latest_stream_result()` method on `ui.MarkdownStream()` was deprecated in favor of the new `.latest_stream` property. Call `.result()` on the property to get the latest result, `.status` to check the status, and `.cancel()` to cancel the stream.
 
 ### Bug fixes

--- a/shiny/express/_run.py
+++ b/shiny/express/_run.py
@@ -295,6 +295,7 @@ class AppOpts(TypedDict):
 
 @no_example()
 def app_opts(
+    *,
     static_assets: str | Path | Mapping[str, str | Path] | MISSING_TYPE = MISSING,
     debug: bool | MISSING_TYPE = MISSING,
 ):

--- a/tests/playwright/shiny/components/chat/icon/app.py
+++ b/tests/playwright/shiny/components/chat/icon/app.py
@@ -7,7 +7,7 @@ from shiny.express import app_opts, input, ui
 
 ui.page_opts(title="Chat Icons")
 
-app_opts({"/img": Path(__file__).parent / "img"})
+app_opts(static_assets={"/img": Path(__file__).parent / "img"})
 
 with ui.layout_columns():
     # Default Bot ---------------------------------------------------------------------


### PR DESCRIPTION
These parameters are independent and will not scale with new additions: ex: `bookmark_store`.

Making them kwargs feels like a natural setup.