### PR TITLE
docs: fix bare ':' Returns labels in toast_header and render.image docstrings

### DIFF
--- a/shiny/render/_render.py
+++ b/shiny/render/_render.py
@@ -393,7 +393,7 @@ class image(Renderer[ImgData]):
 
     Returns
     -------
-    :
+    Renderer[ImgData]
         A decorator for a function that returns an :func:`~shiny.types.ImgData` object.
 
     Tip

--- a/shiny/ui/_toast.py
+++ b/shiny/ui/_toast.py
@@ -334,7 +334,7 @@ def toast_header(
 
     Returns
     -------
-    :
+    ToastHeader
         A toast header object.
 
     Examples


### PR DESCRIPTION
## Summary

Two NumPy-style docstrings used a bare \`:\` as the Returns label, which renders as an orphaned colon in the generated API docs:

- \`shiny.ui.toast_header\` — Returns section showed "\`:  A toast header object.\`"
- \`shiny.render.image\` — Returns section showed "\`:  A decorator for a function that returns an ImgData object.\`"

Replaced the bare \`:\` with the actual return type:

- \`shiny/ui/_toast.py\` :: \`toast_header\` — \`-> ToastHeader\` matches the function's signature.
- \`shiny/render/_render.py\` :: \`render.image\` — \`-> Renderer[ImgData]\` matches the \`class image(Renderer[ImgData])\` declaration.

Closes #2215

## Testing

Docstring-only change. No runtime paths affected. The rendered docs page will now show a typed Returns label instead of a dangling colon.