### PR TITLE
chore: Bump shinylive docs dependency to >=0.8.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ doc = [
     "jupyter",
     "jupyter_client < 8.0.0",
     "tabulate",
-    "shinylive>=0.8.6",
+    "shinylive>=0.8.7",
     "pydantic>=2.7.4",
     "quartodoc>=0.8.1",
     "griffe>=1.3.2,<2.0.0",


### PR DESCRIPTION
## Summary

* Bump `shinylive` docs dependency from >=0.8.6 to >=0.8.7 (picks up Shinylive web assets 0.10.9)

Part of the py-shiny v1.6.1 release train.