### PR TITLE
chore(uvicorn): Remove uv source of uvicorn PR

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,9 +134,6 @@ doc = [
     "griffe>=1.3.2",
 ]
 
-[tool.uv.sources]
-# https://github.com/encode/uvicorn/pull/2602
-uvicorn = { git = "https://github.com/schloerke/uvicorn", branch = "reload-exclude-abs-path" }
 
 [project.urls]
 Homepage = "https://github.com/posit-dev/py-shiny"

--- a/shiny/api-examples/notification_show/app-core.py
+++ b/shiny/api-examples/notification_show/app-core.py
@@ -14,7 +14,6 @@ def server(input: Inputs, output: Outputs, session: Session):
     @reactive.effect
     @reactive.event(input.show)
     def _():
-        nonlocal ids
         nonlocal n
         # Save the ID for removal later
         id = ui.notification_show("Message " + str(n), duration=None)
@@ -24,7 +23,6 @@ def server(input: Inputs, output: Outputs, session: Session):
     @reactive.effect
     @reactive.event(input.remove)
     def _():
-        nonlocal ids
         if ids:
             ui.notification_remove(ids.pop())
 

--- a/shiny/api-examples/notification_show/app-express.py
+++ b/shiny/api-examples/notification_show/app-express.py
@@ -11,7 +11,6 @@ n: int = 0
 @reactive.effect
 @reactive.event(input.show)
 def _():
-    global ids
     global n
     # Save the ID for removal later
     id = ui.notification_show("Message " + str(n), duration=None)
@@ -22,6 +21,5 @@ def _():
 @reactive.effect
 @reactive.event(input.remove)
 def _():
-    global ids
     if ids:
         ui.notification_remove(ids.pop())

--- a/shiny/bookmark/_bookmark.py
+++ b/shiny/bookmark/_bookmark.py
@@ -610,7 +610,8 @@ class BookmarkProxy(Bookmark):
         )
 
         # Make subdir for scope
-        # TODO: Barret; Is this for uploaded files?!?
+        #
+        # Folder only used by author callbacks. File uploads are handled by root session
         if root_state.dir is not None:
             scope_subpath = self._ns
             scoped_state.dir = Path(root_state.dir) / scope_subpath

--- a/tests/pytest/test_reactives.py
+++ b/tests/pytest/test_reactives.py
@@ -235,7 +235,6 @@ async def test_async_sequential():
     async def react_chain(n: int):
         @calc()
         async def r():
-            nonlocal exec_order
             exec_order.append(f"r{n}-1")
             await asyncio.sleep(0)
             exec_order.append(f"r{n}-2")
@@ -243,7 +242,6 @@ async def test_async_sequential():
 
         @effect()
         async def _():
-            nonlocal exec_order
             exec_order.append(f"o{n}-1")
             await asyncio.sleep(0)
             exec_order.append(f"o{n}-2")
@@ -402,19 +400,16 @@ async def test_effect_priority():
 
     @effect(priority=1)
     def o1():
-        nonlocal results
         v()
         results.append(1)
 
     @effect(priority=2)
     def o2():
-        nonlocal results
         v()
         results.append(2)
 
     @effect(priority=1)
     def o3():
-        nonlocal results
         v()
         results.append(3)
 
@@ -425,7 +420,6 @@ async def test_effect_priority():
     # invalidate others by changing v).
     @effect(priority=2)
     def o4():
-        nonlocal results
         v()
         results.append(4)
 
@@ -453,19 +447,16 @@ async def test_async_effect_priority():
 
     @effect(priority=1)
     async def o1():
-        nonlocal results
         v()
         results.append(1)
 
     @effect(priority=2)
     async def o2():
-        nonlocal results
         v()
         results.append(2)
 
     @effect(priority=1)
     async def o3():
-        nonlocal results
         v()
         results.append(3)
 
@@ -476,7 +467,6 @@ async def test_async_effect_priority():
     # invalidate others by changing v).
     @effect(priority=2)
     async def o4():
-        nonlocal results
         v()
         results.append(4)
 
@@ -506,7 +496,6 @@ async def test_effect_destroy():
 
     @effect()
     def o1():
-        nonlocal results
         v()
         results.append(1)
 
@@ -524,7 +513,6 @@ async def test_effect_destroy():
 
     @effect()
     def o2():
-        nonlocal results
         v()
         results.append(1)
 


### PR DESCRIPTION
With https://github.com/encode/uvicorn/pull/2602, the expected behavior is achieved and this PR's changes in `_main.py` may be reverted.

---------------------------

We are close to a release and can not have a uv source in the `pyproject.toml`. Therefore, we're removing it and extending the reload-excludes to exclude any file within  `shiny_bookmarks` up to 5 sub-folders deep. This should be a near 100% coverage.
