### PR TITLE
test(bookmark): Add retries to flaky test

### DIFF
--- a/tests/playwright/shiny/bookmark/chat/client_state/test_bookmark_chat.py
+++ b/tests/playwright/shiny/bookmark/chat/client_state/test_bookmark_chat.py
@@ -1,12 +1,14 @@
 import re
 
+import pytest
 from playwright.sync_api import Page
 
 from shiny.playwright.controller import Chat
 from shiny.run import ShinyAppProc
 
 
-def test_bookmark_chatlas(page: Page, local_app: ShinyAppProc):
+@pytest.mark.flaky(reruns=3, reruns_delay=1)
+def test_bookmark_chat(page: Page, local_app: ShinyAppProc):
 
     page.goto(local_app.url)
 

--- a/tests/playwright/shiny/bookmark/chat/client_state/test_bookmark_chat.py
+++ b/tests/playwright/shiny/bookmark/chat/client_state/test_bookmark_chat.py
@@ -6,6 +6,7 @@ from playwright.sync_api import Page
 from shiny.playwright.controller import Chat
 from shiny.run import ShinyAppProc
 
+
 # Up to 5 retries for intermittent WebKit timing issues
 @pytest.mark.flaky(reruns=5, reruns_delay=1)
 def test_bookmark_chat(page: Page, local_app: ShinyAppProc):

--- a/tests/playwright/shiny/bookmark/chat/client_state/test_bookmark_chat.py
+++ b/tests/playwright/shiny/bookmark/chat/client_state/test_bookmark_chat.py
@@ -6,8 +6,8 @@ from playwright.sync_api import Page
 from shiny.playwright.controller import Chat
 from shiny.run import ShinyAppProc
 
-
-@pytest.mark.flaky(reruns=3, reruns_delay=1)
+# Up to 5 retries for intermittent WebKit timing issues
+@pytest.mark.flaky(reruns=5, reruns_delay=1)
 def test_bookmark_chat(page: Page, local_app: ShinyAppProc):
 
     page.goto(local_app.url)


### PR DESCRIPTION
This pull request includes a change to the `tests/playwright/shiny/bookmark/chat/client_state/test_bookmark_chat.py` file to improve the stability of the test. The change involves marking the `test_bookmark_chat` function as flaky and allowing it to rerun up to three times with a one-second delay between reruns.
