### PR TITLE
fix(MarkdownStream): correctly set the latest stream when it gets invoked

### DIFF
--- a/shiny/ui/_markdown_stream.py
+++ b/shiny/ui/_markdown_stream.py
@@ -158,6 +158,8 @@ class MarkdownStream:
 
         _task()
 
+        self._latest_stream.set(_task)
+
         # Since the task runs in the background (outside/beyond the current context,
         # if any), we need to manually raise any exceptions that occur
         @reactive.effect
@@ -208,7 +210,7 @@ class MarkdownStream:
             "The `.get_latest_stream_result()` method is deprecated and will be removed "
             "in a future release. Use `.latest_stream.result()` instead. "
         )
-        self.latest_stream.result()
+        return self.latest_stream.result()
 
     async def clear(self):
         """

--- a/tests/playwright/shiny/components/MarkdownStream/stream-result/app.py
+++ b/tests/playwright/shiny/components/MarkdownStream/stream-result/app.py
@@ -1,0 +1,28 @@
+import asyncio
+
+from shiny import reactive
+from shiny.express import input, render, ui
+
+stream = ui.MarkdownStream("stream_id")
+stream.ui()
+
+
+ui.input_action_button("do_stream", "Do stream")
+
+
+async def gen():
+    yield "Hello "
+    await asyncio.sleep(0.1)
+    yield "world!"
+
+
+@reactive.effect
+@reactive.event(input.do_stream)
+async def _():
+    await stream.stream(gen())
+
+
+@render.code
+def stream_result():
+    res = stream.latest_stream.result()
+    return f"Stream result: {res}"

--- a/tests/playwright/shiny/components/MarkdownStream/stream-result/test_latest_stream_result.py
+++ b/tests/playwright/shiny/components/MarkdownStream/stream-result/test_latest_stream_result.py
@@ -1,0 +1,18 @@
+from playwright.sync_api import Page, expect
+
+from shiny.playwright import controller
+from shiny.run import ShinyAppProc
+
+
+def test_latest_stream_result(page: Page, local_app: ShinyAppProc) -> None:
+    page.goto(local_app.url)
+
+    stream = page.locator("#stream_id")
+    stream_result = controller.OutputCode(page, "stream_result")
+    stream_result.expect_value("")
+
+    btn = controller.InputActionButton(page, "do_stream")
+    btn.click()
+
+    expect(stream).to_contain_text("Hello world!")
+    stream_result.expect_value("Stream result: Hello world!")


### PR DESCRIPTION
Follow up to https://github.com/posit-dev/py-shiny/pull/1880.