### PR TITLE
chore: Add support for Narwhals `Binary` dtype in `serialize_dtype`

### DIFF
--- a/shiny/render/_data_frame_utils/_tbl_data.py
+++ b/shiny/render/_data_frame_utils/_tbl_data.py
@@ -208,6 +208,12 @@ def serialize_dtype(col: nw.Series) -> FrameDtype:
         nw.Time,  # pyright: ignore[reportUnknownMemberType,reportAttributeAccessIssue]
     ):
         type_ = "time"
+    elif hasattr(nw, "Binary") and isinstance(
+        dtype,
+        # https://github.com/narwhals-dev/narwhals/pull/2243
+        nw.Binary,  # pyright: ignore[reportUnknownMemberType,reportAttributeAccessIssue]
+    ):
+        type_ = "binary"
     elif isinstance(dtype, nw.Object):
         type_ = "object"
         if series_contains_htmltoolslike(col):

--- a/shiny/render/_data_frame_utils/_types.py
+++ b/shiny/render/_data_frame_utils/_types.py
@@ -184,6 +184,7 @@ class FrameDtypeSubset(TypedDict):
         "object",
         "unknown",
         "html",
+        "binary",
     ]
 
 


### PR DESCRIPTION
# Description

[Narwhals#2243](https://github.com/narwhals-dev/narwhals/pull/2243) is going to introduce `Binary` dtype, this PR prepares for that by serializing `Binary` to `"binary"`

