### PR TITLE
fix(docs): Pin griffe to <2.0.0 for quartodoc compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ doc = [
     "shinylive",
     "pydantic>=2.7.4",
     "quartodoc>=0.8.1",
-    "griffe>=1.3.2",
+    "griffe>=1.3.2,<2.0.0",
 ]
 add-test = [
     "chatlas[anthropic,openai]",


### PR DESCRIPTION
griffe 2.0.0 was released on February 9, 2026 and introduced breaking changes that removed the `options` parameter from docstring parsing functions. quartodoc 0.11.1 still passes `allow_section_blank_line` via this parameter, causing a TypeError when building docs.
(See https://github.com/posit-dev/py-shiny/actions/runs/21870887721/job/63144591291)

Pin griffe to versions before 2.0.0 until quartodoc releases a version compatible with griffe 2.0.0's API changes.

Griffe release in question: https://github.com/mkdocstrings/griffe/releases/tag/2.0.0

Quartodoc issue: https://github.com/machow/quartodoc/issues/423