### PR TITLE
fix(test): Add row focus state checks in edit mode test

### DIFF
--- a/tests/playwright/shiny/components/data_frame/validate_row_selection_edit_mode/test_validate_row_selection_edit_mode.py
+++ b/tests/playwright/shiny/components/data_frame/validate_row_selection_edit_mode/test_validate_row_selection_edit_mode.py
@@ -75,7 +75,9 @@ def test_validate_row_selection_in_edit_mode(
     # Tab to the column name, hit enter. Verify the table becomes sorted.
     # Tab to an HTML column name, hit enter. Verify the sort does not update.
     page.keyboard.press("Escape")
+    data_frame._expect_row_focus_state(True, row=1)
     page.keyboard.press("Escape")
+    data_frame._expect_row_focus_state(False, row=1)
     page.keyboard.press("Tab")
     page.keyboard.press("Tab")  # tab to sample number
     page.keyboard.press("Enter")


### PR DESCRIPTION
Inserted assertions to verify row focus state before and after pressing Escape in the data frame edit mode validation test. This enables dynamic delays between rapid, successive key presses.