### PR TITLE
test(navset): Add retries to flaky navset test for intermittent webkit failures

### DIFF
--- a/tests/playwright/shiny/components/nav/navsets_kitchensink/test_navsets_kitchensink.py
+++ b/tests/playwright/shiny/components/nav/navsets_kitchensink/test_navsets_kitchensink.py
@@ -1,3 +1,4 @@
+import pytest
 from playwright.sync_api import Page, expect
 
 from shiny.playwright import controller
@@ -26,6 +27,8 @@ def format_navset_name(navset_name: str) -> str:
     return navset_name
 
 
+# Up to 5 retries for intermittent WebKit timing issues
+@pytest.mark.flaky(reruns=5, reruns_delay=1)
 def test_navset_kitchensink(page: Page, local_app: ShinyAppProc) -> None:
     page.goto(local_app.url)
 


### PR DESCRIPTION
Improvements to test reliability:

* Added `pytest` import to enable the use of `pytest.mark.flaky` for retrying flaky tests.
* Annotated the `test_navset_kitchensink` function with `@pytest.mark.flaky` to allow up to 5 retries with a 1-second delay between attempts, addressing intermittent WebKit timing issues.