### PR TITLE
fix(deps): Restrict `pytest-rerunfailures` version to below 16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ test = [
     "playwright>=1.48.0",
     "pytest-xdist",
     "pytest-timeout",
-    "pytest-rerunfailures",
+    "pytest-rerunfailures<16",
     "pytest-cov",
     "coverage",
     "syrupy>=4.7.1",


### PR DESCRIPTION
Related: https://github.com/pytest-dev/pytest-rerunfailures/issues/302