### PR TITLE
chore(Chat): Small CSS adjustments

### DIFF
--- a/js/chat/chat.scss
+++ b/js/chat/chat.scss
@@ -145,7 +145,8 @@ shiny-chat-input {
 
   margin-top: calc(-1 * var(--_input-padding-top));
   position: sticky;
-  bottom: calc(-1 * var(--_input-padding-bottom));
+  bottom: calc(-1 * var(--_input-padding-bottom) + 4px);
+  // 4px: autoscroll adds 2px to height, this keeps input from wiggling when scrolling on top of chat
   padding-block: var(--_input-padding-top) var(--_input-padding-bottom);
 
   textarea {

--- a/js/markdown-stream/markdown-stream.scss
+++ b/js/markdown-stream/markdown-stream.scss
@@ -68,6 +68,7 @@ pre:has(.code-copy-button) {
 .markdown-stream-dot {
   // The stream dot is appended with each streaming chunk update, so the pulse animation
   // only shows up when streaming pauses but isn't complete.
+  animation: markdown-stream-dot-pulse 1.75s infinite cubic-bezier(0.18, 0.89, 0.32, 1.28);
   animation-delay: 250ms;
   display: inline-block;
   transform-origin: center;

--- a/js/markdown-stream/markdown-stream.scss
+++ b/js/markdown-stream/markdown-stream.scss
@@ -68,7 +68,7 @@ pre:has(.code-copy-button) {
 .markdown-stream-dot {
   // The stream dot is appended with each streaming chunk update, so the pulse animation
   // only shows up when streaming pauses but isn't complete.
-  animation: markdown-stream-dot-pulse 2s infinite cubic-bezier(0.18, 0.89, 0.32, 1.28);
+  animation-delay: 250ms;
   display: inline-block;
   transform-origin: center;
 }


### PR DESCRIPTION
Small CSS adjustments for style nudges:

* Delay dot pulse until streaming has paused, keeping the dot stead while incoming text is streaming
* Speed up the pulse just a tiny bit
* Fix some wiggle that was added to the text input by #1891