### PR TITLE
test(narwhals): Update Playwright test path in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,4 +260,4 @@ narwhals-test-integration: FORCE
 	@echo "-------- Running py-shiny format, lint, typing, and unit tests ----------"
 	$(MAKE) check
 	@echo "-------- Running py-shiny playwright tests ----------"
-	$(MAKE) playwright TEST_FILE="tests/playwright/shiny/components/data_frame" PYTEST_BROWSERS="--browser chromium"
+	$(MAKE) playwright TEST_FILE="tests/playwright/shiny/components/data_frame/data_type/" PYTEST_BROWSERS="--browser chromium"


### PR DESCRIPTION
This pull request changes the path for Playwright tests in the `narwhals-test-integration` target to point to the test that tests shiny integration with various data processing libraries.
This way it will make this test suite more robust.