### PR TITLE
feat: Improvements to selectize plugin defaults/updates

### DIFF
--- a/tests/pytest/test_ui.py
+++ b/tests/pytest/test_ui.py
@@ -3,7 +3,7 @@ import textwrap
 from htmltools import HTMLDocument, TagList, tags
 
 from shiny import ui
-from shiny.ui._input_select import _update_options
+from shiny.ui._input_select import _add_remove_button
 
 
 def test_panel_title():
@@ -136,56 +136,3 @@ def test_modal_footer():
         }</script>
         </div>"""
     )
-
-
-def test__update_options():
-    # User does not supply options
-    assert _update_options({}, remove_button=False, multiple=True) == {}
-    assert _update_options({}, remove_button=True, multiple=True) == {
-        "plugins": ["remove_button"]
-    }
-    assert _update_options({}, remove_button=True, multiple=False) == {
-        "plugins": ["clear_button"]
-    }
-
-    # User supplies other plugins
-    d1 = {"plugins": ["foo", "bar"]}
-    assert _update_options(d1, remove_button=True, multiple=True) == {
-        "plugins": ["foo", "bar", "remove_button"]
-    }
-    assert _update_options(d1, remove_button=True, multiple=False) == {
-        "plugins": ["foo", "bar", "clear_button"]
-    }
-    assert _update_options(d1, remove_button=False, multiple=False) == {
-        "plugins": ["foo", "bar"]
-    }
-
-    # User supplies non-plugin options
-    d2 = {"other_key": "foo"}
-
-    assert _update_options(d2, remove_button=True, multiple=True) == {
-        "other_key": "foo",
-        "plugins": ["remove_button"],
-    }
-    assert _update_options(d2, remove_button=True, multiple=True) == {
-        "other_key": "foo",
-        "plugins": ["remove_button"],
-    }
-    assert _update_options(d2, remove_button=False, multiple=False) == d2
-
-    # User supplies clear button plugin
-    d3 = {"plugins": ["clear_button"]}
-
-    assert _update_options(d3, remove_button=True, multiple=True) == {
-        "plugins": ["clear_button", "remove_button"]
-    }
-
-    assert _update_options(d3, remove_button=False, multiple=True) == d3
-    assert _update_options(d3, remove_button=True, multiple=False) == d3
-
-    # User supplies both clear and remove button plugins
-    d4 = {"plugins": ["clear_button", "remove_button"]}
-
-    assert _update_options(d4, remove_button=True, multiple=True) == d4
-    assert _update_options(d4, remove_button=True, multiple=False) == d4
-    assert _update_options(d4, remove_button=False, multiple=False) == d4


### PR DESCRIPTION
This PR does the following:

1. Adds the "clear_button" plugin by default when `input_selectize(multiple=True)`. This makes it possible to clear all the selected items at once:

2. Adds the "clear_button" plugin by default when `input_selectize(multiple=False)` _and `choices` contains `""`_.
    * We don't want to add generally when `multiple=False` since clearing the selection will make the input value `""`, which may be surprising/unsupported by the server logic.

3. `update_selectize(options=...)` now preserves it's default plugins (i.e., `remove_button`/`clear_button`) correctly.

4. `update_selectize()` gains a `remove_button` parameter that can be used to explicitly add/remove.

Closes #1384
Closes #2055


### TODO

Need to address the double-x on update case via shiny.scss (which lives in the R package)
