### PR TITLE
feat(bookmark): Use helper method to set default bookmark methods on an `App` object directly

### DIFF
--- a/shiny/__init__.py
+++ b/shiny/__init__.py
@@ -30,6 +30,9 @@ if _is_pyodide:
 else:
     from ._main import run_app
 
+# External hooks for bookmarking in places like Connect, SSO/SSP, Shinylive, etc.
+from .bookmark._global import set_app_bookmark_callbacks as _set_app_bookmark_callbacks
+
 
 # N.B.: we intentionally don't import 'developer-facing' submodules (e.g.,
 # html_dependencies) so that they aren't super visible when you `import shiny`, but
@@ -62,4 +65,6 @@ __all__ = (
     "render_image",
     "render_ui",
     "event",
+    # external hooks
+    "_set_app_bookmark_callbacks",
 )

--- a/shiny/_app.py
+++ b/shiny/_app.py
@@ -30,7 +30,6 @@ from ._connection import Connection, StarletteConnection
 from ._error import ErrorMiddleware
 from ._shinyenv import is_pyodide
 from ._utils import guess_mime_type, is_async_callable, sort_keys_length
-from .bookmark import _global as bookmark_global_state
 from .bookmark._global import as_bookmark_dir_fn
 from .bookmark._restore_state import RestoreContext, restore_context
 from .bookmark._types import (

--- a/shiny/_app.py
+++ b/shiny/_app.py
@@ -498,8 +498,8 @@ class App:
     # ==========================================================================
 
     def _init_bookmarking(self, *, bookmark_store: BookmarkStore, ui: Any) -> None:
-        self._bookmark_save_dir_fn = bookmark_global_state.bookmark_save_dir
-        self._bookmark_restore_dir_fn = bookmark_global_state.bookmark_restore_dir
+        self._bookmark_save_dir_fn = None
+        self._bookmark_restore_dir_fn = None
         self._bookmark_store = bookmark_store
 
         if bookmark_store != "disable" and not callable(ui):

--- a/shiny/bookmark/__init__.py
+++ b/shiny/bookmark/__init__.py
@@ -5,7 +5,6 @@ from ._bookmark import (
     BookmarkProxy,
 )
 from ._button import input_bookmark_button
-from ._global import set_global_restore_dir_fn, set_global_save_dir_fn
 from ._restore_state import RestoreContext, RestoreState, restore_input
 from ._save_state import BookmarkState
 from ._serializers import Unserializable, serializer_unserializable
@@ -18,9 +17,6 @@ __all__ = (
     "BookmarkExpressStub",
     # _button
     "input_bookmark_button",
-    # _external
-    "set_global_save_dir_fn",
-    "set_global_restore_dir_fn",
     # _restore_state
     "RestoreContext",
     "RestoreState",

--- a/shiny/bookmark/_global.py
+++ b/shiny/bookmark/_global.py
@@ -7,12 +7,7 @@ from starlette.applications import Starlette
 from starlette.routing import BaseRoute, Mount
 
 from .._utils import wrap_async
-from ._types import (
-    BookmarkDirFn,
-    BookmarkDirFnAsync,
-    BookmarkRestoreDirFn,
-    BookmarkSaveDirFn,
-)
+from ._types import BookmarkDirFn, BookmarkDirFnAsync
 
 if TYPE_CHECKING:
     from .._app import App
@@ -20,10 +15,6 @@ if TYPE_CHECKING:
 # WARNING! This file contains global state!
 # During App initialization, the save_dir and restore_dir functions are conventionally set
 # to read-only on the App.
-
-
-bookmark_save_dir: BookmarkSaveDirFn | None = None
-bookmark_restore_dir: BookmarkRestoreDirFn | None = None
 
 
 @overload
@@ -40,95 +31,6 @@ def as_bookmark_dir_fn(fn: BookmarkDirFn | None) -> BookmarkDirFnAsync | None:
     if fn is None:
         return None
     return wrap_async(fn)
-
-
-def set_global_save_dir_fn(fn: BookmarkDirFn):
-    """
-    Set the global bookmark save directory function.
-
-    This function is NOT intended to be used by app authors. Instead, it is a last resort option for hosted invironments to adjust how bookmarks are saved.
-
-    Parameters
-    ----------
-    fn : BookmarkDirFn
-        The function that will be used to determine the directory where bookmarks are saved. This function should create the directory (`pathlib.Path` object) that is returned.
-
-    Examples
-    --------
-    ```python
-    from pathlib import Path
-    from shiny.bookmark import set_global_save_dir_fn, set_global_restore_dir_fn
-
-    bookmark_dir = Path(__file__).parent / "bookmarks"
-
-    def save_bookmark_dir(id: str) -> Path:
-        save_dir = bookmark_dir / id
-        save_dir.mkdir(parents=True, exist_ok=True)
-        return save_dir
-
-    def restore_bookmark_dir(id: str) -> Path:
-        return bookmark_dir / id
-
-    # Set global defaults for bookmark saving and restoring.
-    set_global_restore_dir_fn(restore_bookmark_dir)
-    set_global_save_dir_fn(save_bookmark_dir)
-
-    app = App(app_ui, server, bookmark_store="server")
-    ```
-
-
-    See Also
-    --------
-    * `~shiny.bookmark.set_global_restore_dir_fn` : Set the global bookmark restore directory function
-    """
-    global bookmark_save_dir
-
-    bookmark_save_dir = as_bookmark_dir_fn(fn)
-    return fn
-
-
-def set_global_restore_dir_fn(fn: BookmarkDirFn):
-    """
-    Set the global bookmark restore directory function.
-
-    This function is NOT intended to be used by app authors. Instead, it is a last resort option for hosted invironments to adjust how bookmarks are restored.
-
-    Parameters
-    ----------
-    fn : BookmarkDirFn
-        The function that will be used to determine the directory (`pathlib.Path` object) where bookmarks are restored from.
-
-    Examples
-    --------
-    ```python
-    from pathlib import Path
-    from shiny.bookmark import set_global_save_dir_fn, set_global_restore_dir_fn
-
-    bookmark_dir = Path(__file__).parent / "bookmarks"
-
-    def save_bookmark_dir(id: str) -> Path:
-        save_dir = bookmark_dir / id
-        save_dir.mkdir(parents=True, exist_ok=True)
-        return save_dir
-
-    def restore_bookmark_dir(id: str) -> Path:
-        return bookmark_dir / id
-
-    # Set global defaults for bookmark saving and restoring.
-    set_global_restore_dir_fn(restore_bookmark_dir)
-    set_global_save_dir_fn(save_bookmark_dir)
-
-    app = App(app_ui, server, bookmark_store="server")
-    ```
-
-    See Also
-    --------
-    * `~shiny.bookmark.set_global_save_dir_fn` : Set the global bookmark save directory function.
-    """
-    global bookmark_restore_dir
-
-    bookmark_restore_dir = as_bookmark_dir_fn(fn)
-    return fn
 
 
 def set_app_bookmark_callbacks(

--- a/shiny/bookmark/_global.py
+++ b/shiny/bookmark/_global.py
@@ -166,9 +166,8 @@ def set_app_bookmark_callbacks(
     bookmark_restore_dir_fn = as_bookmark_dir_fn(get_bookmark_restore_dir)
 
     if isinstance(app, App):
-        # print("Raw Shiny App: ", app)
-        app._bookmark_save_dir_fn = bookmark_save_dir_fn
-        app._bookmark_restore_dir_fn = bookmark_restore_dir_fn
+        app.set_bookmark_save_dir_fn(bookmark_save_dir_fn)
+        app.set_bookmark_restore_dir_fn(bookmark_restore_dir_fn)
     elif isinstance(app, Starlette):
 
         an_app_found: bool = False
@@ -181,15 +180,13 @@ def set_app_bookmark_callbacks(
                 if isinstance(route.app, App):
                     nonlocal an_app_found
                     an_app_found = True
-                    # print("Shiny App: ", route.path)
-                    route.app._bookmark_save_dir_fn = bookmark_save_dir_fn
-                    route.app._bookmark_restore_dir_fn = bookmark_restore_dir_fn
+                    route.app.set_bookmark_save_dir_fn(bookmark_save_dir_fn)
+                    route.app.set_bookmark_restore_dir_fn(bookmark_restore_dir_fn)
                 else:
-                    # print("Inspecting Mount: ", route.path)
+                    # Recurse
                     inspect_starlette_routes(route.routes)
 
-        # print("Inspecting Starlette App: ", app)
-        inspect_starlette_routes(app.router.routes)
+        inspect_starlette_routes(app.routes)
 
         if not an_app_found:
             warnings.warn(

--- a/shiny/bookmark/_global.py
+++ b/shiny/bookmark/_global.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from typing import overload
+import warnings
+from typing import TYPE_CHECKING, overload
+
+from starlette.applications import Starlette
+from starlette.routing import BaseRoute, Mount
 
 from .._utils import wrap_async
 from ._types import (
@@ -9,6 +13,9 @@ from ._types import (
     BookmarkRestoreDirFn,
     BookmarkSaveDirFn,
 )
+
+if TYPE_CHECKING:
+    from .._app import App
 
 # WARNING! This file contains global state!
 # During App initialization, the save_dir and restore_dir functions are conventionally set
@@ -122,3 +129,77 @@ def set_global_restore_dir_fn(fn: BookmarkDirFn):
 
     bookmark_restore_dir = as_bookmark_dir_fn(fn)
     return fn
+
+
+def set_app_bookmark_callbacks(
+    app: App | Starlette,
+    *,
+    get_bookmark_save_dir: BookmarkDirFn,
+    get_bookmark_restore_dir: BookmarkDirFn,
+) -> None:
+    """
+    Set the bookmark save and restore callbacks on the app.
+
+    Parameters
+    ----------
+    app
+        The app to set the callbacks on. This can be a `shiny.App` or a
+        `starlette.applications.Starlette` app. If a `starlette.applications.Starlette`
+        app, the callbacks will be set on all `shiny.App` instances mounted anywhere the
+        app (through recursive route inspection).
+    get_bookmark_save_dir
+        The function to call to retrieve the bookmark save directory. This function should
+        create the directory (`pathlib.Path` object) that is returned.
+    get_bookmark_restore_dir
+        The function to call to retrieve the bookmark restore directory. This function
+        should create the directory (`pathlib.Path` object) that is returned.
+
+    Returns
+    -------
+    None
+        This function does not return anything. It modifies the app object in place.
+    """
+
+    from .. import App
+
+    bookmark_save_dir_fn = as_bookmark_dir_fn(get_bookmark_save_dir)
+    bookmark_restore_dir_fn = as_bookmark_dir_fn(get_bookmark_restore_dir)
+
+    if isinstance(app, App):
+        # print("Raw Shiny App: ", app)
+        app._bookmark_save_dir_fn = bookmark_save_dir_fn
+        app._bookmark_restore_dir_fn = bookmark_restore_dir_fn
+    elif isinstance(app, Starlette):
+
+        an_app_found: bool = False
+
+        def inspect_starlette_routes(routes: list[BaseRoute]):
+            for route in routes:
+                if not isinstance(route, Mount):
+                    continue
+
+                if isinstance(route.app, App):
+                    nonlocal an_app_found
+                    an_app_found = True
+                    # print("Shiny App: ", route.path)
+                    route.app._bookmark_save_dir_fn = bookmark_save_dir_fn
+                    route.app._bookmark_restore_dir_fn = bookmark_restore_dir_fn
+                else:
+                    # print("Inspecting Mount: ", route.path)
+                    inspect_starlette_routes(route.routes)
+
+        # print("Inspecting Starlette App: ", app)
+        inspect_starlette_routes(app.router.routes)
+
+        if not an_app_found:
+            warnings.warn(
+                "No Shiny app found in the Starlette app. Bookmarking will not be set.",
+                UserWarning,
+                stacklevel=1,
+            )
+    else:
+        warnings.warn(
+            "The app is not a Shiny app or a Starlette app. Bookmarking will not be set.",
+            UserWarning,
+            stacklevel=1,
+        )

--- a/tests/playwright/shiny/bookmark/dir/app-global.py
+++ b/tests/playwright/shiny/bookmark/dir/app-global.py
@@ -5,7 +5,7 @@ from starlette.requests import Request
 
 from shiny import App, Inputs, Outputs, Session, reactive, render, ui
 from shiny._utils import rand_hex
-from shiny.bookmark import set_global_restore_dir_fn, set_global_save_dir_fn
+from shiny.bookmark._global import set_app_bookmark_callbacks
 
 
 def app_ui(request: Request):
@@ -43,6 +43,10 @@ def server(input: Inputs, ouput: Outputs, session: Session):
 did_save = False
 did_restore = False
 
+
+app = App(app_ui, server, bookmark_store="server")
+
+
 # Note:
 # This is a "temp" directory that is only used for testing and is cleaned up on app
 # shutdown. This should NOT be standard behavior of a hosting environment. Instead, it
@@ -66,11 +70,10 @@ def save_bookmark_dir(id: str) -> Path:
 
 
 # Same exact app as `app-attr.py`, except we're using global functions to set the save and restore directories.
-set_global_restore_dir_fn(restore_bookmark_dir)
-set_global_save_dir_fn(save_bookmark_dir)
-
-
-app = App(app_ui, server, bookmark_store="server")
-
+set_app_bookmark_callbacks(
+    app,
+    get_bookmark_save_dir=save_bookmark_dir,
+    get_bookmark_restore_dir=restore_bookmark_dir,
+)
 
 app.on_shutdown(lambda: shutil.rmtree(bookmark_dir))

--- a/tests/pytest/test_app_bookmark.py
+++ b/tests/pytest/test_app_bookmark.py
@@ -1,0 +1,116 @@
+from pathlib import Path
+
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+from starlette.routing import Mount, Route, WebSocketRoute
+from starlette.staticfiles import StaticFiles
+from starlette.websockets import WebSocket
+
+import shiny
+from shiny import App, ui
+from shiny.bookmark._global import as_bookmark_dir_fn
+
+
+def homepage(request: Request):
+    return PlainTextResponse("Hello, world!")
+
+
+def user_me(request: Request):
+    username = "John Doe"
+    return PlainTextResponse("Hello, %s!" % username)
+
+
+def user(request: Request):
+    username = request.path_params["username"]
+    return PlainTextResponse("Hello, %s!" % username)
+
+
+async def websocket_endpoint(websocket: WebSocket):
+    await websocket.accept()
+    await websocket.send_text("Hello, websocket!")
+    await websocket.close()
+
+
+# shiny app ----
+app_shiny = App(ui.page_fluid("hello from shiny!"), None)
+sub_app_shiny = App(ui.page_fluid("hello from sub shiny!"), None)
+sub_sub_app_shiny = App(ui.page_fluid("hello from sub sub shiny!"), None)
+
+
+# combine apps ----
+sub_sub_app = Starlette(
+    routes=[
+        Mount("/sub_sub_static", StaticFiles(directory=".")),
+        Mount("/sub_sub_shiny", app=sub_sub_app_shiny),
+    ]
+)
+sub_app = Starlette(
+    routes=[
+        Mount("/sub_sub", app=sub_sub_app),
+        Mount("/sub_static", StaticFiles(directory=".")),
+        Mount("/sub_shiny", app=sub_app_shiny),
+    ]
+)
+routes = [
+    Route("/", homepage),
+    Route("/user/me", user_me),
+    Route("/user/{username}", user),
+    WebSocketRoute("/ws", websocket_endpoint),
+    Mount("/static", StaticFiles(directory=".")),
+    Mount("/shiny", app=app_shiny),
+    Mount("/sub", sub_app),
+]
+
+app = Starlette(routes=routes)
+
+
+def test_shiny_can_set_app_bookmarking_fns():
+
+    app_fns = [
+        app_shiny._bookmark_save_dir_fn,
+        app_shiny._bookmark_restore_dir_fn,
+    ]
+    sub_app_fns = [
+        sub_app_shiny._bookmark_save_dir_fn,
+        sub_app_shiny._bookmark_restore_dir_fn,
+    ]
+    sub_sub_app_fns = [
+        sub_sub_app_shiny._bookmark_save_dir_fn,
+        sub_sub_app_shiny._bookmark_restore_dir_fn,
+    ]
+
+    assert app_fns == [None, None]
+    assert sub_app_fns == [None, None]
+    assert sub_sub_app_fns == [None, None]
+
+    def save_dir(id: str) -> Path:
+        # This function should really create the directory,
+        # but for testing purposes, we just return the path without creating it.
+        return Path("save_dir") / id
+
+    def restore_dir(id: str) -> Path:
+        return Path("restore_dir") / id
+
+    internally_upgraded_fn_save = as_bookmark_dir_fn(save_dir)
+    internally_upgraded_fn_restore = as_bookmark_dir_fn(restore_dir)
+
+    shiny._set_app_bookmark_callbacks(
+        app=app,
+        get_bookmark_save_dir=internally_upgraded_fn_save,
+        get_bookmark_restore_dir=internally_upgraded_fn_restore,
+        # # Normally...
+        # get_bookmark_save_dir=save_dir,
+        # get_bookmark_restore_dir=restore_dir,
+        # # ...but we want to test the upgrade to bookmark_dir_fn
+        # # and not that the user function is always upgraded to async
+    )
+
+    assert app_shiny._bookmark_save_dir_fn == internally_upgraded_fn_save
+    assert app_shiny._bookmark_restore_dir_fn == internally_upgraded_fn_restore
+
+    assert sub_app_shiny._bookmark_save_dir_fn == internally_upgraded_fn_save
+    assert sub_app_shiny._bookmark_restore_dir_fn == internally_upgraded_fn_restore
+
+    assert sub_sub_app_shiny._bookmark_save_dir_fn == internally_upgraded_fn_save
+    assert sub_sub_app_shiny._bookmark_restore_dir_fn == internally_upgraded_fn_restore


### PR DESCRIPTION
Notes: `app` can be a `Starlette` or `shiny.App` object