### PR TITLE
fix: Escape leading asterisks and omit empty return labels in docs renderer

### DIFF
--- a/docs/_renderer.py
+++ b/docs/_renderer.py
@@ -12,6 +12,9 @@ import quartodoc.ast as qast
 from griffe import (
     Alias,
     DocstringAttribute,
+    DocstringParameter,
+    DocstringReturn,
+    DocstringSectionReturns,
     DocstringSectionText,
     Expr,
     ExprName,
@@ -22,8 +25,6 @@ from plum import dispatch
 from quartodoc import MdRenderer
 from quartodoc.renderers.base import convert_rst_link_to_md, sanitize
 from quartodoc.renderers.md_renderer import ParamRow
-
-# from quartodoc.ast import preview
 
 SHINY_PATH = Path(files("shiny").joinpath())
 
@@ -106,6 +107,29 @@ class Renderer(MdRenderer):
             annotation=self.render_annotation(el.annotation),
         )
         return row
+
+    @dispatch
+    def render(self, el: DocstringParameter) -> ParamRow:
+        param_row = super().render(el)
+        # Escape leading asterisks to prevent markdown bold/italic collision.
+        # e.g. "**kwargs" -> r"\*\*kwargs", "*args" -> r"\*args"
+        param_row.name = re.sub(
+            r"^\*+", lambda m: "".join(r"\*" for _ in m.group()), param_row.name
+        )
+
+        return param_row
+
+    @dispatch
+    def render(self, el: DocstringSectionReturns):
+        if len(el.value) == 1:
+            if isinstance(el.value[0], DocstringReturn):
+                if not el.value[0].name and not el.value[0].annotation:
+                    # When name and annotation are both empty (common for class docstrings
+                    # where griffe cannot resolve a return type), the default rendering
+                    # produces an orphaned colon. Override to use an empty definition term.
+                    return self.render(el.value[0].description)
+
+        return super().render(el)
 
     @dispatch
     def render_annotation(self, el: None):

--- a/shiny/render/_render.py
+++ b/shiny/render/_render.py
@@ -216,11 +216,11 @@ class plot(Renderer[object]):
            :class:`matplotlib.figure.Figure` instance.
         5. A :class:`PIL.Image.Image` instance.
 
-    It's also possible to use the ``matplotlib.pyplot`` interface; in that case, your
-    function should just call pyplot functions and not return anything. (Note that if
-    the decorated function is async, then it's not safe to use pyplot. Shiny will detect
-    this case and throw an error asking you to use matplotlib's object-oriented
-    interface instead.)
+        It's also possible to use the ``matplotlib.pyplot`` interface; in that case,
+        your function should just call pyplot functions and not return anything. (Note
+        that if the decorated function is async, then it's not safe to use pyplot. Shiny
+        will detect this case and throw an error asking you to use matplotlib's
+        object-oriented interface instead.)
 
     Tip
     ----


### PR DESCRIPTION
## Summary

Fixes two rendering bugs in the quartodoc custom renderer (`docs/_renderer.py`):

- **`**kwargs` / `*args` double-bold:** Parameter names with leading asterisks collided with markdown bold/italic syntax, rendering as `****kwargs**`. Now escaped as `\*\*kwargs` and `\*args`.
- **Orphaned colon in Returns sections:** Class docstrings with bare `:` return labels (where griffe cannot resolve a return type) produced an orphaned `: Description`. Now omits the name/colon line entirely when both name and annotation are empty.
- **`render.plot` docstring indentation:** A continuation paragraph about `matplotlib.pyplot` was dedented, causing it to render outside the Returns section.

Closes #2215

## Test plan

- [x] `uv run make docs-quartodoc` builds successfully
- [x] Zero `****kwargs**` patterns remain in rendered output
- [x] Zero `***args**` patterns remain in rendered output
- [x] `render.image` and `render.plot` Returns sections have no orphaned colons
- [x] Standalone functions with resolved return types (e.g., `ui.input_text`, `ui.toast_header`) still render correctly with type annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)