### PR TITLE
ci: Disable flaky test on firefox

### DIFF
--- a/tests/playwright/shiny/components/selectize/test_selectize.py
+++ b/tests/playwright/shiny/components/selectize/test_selectize.py
@@ -1,9 +1,9 @@
 # import pytest
 from playwright.sync_api import Page, expect
+from utils.deploy_utils import skip_if_not_chrome
 
 from shiny.playwright import controller
 from shiny.run import ShinyAppProc
-from tests.playwright.utils.deploy_utils import skip_if_not_chrome
 
 
 @skip_if_not_chrome  # trouble with firefox. ??


### PR DESCRIPTION
Firefox consistently couldn't find any DOM element with placeholders. 

As this test isn't browser specific, I'm only going to test on Chrome