### PR TITLE
Enable ts-eslint checks for promises

### DIFF
--- a/js/.eslintrc.js
+++ b/js/.eslintrc.js
@@ -17,11 +17,15 @@ module.exports = {
   parserOptions: {
     ecmaVersion: "latest",
     sourceType: "module",
+    project: "./tsconfig.json",
+    tsconfigRootDir: __dirname,
   },
   plugins: ["react", "@typescript-eslint"],
   rules: {
     "@typescript-eslint/no-unused-vars": "off",
     "@typescript-eslint/no-non-null-assertion": "off",
+    "@typescript-eslint/no-floating-promises": "error",
+    "@typescript-eslint/no-misused-promises": "error",
   },
   settings: {
     react: {

--- a/js/tsconfig.json
+++ b/js/tsconfig.json
@@ -21,5 +21,5 @@
     "experimentalDecorators": true,
     "useDefineForClassFields": false,
   },
-  "include": ["**/*.tsx", "**/*.ts"],
+  "include": ["**/*.tsx", "**/*.ts", "**/*.js"]
 }


### PR DESCRIPTION
This PR enables `@typescript-eslint/no-floating-promises` and `@typescript-eslint/no-misused-promises`, which can find problems in usage of async/promise-returning functions.