### PR TITLE
fix(asyncio-test): fixture is no longer a valid value for asyncio

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 asyncio_mode=strict
 # Used for ./tests/pytest/asyncio_prevent.py
-asyncio_default_fixture_loop_scope=fixture
+asyncio_default_fixture_loop_scope=function
 testpaths=tests/pytest/
 ; Note: Browsers are set within `./Makefile`
 addopts = --strict-markers --durations=6 --durations-min=5.0 --numprocesses auto

--- a/tests/playwright/shiny/components/chat/stream-result/test_chat_stream_result.py
+++ b/tests/playwright/shiny/components/chat/stream-result/test_chat_stream_result.py
@@ -16,6 +16,8 @@ def test_validate_chat_stream_result(page: Page, local_app: ShinyAppProc) -> Non
 
     expect(chat.loc).to_be_visible(timeout=10 * 1000)
 
+    chat.expect_user_input("Press Enter to start the stream", timeout=30 * 1000)
+
     chat.send_user_input()
 
     messages = [
@@ -34,4 +36,4 @@ def test_validate_chat_stream_result(page: Page, local_app: ShinyAppProc) -> Non
     chat.expect_messages(re.compile(r"\s*".join(messages)), timeout=30 * 1000)
 
     # Verify that the stream result is as expected
-    stream_result.expect.to_contain_text("Message 9")
+    stream_result.expect.to_contain_text("Message 9", timeout=30 * 1000)


### PR DESCRIPTION
This pull request makes a minor configuration change to the `pytest.ini` file, adjusting the scope of the default asyncio fixture loop from `fixture` to `function`. This change ensures that a new event loop is created for each test function, which can help prevent cross-test interference in asynchronous test scenarios.

This [change](https://github.com/pytest-dev/pytest-asyncio/pull/1189) is causing pytest tests to fail since `fixture` is not a valid value anymore

Also make the `test_chat_stream_result` test more robust