### PR TITLE
fix(deploy tests): Temporarily disable Connect server test in CI

### DIFF
--- a/.github/workflows/deploy-tests.yaml
+++ b/.github/workflows/deploy-tests.yaml
@@ -19,13 +19,15 @@ jobs:
         os: [ubuntu-latest]
         config:
           # Released server, shiny, and rsconnect
-          - name: "pypi-shiny-rsconnect-connect"
-            released_connect_server: true
-            pypi_shiny: true
-            pypi_rsconnect: true
-            base_test_dir: "./tests/playwright/deploys/express-page_sidebar"
-            app_name: "pypi-shiny-rsconnect"
-            test_shinyappsio: false
+          # TEMPORARILY DISABLED: Connect server missing uv binary at /opt/rstudio-connect/mnt/python-environments/_bootstrap/3.10.15/uv/bin/uv
+          # TODO: Re-enable once the Connect server is fixed
+          # - name: "pypi-shiny-rsconnect-connect"
+          #   released_connect_server: true
+          #   pypi_shiny: true
+          #   pypi_rsconnect: true
+          #   base_test_dir: "./tests/playwright/deploys/express-page_sidebar"
+          #   app_name: "pypi-shiny-rsconnect"
+          #   test_shinyappsio: false
 
           # Released shiny and rsconnect
           # Dev server


### PR DESCRIPTION
Commented out the 'pypi-shiny-rsconnect-connect' test configuration in deploy-tests.yaml due to a missing 'uv' binary on the Connect server. Added a TODO to re-enable the test once the server issue is resolved.