### PR TITLE
fix(types): Adapt to htmltools tagified-tag type system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "uvicorn>=0.16.0;platform_system!='Emscripten'",
     "starlette",
     "websockets>=13.0",
-    "htmltools>=0.6.0",
+    "htmltools>=0.7.0",
     "click>=8.1.4;platform_system!='Emscripten'",
     "markdown-it-py>=1.1.0",
     "mdit-py-plugins>=0.3.0",

--- a/shiny/express/_run.py
+++ b/shiny/express/_run.py
@@ -131,7 +131,7 @@ def create_express_app(file: Path, package_name: str) -> App:
             # catch them here and convert them to a different type of error, because uvicorn
             # specifically catches AttributeErrors and prints an error message that is
             # misleading for Shiny Express. https://github.com/posit-dev/py-shiny/issues/937
-            app_ui = run_express(file, package_name).tagify()
+            app_ui = cast("Tag | TagList", run_express(file, package_name).tagify())
 
     except AttributeError as e:
         raise RuntimeError(e) from e
@@ -140,10 +140,10 @@ def create_express_app(file: Path, package_name: str) -> App:
     if express_bookmark_store != "disable":
         # If bookmarking is enabled, wrap UI in function to automatically leverage UI
         # functions to restore their values
-        def app_ui_wrapper(request: Request):
+        def app_ui_wrapper(request: Request) -> Tag | TagList:
             # Stub session used to pass `app_opts()` checks.
             with session_context(ExpressStubSession()):
-                return run_express(file, package_name).tagify()
+                return cast("Tag | TagList", run_express(file, package_name).tagify())
 
         app_ui = app_ui_wrapper
 

--- a/shiny/express/expressify_decorator/_func_displayhook.py
+++ b/shiny/express/expressify_decorator/_func_displayhook.py
@@ -1,4 +1,5 @@
 import sys
+from typing import cast
 
 from htmltools import Tag, Tagifiable, TagList
 
@@ -8,6 +9,6 @@ from htmltools import Tag, Tagifiable, TagList
 # the current sys.displayhook.
 def _expressify_decorator_function_def(fn: object) -> object:
     if isinstance(fn, (Tag, TagList, Tagifiable)) or hasattr(fn, "_repr_html_"):
-        sys.displayhook(fn)
+        sys.displayhook(cast(object, fn))
 
-    return fn
+    return cast(object, fn)

--- a/shiny/ui/_accordion.py
+++ b/shiny/ui/_accordion.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal, Optional, TypeVar
 
-from htmltools import Tag, TagAttrs, TagAttrValue, TagChild, css, tags
+from htmltools import Tag, TagAttrs, TagAttrValue, TagChild, Tagified, css, tags
 
 from .._docstring import add_example
 from .._namespaces import resolve_id_or_none
@@ -159,7 +159,7 @@ class AccordionPanel:
             ),
         )
 
-    def tagify(self) -> Tag:
+    def tagify(self) -> Tagified:
         """
         Resolve the :class:`~shiny.ui.AccordionPanel` into a
         :class:`~htmltools.Tag`.

--- a/shiny/ui/_card.py
+++ b/shiny/ui/_card.py
@@ -9,6 +9,7 @@ from htmltools import (
     TagAttrValue,
     TagChild,
     TagFunction,
+    Tagified,
     TagList,
     css,
     div,
@@ -429,7 +430,7 @@ class CardItem:
         """
         return self._item
 
-    def tagify(self) -> TagList:
+    def tagify(self) -> Tagified:
         """
         Tagify the `item`
 

--- a/shiny/ui/_navs.py
+++ b/shiny/ui/_navs.py
@@ -12,6 +12,7 @@ from htmltools import (
     TagAttrs,
     TagAttrValue,
     TagChild,
+    Tagified,
     TagList,
     css,
     div,
@@ -404,7 +405,7 @@ class NavSet:
         self.header = header
         self.footer = footer
 
-    def tagify(self) -> TagList | Tag:
+    def tagify(self) -> Tagified:
         id = self.id
         ul_class = self.ul_class
         if id is not None:
@@ -1428,12 +1429,13 @@ def _make_tabs_fillable(
         # Only work on Tags
         if not isinstance(child, Tag):
             continue
+        child_tag = cast(Tag, child)
         # Only work on .tab-pane children
-        if not child.has_class("tab-pane"):
+        if not child_tag.has_class("tab-pane"):
             continue
         # If `fillable` is a list, only fill the .tab-pane if its data-value is contained in `fillable`
         if isinstance(fillable, list):
-            child_attr = child.attrs.get("data-value")
+            child_attr = child_tag.attrs.get("data-value")
             if child_attr is None or child_attr not in fillable:
                 continue
         styles = css(
@@ -1441,11 +1443,11 @@ def _make_tabs_fillable(
             padding=as_css_padding(padding),
             __bslib_navbar_margin="0;" if navbar else None,
         )
-        child = as_fillable_container(as_fill_item(child))
-        child.add_style(cast(str, styles))
-        child.add_class("bslib-gap-spacing")
+        child_tag = as_fillable_container(as_fill_item(child_tag))
+        child_tag.add_style(cast(str, styles))
+        child_tag.add_class("bslib-gap-spacing")
 
-        content.children[i] = child
+        content.children[i] = child_tag
 
     return content
 

--- a/shiny/ui/_page.py
+++ b/shiny/ui/_page.py
@@ -14,7 +14,7 @@ __all__ = (
 )
 
 from copy import copy
-from typing import Any, Callable, Literal, Optional, Sequence
+from typing import Any, Callable, Literal, Optional, Sequence, cast
 
 from htmltools import (
     MetadataNode,
@@ -441,8 +441,9 @@ def page_fillable(
     body = page.children[1]
     if not isinstance(body, Tag) or body.name != "body":
         raise ValueError("Expected a <body> tag")
+    body_tag = cast(Tag, body)
 
-    page.children[1] = as_fillable_container(body)
+    page.children[1] = as_fillable_container(body_tag)
 
     return page
 

--- a/shiny/ui/_sidebar.py
+++ b/shiny/ui/_sidebar.py
@@ -10,6 +10,7 @@ from htmltools import (
     TagAttrs,
     TagAttrValue,
     TagChild,
+    Tagified,
     TagList,
     css,
     div,
@@ -458,7 +459,7 @@ class Sidebar:
 
         return sidebar_tag
 
-    def tagify(self) -> TagList:
+    def tagify(self) -> Tagified:
         id = self._get_sidebar_id()
         taglist = TagList(self._sidebar_tag(id), self._collapse_tag(id))
         return taglist.tagify()

--- a/shiny/ui/_toolbar.py
+++ b/shiny/ui/_toolbar.py
@@ -11,7 +11,7 @@ __all__ = (
 )
 
 import warnings
-from typing import Literal, Optional
+from typing import Literal, Optional, cast
 
 from htmltools import Tag, TagAttrValue, TagChild, css, div, span, tags
 
@@ -355,8 +355,9 @@ def _extract_text(x: TagChild) -> str:
     if isinstance(x, (list, tuple)):
         return " ".join(_extract_text(item) for item in x)
     if isinstance(x, Tag):
-        if hasattr(x, "children"):
-            return _extract_text(x.children)
+        x_tag = cast(Tag, x)
+        if hasattr(x_tag, "children"):
+            return _extract_text(cast(TagChild, x_tag.children))
     return ""
 
 

--- a/shiny/ui/_utils.py
+++ b/shiny/ui/_utils.py
@@ -58,10 +58,13 @@ def get_window_title(
 
 
 def _find_child_strings(x: TagList | TagNode) -> str:
-    if isinstance(x, Tag) and x.name not in ("script", "style"):
-        x = x.children
+    if isinstance(x, Tag):
+        x_tag = cast(Tag, x)
+        if x_tag.name not in ("script", "style"):
+            x = x_tag.children
     if isinstance(x, TagList):
-        strings = [_find_child_strings(y) for y in x]
+        x_taglist = cast(TagList, x)
+        strings = [_find_child_strings(y) for y in x_taglist]
         return " ".join(filter(lambda x: x != "", strings))
     if isinstance(x, str):
         return x

--- a/tests/pytest/test_sidebar.py
+++ b/tests/pytest/test_sidebar.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, cast
 
 import pytest
-from htmltools import Tag, TagAttrValue
+from htmltools import Tag, TagAttrValue, TagList
 
 from shiny import ui
 from shiny.ui._sidebar import SidebarOpenSpec, SidebarOpenValue
@@ -25,10 +25,13 @@ def test_sidebar_open_string_values(
 
 
 def get_sidebar_tags(sb: ui.Sidebar) -> tuple[Tag, Tag]:
-    sidebar, collapse = sb.tagify()
+    tagified = sb.tagify()
+    assert isinstance(tagified, TagList)
+    sidebar = cast(object, tagified[0])
+    collapse = cast(object, tagified[1])
     assert isinstance(sidebar, Tag)
     assert isinstance(collapse, Tag)
-    return sidebar, collapse
+    return cast(Tag, sidebar), cast(Tag, collapse)
 
 
 def test_sidebar_assigns_input_binding_class_if_id_provided():


### PR DESCRIPTION
## Summary

Updates py-shiny to satisfy pyright against the new generic `Tag[ChildT]` / `TagList[ChildT]` types and the tighter `Tagified` return type of `.tagify()` introduced in posit-dev/py-htmltools#106.

- Use `Tagified` as the return type for all custom `.tagify()` methods (`AccordionPanel`, `CardItem`, `NavSet*`, `Sidebar`).
- Cast to `Tag` after `isinstance(x, Tag)` narrowing where pyright produces `Tag[Unknown] | Tag[TagifiedNode]` due to invariance (`_navs._make_tabs_fillable`, `_page`, `_toolbar._extract_text`, `_utils._find_child_strings`).
- Express: cast `.tagify()` result back to `Tag | TagList` before handing it to `App` (which still operates on the narrower type), and avoid pyright narrowing of `object` in `_func_displayhook`.
- Update `test_sidebar.get_sidebar_tags` to index + cast rather than tuple-unpack a `Tagified` value.
- Bump `htmltools>=0.7.0`.

Depends on posit-dev/py-htmltools#106. The version pin assumes that PR lands as htmltools 0.7.0 — adjust if the released version differs.

## Test plan

- [x] \`pyright\` — 0 errors
- [x] \`make check-format\` — clean
- [x] \`pytest tests/pytest\` — 692 passed
- [ ] Verify against the final released htmltools version once #106 merges