### PR TITLE
fix(example-tests): Remove deprecated warning messages from allowed errors

### DIFF
--- a/tests/playwright/examples/example_apps.py
+++ b/tests/playwright/examples/example_apps.py
@@ -91,8 +91,6 @@ app_allow_external_errors: typing.List[str] = [
     "FutureWarning: use_inf_as_na option is deprecated",
     "pd.option_context('mode.use_inf_as_na",  # continutation of line above,
     "RuntimeWarning: invalid value encountered in dot",  # some groups didn't have enough data points to create a meaningful line
-    "DatetimeIndex.format is deprecated and will be removed in a future version. Convert using index.astype(str) or index.map(formatter) instead.",  # cufflinks package is using this method
-    "Series.__getitem__ treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To access a value by position, use `ser.iloc[pos]`",  # cufflinks package is using this method
 ]
 app_allow_js_errors: typing.Dict[str, typing.List[str]] = {
     "examples/brownian": ["Failed to acquire camera feed:"],


### PR DESCRIPTION
Deleted two deprecated warning messages related to DatetimeIndex.format and Series.__getitem__ from the app_allow_external_errors list in example_apps.py. These warnings are no longer needed for error allowance.

This is possible because of [this PR](https://github.com/posit-dev/py-shiny-templates/pull/39)