### PR TITLE
chore(add-test): Rename testgen extra to add-test and update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ update-testing-docs: docs update-testing-docs-repomix update-testing-docs-proces
 	@echo "-------- Testing documentation update complete --------"
 
 ci-install-ai-deps: FORCE
-	uv pip install -e ".[dev,test,testgen]"
+	uv pip install -e ".[dev,test,add-test]"
 	$(MAKE) install-playwright
 
 run-test-ai-evaluation: FORCE ## Run the AI evaluation script for tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,12 +124,15 @@ doc = [
     "quartodoc>=0.8.1",
     "griffe>=1.3.2",
 ]
-testgen = [
+add-test = [
     "chatlas[anthropic,openai]",
     "openai>=1.104.1",
     "anthropic>=0.62.0",
     "inspect-ai>=0.3.129",
     "pytest-timeout",
+    "pytest>=6.2.4",
+    "pytest-playwright>=0.5.2",
+    "playwright>=1.48.0",
 ]
 
 

--- a/shiny/pytest/_generate/_main.py
+++ b/shiny/pytest/_generate/_main.py
@@ -31,7 +31,7 @@ class Config:
     }
 
     DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-20250514"
-    DEFAULT_OPENAI_MODEL = "gpt-5-mini-2025-08-07"
+    DEFAULT_OPENAI_MODEL = "gpt-5-2025-08-07"
     DEFAULT_PROVIDER = "anthropic"
 
     MAX_TOKENS = 8092


### PR DESCRIPTION

This pull request updates the testing dependencies and configuration for the project, primarily by renaming and expanding the test dependency group and correcting a model name in the test generation code. The most important changes are:

* Renamed the `testgen` dependency group to `add-test` in `pyproject.toml` and expanded it to include `pytest`, `pytest-playwright`, and `playwright` for improved test capabilities.
* Updated the `Makefile` to use the new `add-test` dependency group instead of the old `testgen` group for installing test dependencies.
* Fixed the default OpenAI model name in `shiny/pytest/_generate/_main.py` from `gpt-5-mini-2025-08-07` to `gpt-5-2025-08-07` to ensure correct model usage.