### PR TITLE
test(CLI): Update test template to use create_app_fixture

### DIFF
--- a/shiny/_main_add_test.py
+++ b/shiny/_main_add_test.py
@@ -85,12 +85,15 @@ def add_test_file(
 from playwright.sync_api import Page
 
 from shiny.playwright import controller
+from shiny.pytest import create_app_fixture
 from shiny.run import ShinyAppProc
 
+app = create_app_fixture("{app_file.name}")
 
-def {test_name}(page: Page, local_app: ShinyAppProc):
 
-    page.goto(local_app.url)
+def {test_name}(page: Page, app: ShinyAppProc):
+
+    page.goto(app.url)
     # Add test code here
 """
         if is_same_dir

--- a/shiny/_main_add_test.py
+++ b/shiny/_main_add_test.py
@@ -80,24 +80,7 @@ def add_test_file(
     test_name = test_file.name.replace(".py", "")
     rel_path = os.path.relpath(app_file, test_file.parent)
 
-    template = (
-        f"""\
-from playwright.sync_api import Page
-
-from shiny.playwright import controller
-from shiny.pytest import create_app_fixture
-from shiny.run import ShinyAppProc
-
-app = create_app_fixture("{app_file.name}")
-
-
-def {test_name}(page: Page, app: ShinyAppProc):
-
-    page.goto(app.url)
-    # Add test code here
-"""
-        if is_same_dir
-        else f"""\
+    template = f"""\
 from playwright.sync_api import Page
 
 from shiny.playwright import controller
@@ -112,7 +95,6 @@ def {test_name}(page: Page, app: ShinyAppProc):
     page.goto(app.url)
     # Add test code here
 """
-    )
     # Make sure test file directory exists
     test_file.parent.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
Replaces the use of `local_app` with `app` for `ShinyAppProc`. This improves consistency and aligns with updated testing practices.

So now when the user runs `shiny add test` and the app dir is `accordion/app_express.py`
if the user chooses the tests to be created as `accordion/tests/test_app.py`
the created file will look like this
```python
from playwright.sync_api import Page

from shiny.playwright import controller
from shiny.pytest import create_app_fixture
from shiny.run import ShinyAppProc

app = create_app_fixture("../app-express.py")


def test_accordion_demo1(page: Page, app: ShinyAppProc) -> None:
    page.goto(app.url)
```
Else if the user chooses the tests to be created as `accordion/test_app.py` i.e. living besides the app_express.py file, the created file will look like this
```python
from playwright.sync_api import Page

from shiny.playwright import controller
from shiny.pytest import create_app_fixture
from shiny.run import ShinyAppProc

app = create_app_fixture("app-express.py")


def test_accordion_demo1(page: Page, app: ShinyAppProc) -> None:
```
