### PR TITLE
chore: Use `shiny.module` to import reexported values from `shiny._namespaces`

### DIFF
--- a/shiny/express/_stub_session.py
+++ b/shiny/express/_stub_session.py
@@ -4,7 +4,8 @@ from typing import TYPE_CHECKING, Awaitable, Callable, Literal, Optional
 
 from htmltools import TagChild
 
-from .._namespaces import Id, ResolvedId, Root
+from .._namespaces import Id, Root
+from ..module import ResolvedId
 from ..session import Inputs, Outputs, Session
 from ..session._session import SessionProxy
 

--- a/shiny/render/_render.py
+++ b/shiny/render/_render.py
@@ -21,8 +21,8 @@ if TYPE_CHECKING:
 from .. import _utils
 from .. import ui as _ui
 from .._docstring import add_example, no_example
-from .._namespaces import ResolvedId
 from .._typing_extensions import Self
+from ..module import ResolvedId
 from ..session import get_current_session, require_active_session
 from ..session._session import DownloadHandler, DownloadInfo
 from ..types import MISSING, MISSING_TYPE, ImgData

--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -41,11 +41,12 @@ from .._connection import Connection, ConnectionClosed
 from .._deprecated import warn_deprecated
 from .._docstring import add_example
 from .._fileupload import FileInfo, FileUploadManager
-from .._namespaces import Id, ResolvedId, Root
+from .._namespaces import Id, Root
 from .._typing_extensions import NotRequired, TypedDict
 from .._utils import wrap_async
 from ..http_staticfiles import FileResponse
 from ..input_handler import input_handlers
+from ..module import ResolvedId
 from ..reactive import Effect_, Value, effect, flush, isolate
 from ..reactive._core import lock, on_flushed
 from ..render.renderer import Renderer, RendererT

--- a/shiny/session/_utils.py
+++ b/shiny/session/_utils.py
@@ -14,8 +14,8 @@ if TYPE_CHECKING:
     from ._session import Session
 
 from .._docstring import no_example
-from .._namespaces import namespace_context
 from .._typing_extensions import TypedDict
+from ..module import namespace_context
 
 
 class RenderedDeps(TypedDict):

--- a/shiny/ui/_chat.py
+++ b/shiny/ui/_chat.py
@@ -22,7 +22,7 @@ from htmltools import HTML, Tag, TagAttrValue, TagList, css
 from .. import _utils, reactive
 from .._deprecated import warn_deprecated
 from .._docstring import add_example
-from .._namespaces import ResolvedId, resolve_id
+from ..module import ResolvedId, resolve_id
 from ..session import require_active_session, session_context
 from ..types import MISSING, MISSING_TYPE, NotifyException
 from ..ui.css import CssUnit, as_css_unit

--- a/shiny/ui/_download_button.py
+++ b/shiny/ui/_download_button.py
@@ -5,8 +5,8 @@ from typing import Optional
 from htmltools import Tag, TagAttrValue, TagChild, css, tags
 
 from .._docstring import add_example
-from .._namespaces import resolve_id
 from .._shinyenv import is_pyodide
+from ..module import resolve_id
 
 
 @add_example()

--- a/shiny/ui/_input_action_button.py
+++ b/shiny/ui/_input_action_button.py
@@ -5,7 +5,7 @@ from typing import Optional
 from htmltools import Tag, TagAttrValue, TagChild, css, tags
 
 from .._docstring import add_example
-from .._namespaces import resolve_id
+from ..module import resolve_id
 
 
 @add_example()

--- a/shiny/ui/_input_check_radio.py
+++ b/shiny/ui/_input_check_radio.py
@@ -11,7 +11,7 @@ from typing import Mapping, Optional, Union
 from htmltools import Tag, TagChild, css, div, span, tags
 
 from .._docstring import add_example
-from .._namespaces import resolve_id
+from ..module import resolve_id
 from ._html_deps_shinyverse import components_dependencies
 from ._utils import shiny_input_label
 

--- a/shiny/ui/_input_dark_mode.py
+++ b/shiny/ui/_input_dark_mode.py
@@ -7,7 +7,7 @@ from typing import Literal, Optional
 from htmltools import Tag, TagAttrValue, css
 
 from .._docstring import add_example, no_example
-from .._namespaces import resolve_id
+from ..module import resolve_id
 from ..session import Session, require_active_session
 from ._web_component import web_component
 

--- a/shiny/ui/_input_date.py
+++ b/shiny/ui/_input_date.py
@@ -9,7 +9,7 @@ from typing import Optional
 from htmltools import Tag, TagAttrValue, TagChild, css, div, span, tags
 
 from .._docstring import add_example
-from .._namespaces import resolve_id
+from ..module import resolve_id
 from ._html_deps_external import datepicker_deps
 from ._utils import shiny_input_label
 

--- a/shiny/ui/_input_file.py
+++ b/shiny/ui/_input_file.py
@@ -7,7 +7,7 @@ from typing import Literal, Optional
 from htmltools import Tag, TagChild, css, div, span, tags
 
 from .._docstring import add_example
-from .._namespaces import resolve_id
+from ..module import resolve_id
 from ._utils import shiny_input_label
 
 

--- a/shiny/ui/_input_numeric.py
+++ b/shiny/ui/_input_numeric.py
@@ -5,7 +5,7 @@ from typing import Literal, Optional
 from htmltools import Tag, TagChild, css, div, tags
 
 from .._docstring import add_example
-from .._namespaces import resolve_id
+from ..module import resolve_id
 from ._utils import shiny_input_label
 
 

--- a/shiny/ui/_input_password.py
+++ b/shiny/ui/_input_password.py
@@ -5,7 +5,7 @@ from typing import Literal, Optional
 from htmltools import Tag, TagChild, css, div, tags
 
 from .._docstring import add_example
-from .._namespaces import resolve_id
+from ..module import resolve_id
 from ._utils import shiny_input_label
 
 

--- a/shiny/ui/_input_select.py
+++ b/shiny/ui/_input_select.py
@@ -16,7 +16,7 @@ from typing import Any, Mapping, Optional, Union, cast
 from htmltools import Tag, TagChild, TagList, css, div, tags
 
 from .._docstring import add_example
-from .._namespaces import resolve_id
+from ..module import resolve_id
 from ._html_deps_external import selectize_deps
 from ._utils import JSEval, extract_js_keys, shiny_input_label
 

--- a/shiny/ui/_input_slider.py
+++ b/shiny/ui/_input_slider.py
@@ -14,8 +14,8 @@ from typing import Iterable, Optional, TypeVar, Union, cast
 from htmltools import HTML, Tag, TagAttrValue, TagChild, css, div, tags
 
 from .._docstring import add_example
-from .._namespaces import resolve_id
 from .._typing_extensions import NotRequired, TypedDict
+from ..module import resolve_id
 from ._html_deps_external import ionrangeslider_deps
 from ._utils import shiny_input_label
 

--- a/shiny/ui/_input_task_button.py
+++ b/shiny/ui/_input_task_button.py
@@ -10,8 +10,8 @@ from htmltools import HTML, Tag, TagAttrValue, TagChild, css, tags
 from shiny.types import MISSING, MISSING_TYPE
 
 from .._docstring import add_example
-from .._namespaces import resolve_id
 from .._typing_extensions import ParamSpec
+from ..module import resolve_id
 from ..reactive._extended_task import ExtendedTask
 from ..reactive._reactives import effect
 from ._html_deps_py_shiny import spin_dependency

--- a/shiny/ui/_input_text.py
+++ b/shiny/ui/_input_text.py
@@ -5,7 +5,7 @@ from typing import Literal, Optional
 from htmltools import Tag, TagChild, css, div, tags
 
 from .._docstring import add_example
-from .._namespaces import resolve_id
+from ..module import resolve_id
 from ._html_deps_py_shiny import autoresize_dependency
 from ._utils import shiny_input_label
 

--- a/shiny/ui/_input_update.py
+++ b/shiny/ui/_input_update.py
@@ -28,10 +28,10 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 
 from .._docstring import add_example, doc_format, no_example
-from .._namespaces import ResolvedId, resolve_id
 from .._typing_extensions import NotRequired, TypedDict
 from .._utils import drop_none
 from ..input_handler import input_handlers
+from ..module import ResolvedId, resolve_id
 from ..session import require_active_session, session_context
 from ..types import ActionButtonValue
 from ._input_check_radio import ChoicesArg, _generate_options

--- a/shiny/ui/_markdown_stream.py
+++ b/shiny/ui/_markdown_stream.py
@@ -6,8 +6,8 @@ from htmltools import css
 from .. import _utils, reactive
 from .._deprecated import warn_deprecated
 from .._docstring import add_example
-from .._namespaces import resolve_id
 from .._typing_extensions import TypedDict
+from ..module import resolve_id
 from ..session import require_active_session, session_context
 from ..types import NotifyException
 from ..ui.css import CssUnit, as_css_unit

--- a/shiny/ui/_output.py
+++ b/shiny/ui/_output.py
@@ -15,7 +15,7 @@ from typing import Optional
 from htmltools import Tag, TagAttrValue, TagFunction, css, div, tags
 
 from .._docstring import add_example, no_example
-from .._namespaces import resolve_id
+from ..module import resolve_id
 from ..types import MISSING, MISSING_TYPE
 from ._plot_output_opts import (
     BrushOpts,

--- a/shiny/ui/_sidebar.py
+++ b/shiny/ui/_sidebar.py
@@ -17,9 +17,10 @@ from htmltools import (
 )
 
 from .._docstring import add_example, no_example
-from .._namespaces import ResolvedId, resolve_id_or_none
+from .._namespaces import resolve_id_or_none
 from .._typing_extensions import TypedDict
 from .._utils import private_random_id
+from ..module import ResolvedId
 from ..session import require_active_session
 from ..types import MISSING, MISSING_TYPE
 from ._card import CardItem

--- a/shiny/ui/dataframe/_data_frame.py
+++ b/shiny/ui/dataframe/_data_frame.py
@@ -5,7 +5,7 @@ __all__ = ("output_data_frame",)
 from htmltools import Tag
 
 from ..._docstring import add_example
-from ..._namespaces import resolve_id
+from ...module import resolve_id
 from .._html_deps_py_shiny import data_frame_deps
 from ..fill import as_fill_item, as_fillable_container
 

--- a/tests/pytest/test_chat.py
+++ b/tests/pytest/test_chat.py
@@ -7,7 +7,8 @@ from typing import Union, cast, get_args, get_origin
 import pytest
 
 from shiny import Session
-from shiny._namespaces import ResolvedId, Root
+from shiny._namespaces import Root
+from shiny.module import ResolvedId
 from shiny.session import session_context
 from shiny.types import MISSING
 from shiny.ui import Chat

--- a/tests/pytest/test_modules.py
+++ b/tests/pytest/test_modules.py
@@ -10,7 +10,7 @@ from htmltools import HTML, Tag, TagList
 
 from shiny import App, Inputs, Outputs, Session, module, reactive, ui
 from shiny._connection import MockConnection
-from shiny._namespaces import resolve_id
+from shiny.module import resolve_id
 from shiny.session import get_current_session
 from shiny.session._session import AppSession, SessionProxy
 

--- a/tests/pytest/test_namespaces.py
+++ b/tests/pytest/test_namespaces.py
@@ -1,4 +1,5 @@
-from shiny._namespaces import namespace_context, resolve_id
+from shiny._namespaces import namespace_context
+from shiny.module import resolve_id
 
 
 def test_namespaces():

--- a/tests/pytest/test_output_transformer.py
+++ b/tests/pytest/test_output_transformer.py
@@ -12,8 +12,9 @@ from typing import Any, cast, overload
 import pytest
 
 from shiny._deprecated import ShinyDeprecationWarning
-from shiny._namespaces import ResolvedId, Root
+from shiny._namespaces import Root
 from shiny._utils import is_async_callable
+from shiny.module import ResolvedId
 from shiny.render.transformer import (
     TransformerMetadata,
     ValueFn,

--- a/tests/pytest/test_render_data_frame.py
+++ b/tests/pytest/test_render_data_frame.py
@@ -6,16 +6,13 @@ from htmltools import TagChild, TagList
 
 from shiny import reactive, render
 from shiny._deprecated import ShinyDeprecationWarning
+from shiny._namespaces import Root
 from shiny._utils import wrap_async
+from shiny.module import ResolvedId
 from shiny.render._data_frame_utils._selection import SelectionModes
 from shiny.render._data_frame_utils._tbl_data import as_data_frame
-from shiny.session._session import (
-    RenderedDeps,
-    ResolvedId,
-    Root,
-    Session,
-    session_context,
-)
+from shiny.session import Session, session_context
+from shiny.session._session import RenderedDeps
 
 
 class _MockSession:

--- a/tests/pytest/test_render_data_frame_tbl_data.py
+++ b/tests/pytest/test_render_data_frame_tbl_data.py
@@ -13,6 +13,8 @@ import polars as pl
 import polars.testing as pl_testing
 import pytest
 
+from shiny._namespaces import Root
+from shiny.module import ResolvedId
 from shiny.render._data_frame_utils._tbl_data import (
     as_data_frame,
     serialize_dtype,
@@ -21,7 +23,7 @@ from shiny.render._data_frame_utils._tbl_data import (
 )
 from shiny.render._data_frame_utils._types import IntoDataFrame
 from shiny.session import Session, session_context
-from shiny.session._session import RenderedDeps, ResolvedId, Root
+from shiny.session._session import RenderedDeps
 from shiny.ui import HTML, TagChild, TagList, h1, span
 
 


### PR DESCRIPTION
Updated:
* `shiny._namespaces_.resolve_id()` -> `shiny.module.resolve_id()`
* `shiny._namespaces_.current_namespace()` -> `shiny.module.current_namespace()`
* `shiny._namespaces_.ResolvedId` -> `shiny.module.ResolvedId`

Related: #1896