### PR TITLE
chore: Rename temp environ names to avoid conflict with local names

### DIFF
--- a/shiny/_launchbrowser.py
+++ b/shiny/_launchbrowser.py
@@ -27,14 +27,14 @@ class LaunchBrowserHandler(logging.Handler):
 
         if "Application startup complete." in record.getMessage():
             self._launched = True
-            port = os.environ["SHINY_PORT"]
+            port = os.environ["SHINY_BROWSER_PORT"]
             if not port.isnumeric():
                 print(
-                    "SHINY_PORT environment variable not set or unusable; "
+                    "SHINY_BROWSER_PORT environment variable not set or unusable; "
                     "--launch-browser will be ignored"
                 )
                 # For some reason the shiny port isn't set correctly!?
                 return
-            host = os.environ["SHINY_HOST"]
+            host = os.environ["SHINY_BROWSER_HOST"]
             url = get_proxy_url(f"http://{host}:{port}/")
             webbrowser.open(url, 1)

--- a/shiny/_main.py
+++ b/shiny/_main.py
@@ -295,8 +295,8 @@ def run_app(
     if port == 0:
         port = _utils.random_port(host=host)
 
-    os.environ["SHINY_HOST"] = host
-    os.environ["SHINY_PORT"] = str(port)
+    os.environ["SHINY_BROWSER_HOST"] = host
+    os.environ["SHINY_BROWSER_PORT"] = str(port)
     if dev_mode:
         os.environ["SHINY_DEV_MODE"] = "1"
 


### PR DESCRIPTION
Ex: `SHINY_PORT` is set by hosted environments and is inspected to determine if an app is being hosted. 

Related: https://github.com/rstudio/shiny/blob/f55c26af4a0493b082d2967aca6d36b90795adf1/R/server.R#L510-L514

Useful for bookmarking to determine it's own `inShinyServer()` method