### PR TITLE
fix: Add 'examples/airmass' to app_hard_wait

### DIFF
--- a/tests/playwright/examples/example_apps.py
+++ b/tests/playwright/examples/example_apps.py
@@ -38,6 +38,7 @@ app_idle_wait = {"duration": 300, "timeout": 30 * 1000}
 app_hard_wait: typing.Dict[str, int] = {
     "examples/brownian": 250,
     "examples/ui-func": 250,
+    "examples/airmass": 250,
 }
 output_transformer_errors = [
     "ShinyDeprecationWarning: `shiny.render.transformer.output_transformer()`",

--- a/tests/playwright/shiny/components/data_frame/df_methods/test_df_methods.py
+++ b/tests/playwright/shiny/components/data_frame/df_methods/test_df_methods.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 from playwright.sync_api import Page
 
@@ -13,8 +15,12 @@ def test_dataframe_methods(page: Page, local_app: ShinyAppProc, tab_name: str) -
 
     tab = controller.NavsetUnderline(page, "tab")
     tab.set(tab_name)
+    tab.expect_value(tab_name)
 
     data_frame = controller.OutputDataFrame(page, f"{tab_name}-iris_df")
+    controller.OutputTextVerbatim(page, f"{tab_name}-df_type").expect_value(
+        re.compile(tab_name)
+    )
     data_view_rows = controller.OutputCode(page, f"{tab_name}-data_view_rows")
     data_view_selected_true = controller.OutputCode(
         page, f"{tab_name}-data_view_selected_true"
@@ -38,7 +44,7 @@ def test_dataframe_methods(page: Page, local_app: ShinyAppProc, tab_name: str) -
     reset_data_frame()
 
     # sort column by number descending
-    data_frame.set_sort(0)
+    data_frame.set_sort({"col": 0, "desc": True})
     data_view_rows.expect_value("(2, 3, 4, 5, 0, 1)")
     data_view_selected_true.expect_value("[]")
     data_view_selected_false.expect_value("[50, 51, 100, 101, 0, 1]")
@@ -52,7 +58,7 @@ def test_dataframe_methods(page: Page, local_app: ShinyAppProc, tab_name: str) -
     cell_selection.expect_value("()")
 
     # sort column by text ascending
-    data_frame.set_sort([4])
+    data_frame.set_sort({"col": 4, "desc": False})
     data_view_rows.expect_value("(0, 1, 2, 3, 4, 5)")
     data_view_selected_true.expect_value("[]")
     data_view_selected_false.expect_value("[0, 1, 50, 51, 100, 101]")
@@ -82,7 +88,7 @@ def test_dataframe_methods(page: Page, local_app: ShinyAppProc, tab_name: str) -
     data_view_selected_false.expect_value("[51, 100, 101]")
     cell_selection.expect_value("()")
 
-    data_frame.set_sort(3)
+    data_frame.set_sort({"col": 3, "desc": True})
     data_view_rows.expect_value("(4, 5, 3)")
     data_view_selected_true.expect_value("[]")
     data_view_selected_false.expect_value("[100, 101, 51]")

--- a/tests/playwright/shiny/components/nav/navset_hidden_kitchensink/test_navset_hidden_kitchensink.py
+++ b/tests/playwright/shiny/components/nav/navset_hidden_kitchensink/test_navset_hidden_kitchensink.py
@@ -1,4 +1,4 @@
-from playwright.sync_api import Page, expect
+from playwright.sync_api import Error, Page, expect
 
 from shiny.playwright import controller
 from shiny.playwright.expect._internal import _expect_nav_to_have_header_footer
@@ -6,7 +6,12 @@ from shiny.run import ShinyAppProc
 
 
 def test_navset_hidden_kitchensink(page: Page, local_app: ShinyAppProc) -> None:
-    page.goto(local_app.url)
+    try:
+        page.goto(local_app.url)
+    except Error as e:
+        if "interrupted by another navigation" not in str(e):
+            raise
+        page.goto(local_app.url)
 
     navset_hidden_1 = controller.NavsetHidden(page, "hidden_tabs1")
     radio1 = controller.InputRadioButtons(page, "controller1")


### PR DESCRIPTION
Include "examples/airmass": 250 in app_hard_wait within tests/playwright/examples/example_apps.py to give the airmass example a 250ms hard wait. This change helps stabilize Playwright tests for the airmass example and reduce flakiness.