### PR TITLE
Fix(Chat, MarkdownStream): prevent escaping of HTML inside message content strings

### DIFF
--- a/shiny/ui/_chat.py
+++ b/shiny/ui/_chat.py
@@ -18,7 +18,7 @@ from typing import (
 )
 from weakref import WeakValueDictionary
 
-from htmltools import HTML, Tag, TagAttrValue, TagChild, TagList, css
+from htmltools import HTML, Tag, TagAttrValue, TagChild, TagList, css, RenderedHTML
 
 from .. import _utils, reactive
 from .._deprecated import warn_deprecated
@@ -1450,7 +1450,12 @@ def chat_ui(
             if "role" in x:
                 role = x["role"]
 
-        ui = TagList(content).render()
+        # `content` is most likely a string, so avoid overhead in that case
+        # (it's also important that we *don't escape HTML* here).
+        if isinstance(content, str):
+            ui: RenderedHTML = {"html": content, "dependencies": []}
+        else:
+            ui = TagList(content).render()
 
         if role == "user":
             tag_name = "shiny-user-message"

--- a/shiny/ui/_markdown_stream.py
+++ b/shiny/ui/_markdown_stream.py
@@ -1,7 +1,7 @@
 from contextlib import asynccontextmanager
 from typing import AsyncIterable, Iterable, Literal, Union
 
-from htmltools import TagChild, TagList, css
+from htmltools import RenderedHTML, TagChild, TagList, css
 
 from .. import _utils, reactive
 from .._deprecated import warn_deprecated
@@ -353,7 +353,13 @@ def output_markdown_stream(
     height
         The height of the UI element.
     """
-    ui = TagList(content).render()
+
+    # `content` is most likely a string, so avoid overhead in that case
+    # (it's also important that we *don't escape HTML* here).
+    if isinstance(content, str):
+        ui: RenderedHTML = {"html": content, "dependencies": []}
+    else:
+        ui = TagList(content).render()
 
     return Tag(
         "shiny-markdown-stream",


### PR DESCRIPTION
Follow up to #1868. That PR introduced a problem where HTML content included in a starting message no longer rendered as HTML since the HTML started getting escaped. For a reprex, this example:

```python
from shiny.express import ui

welcome = """
**Hello!** How can I help you today?

Here are a couple suggestions:

* <span class="suggestion">Tell me a joke</span>
* <span class="suggestion submit">Tell me a story</span>
"""

chat = ui.Chat(id="chat")
chat.ui(messages=[welcome])


@chat.on_user_submit
async def _(user_input: str):
    await chat.append_message(f"You said: {user_input}")
```

Went from:

<img width="666" alt="Screenshot 2025-03-24 at 12 07 06 PM" src="https://github.com/user-attachments/assets/9eca3bd3-db00-457f-900d-4c98a08b3561" />

to:

<img width="657" alt="Screenshot 2025-03-24 at 12 07 36 PM" src="https://github.com/user-attachments/assets/8d2e10e5-d832-4f83-8954-343f29b04d86" />


Note that:

1. This isn't a problem for `append_message()` et al. since we're [already skipping the "tagify" step there for strings](https://github.com/posit-dev/py-shiny/blob/f2e774ca/shiny/ui/_chat_types.py#L32-L38).
2. We have the same problem in shinychat, so I'll be doing a follow up PR there.