### PR TITLE
fix: Add explicit date format to suppress dateutil warning

### DIFF
--- a/examples/model-score/app.py
+++ b/examples/model-score/app.py
@@ -285,7 +285,7 @@ def server(input: Inputs, output: Outputs, session: Session):
     @reactive.effect
     def update_time_range():
         """
-        Every 5 seconds, update the custom time range slider's min and max values to
+        Every 15 seconds, update the custom time range slider's min and max values to
         reflect the current min and max values in the database.
         """
 

--- a/examples/model-score/app.py
+++ b/examples/model-score/app.py
@@ -295,6 +295,7 @@ def server(input: Inputs, output: Outputs, session: Session):
                 con.execute(
                     "select min(timestamp), max(timestamp) from accuracy_scores"
                 ).fetchone(),
+                format="ISO8601",
                 utc=True,
             )
             ui.update_slider(


### PR DESCRIPTION
## Summary
- Adds `format="ISO8601"` to the `pd.to_datetime()` call in the model-score example's `update_time_range()` function, matching the format already used by the other two `pd.to_datetime()` calls in the same file.
- Fixes: `UserWarning: Could not infer format, so each element will be parsed individually, falling back to dateutil.`

## Test plan
- [x] Verified the app runs without the warning
- [x] Confirmed this is consistent with the existing `format="ISO8601"` usage on lines 51 and 67

🤖 Generated with [Claude Code](https://claude.com/claude-code)