### PR TITLE
ci: Pull Playwright image with retries

### DIFF
--- a/.github/py-shiny/narwhals-setup/action.yaml
+++ b/.github/py-shiny/narwhals-setup/action.yaml
@@ -24,4 +24,4 @@ runs:
         make ci-install-deps
 
     - name: Setup remote Playwright
-      uses: posit-dev/py-shiny/.github/py-shiny/setup-playwright-remote@a7f74bbfbdbaa2477cb513c52d7655e176fcad3b
+      uses: posit-dev/py-shiny/.github/py-shiny/setup-playwright-remote@main

--- a/.github/py-shiny/narwhals-setup/action.yaml
+++ b/.github/py-shiny/narwhals-setup/action.yaml
@@ -24,4 +24,4 @@ runs:
         make ci-install-deps
 
     - name: Setup remote Playwright
-      uses: posit-dev/py-shiny/.github/py-shiny/setup-playwright-remote@main
+      uses: posit-dev/py-shiny/.github/py-shiny/setup-playwright-remote@a7f74bbfbdbaa2477cb513c52d7655e176fcad3b

--- a/.github/py-shiny/setup-playwright-remote/action.yaml
+++ b/.github/py-shiny/setup-playwright-remote/action.yaml
@@ -100,7 +100,7 @@ runs:
                 with sync_playwright() as playwright:
                     browser_type = getattr(playwright, browser_name)
                     browser = browser_type.connect(
-                        ws_endpoint=ws_endpoint,
+                        ws_endpoint,
                         expose_network="*",
                         timeout=10000,
                     )

--- a/.github/py-shiny/setup-playwright-remote/action.yaml
+++ b/.github/py-shiny/setup-playwright-remote/action.yaml
@@ -38,6 +38,25 @@ runs:
 
         echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+    - name: Pull Playwright image
+      shell: bash
+      run: |
+        IMAGE="mcr.microsoft.com/playwright:v${{ steps.resolve-version.outputs.version }}-noble"
+        # MCR (Azure Front Door) intermittently returns "The request is blocked"
+        # for GitHub Actions runners. Retry a few times before giving up.
+        attempt=1
+        max_attempts=5
+        until docker pull "$IMAGE"; do
+          if [ "$attempt" -ge "$max_attempts" ]; then
+            echo "Failed to pull $IMAGE after $attempt attempts" >&2
+            exit 1
+          fi
+          sleep_seconds=$((attempt * 10))
+          echo "docker pull failed (attempt $attempt/$max_attempts); retrying in ${sleep_seconds}s..." >&2
+          sleep "$sleep_seconds"
+          attempt=$((attempt + 1))
+        done
+
     - name: Start Playwright server
       shell: bash
       run: |

--- a/shiny/playwright/controller/_output.py
+++ b/shiny/playwright/controller/_output.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import platform
 from typing import Literal, Protocol
 
 from playwright.sync_api import Locator, Page
@@ -915,6 +914,14 @@ class OutputDataFrame(UiWithContainer):
                 break
         cell.scroll_into_view_if_needed(timeout=timeout)
 
+    def _multi_select_modifier(self) -> Literal["Control", "Meta"]:
+        platform = self.page.evaluate(
+            "() => window.navigator.userAgentData?.platform ?? window.navigator.platform"
+        )
+        if isinstance(platform, str) and platform.lower().startswith("mac"):
+            return "Meta"
+        return "Control"
+
     def _expect_column_label(
         self,
         value: ListPatternOrStr,
@@ -1016,18 +1023,13 @@ class OutputDataFrame(UiWithContainer):
                 self.cell_locator(row=value[-1], col=0).click(timeout=timeout)
                 self.page.keyboard.up("Shift")
             else:
-                # if operating system is MacOs use Meta (Cmd) else use Ctrl key
-                if platform.system() == "Darwin":
-                    self.page.keyboard.down("Meta")
-                else:
-                    self.page.keyboard.down("Control")
+                modifier = self._multi_select_modifier()
                 for row in value:
                     self._cell_scroll_if_needed(row=row, col=0, timeout=timeout)
-                    self.cell_locator(row=row, col=0).click(timeout=timeout)
-                if platform.system() == "Darwin":
-                    self.page.keyboard.up("Meta")
-                else:
-                    self.page.keyboard.up("Control")
+                    self.cell_locator(row=row, col=0).click(
+                        timeout=timeout,
+                        modifiers=[modifier],
+                    )
         else:
             self.cell_locator(row=value[0], col=0).click(timeout=timeout)
 

--- a/tests/playwright/conftest.py
+++ b/tests/playwright/conftest.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import os
+from inspect import signature
 from pathlib import PurePath
 
 import pytest
-from playwright.sync_api import BrowserContext, Page
+from playwright.sync_api import BrowserContext, BrowserType, Page
 
 from shiny.pytest import ScopeName as ScopeName
 from shiny.pytest import create_app_fixture
@@ -62,7 +63,12 @@ def connect_options() -> dict[str, str] | None:
     if not ws_endpoint:
         return None
 
-    options = {"ws_endpoint": ws_endpoint}
+    endpoint_arg = (
+        "endpoint"
+        if "endpoint" in signature(BrowserType.connect).parameters
+        else "ws_endpoint"
+    )
+    options = {endpoint_arg: ws_endpoint}
     expose_network = os.getenv("PW_TEST_CONNECT_EXPOSE_NETWORK")
     if expose_network:
         options["expose_network"] = expose_network

--- a/tests/playwright/shiny/bugs/1390-df-selected-row-filtered/test_1390_selected_row_filtered.py
+++ b/tests/playwright/shiny/bugs/1390-df-selected-row-filtered/test_1390_selected_row_filtered.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import platform
-
 from playwright.sync_api import Page, expect
 
 from shiny.playwright import controller
@@ -82,7 +80,7 @@ def test_row_selection(page: Page, local_app: ShinyAppProc) -> None:
     selected_rows.expect_value("(8,)")
 
     # Remove selection
-    modifier = "Meta" if platform.system() == "Darwin" else "Control"
+    modifier = my_df._multi_select_modifier()
     for row in (8,):
         my_df.cell_locator(row=row, col=0).click(
             modifiers=[modifier]


### PR DESCRIPTION
Add a 'Pull Playwright image' step to the GitHub Action that pulls mcr.microsoft.com/playwright:v${{ steps.resolve-version.outputs.version }}-noble before starting the server. The step retries up to 5 times with increasing delays to work around intermittent MCR/Azure Front Door "The request is blocked" errors and fails the job if all attempts fail.