### PR TITLE
feat: Save shinylive assets as GHA artifact

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -1,7 +1,7 @@
 name: Build API docs and Shinylive for GitHub Pages
 
-# Allow for `main` branch to build full website and deploy (with shinylive, saved as artifact)
-# Allow branches that start with `docs-` to build full website, but not deploy (with shinylive, not saved as artifact)
+# Allow for `main` branch to build full website and deploy (saving dev shinylive assets as an artifact)
+# Allow branches that start with `docs-` to build full website, but not deploy (builds dev shinylive assets, no artifact)
 # Allow for PRs to build quartodoc only. (No shinylive, no site build, no deploy)
 # Manual workflow_dispatch can build only shinylive (skip docs) or full build
 


### PR DESCRIPTION
This updates the build process to run the workflow on manual trigger OR commit to main to save the shinylive assets saved with the branch (or main)'s version of pyshiny to an artifact.
This can then be pulled into the py-shiny-site process to allow for local previewing before the PyPI release.

Workflow will work like:

Trigger | Quartodoc | Build Shinylive | Save Artifact | Install Assets | Build Site | Deploy
-- | -- | -- | -- | -- | -- | --
PR | ✅ | ❌ | ❌ | ❌ | ❌ | ❌
Push to docs-** | ✅ | ✅ | ❌ | ✅ | ✅ | ❌
Push to main | ✅ | ✅ | ✅ | ✅ | ✅ | ✅
Manual (build_only = false) | ✅ | ✅ | ✅ | ✅ | ✅ | ❌*
Manual (build_only = true) | ❌ | ✅ | ✅ | ❌ | ❌ | ❌

See https://github.com/posit-dev/py-shiny-site/pull/344 for details