### PR TITLE
fix: Revert - fix(session): Always have calling session be the parent session when making scoped session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Fixed an issue with the `.click()` method on InputActionButton controllers in `shiny.playwright.controllers` where the method would not work as expected. (#1886)
 
-* Fixed an issue where the parent session of a nested module's session was not being set to the calling session. Now, a session who's namespace is `A-B` has a parent of `A` and grandparent of `(root)` (whereas before it would have skipped `A` and the parent would have been `(root)`). (#1923)
-
-
 ## [1.3.0] - 2025-03-03
 
 ### New features

--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -1233,9 +1233,8 @@ class SessionProxy(Session):
     async def close(self, code: int = 1001) -> None:
         await self._parent.close(code)
 
-    def make_scope(self, id: Id) -> Session:
-        ns = self.ns(id)
-        return SessionProxy(parent=self, ns=ns)
+    def make_scope(self, id: str) -> Session:
+        return self._parent.make_scope(self.ns(id))
 
     def root_scope(self) -> Session:
         res = self

--- a/tests/playwright/shiny/bookmark/modules/test_bookmark_modules.py
+++ b/tests/playwright/shiny/bookmark/modules/test_bookmark_modules.py
@@ -28,9 +28,6 @@ def test_bookmark_modules(
     mod1_key: str,
 ) -> None:
 
-    if "recursive" in app_name:
-        pytest.skip("Skip broken recursive test")
-
     # Set environment variable before the app starts
     os.environ["SHINY_BOOKMARK_STORE"] = bookmark_store
 


### PR DESCRIPTION
This reverts commit 14b92d4e8f273560ba63a9c4e1206a7f4b0aa9e1 via #1923

From conversations with @jcheng5 , the proxy sessions should have a single "parent" object which is "Root" session, they should not recurse up the session family tree during calls. 

In a followup PR, I'll rename `._parent` to `._root_session` to avoid confusion.


From chat w/ @jcheng5 
> If there are reasons we want nested session scopes to actually be related (and there are reasons we might--like we could add `.destroy()` methods that recursively kill their child scopes), we can do that, but we’d have to make further changes I think. 
> 
> Off the top of my head, we’d have to make sure that make_scope:
> 1. Always returns the same object when `make_scope` is passed with the same `id`, much like Python does with loaded modules. We’d need to do this with weakrefs.
> 2. If `make_scope` is passed with an id more than one level deep, we’d need to create/fetch a separate session proxy object for each level.