### PR TITLE
fix(examples): Run DB updater safely; allow extra warnings

### DIFF
--- a/shiny/api-examples/poll/app-core.py
+++ b/shiny/api-examples/poll/app-core.py
@@ -68,7 +68,17 @@ async def update_db_task(con: sqlite3.Connection) -> Awaitable[None]:
         update_db(con)
 
 
-asyncio.create_task(update_db_task(conn))
+try:
+    loop = asyncio.get_running_loop()
+except RuntimeError:
+    loop = None
+
+if loop and loop.is_running():
+    asyncio.create_task(update_db_task(conn))
+else:
+    from threading import Thread
+
+    Thread(target=lambda: asyncio.run(update_db_task(conn)), daemon=True).start()
 
 
 # === Create the reactive.poll object ===============================

--- a/shiny/api-examples/poll/app-core.py
+++ b/shiny/api-examples/poll/app-core.py
@@ -38,7 +38,7 @@ def init_db(con: sqlite3.Connection) -> None:
         cur.close()
 
 
-conn = sqlite3.connect(":memory:")
+conn = sqlite3.connect(":memory:", check_same_thread=False)
 init_db(conn)
 
 

--- a/shiny/api-examples/poll/app-express.py
+++ b/shiny/api-examples/poll/app-express.py
@@ -39,7 +39,7 @@ def init_db(con: sqlite3.Connection) -> None:
         cur.close()
 
 
-conn = sqlite3.connect(":memory:")
+conn = sqlite3.connect(":memory:", check_same_thread=False)
 init_db(conn)
 
 

--- a/shiny/api-examples/poll/app-express.py
+++ b/shiny/api-examples/poll/app-express.py
@@ -69,7 +69,17 @@ async def update_db_task(con: sqlite3.Connection) -> Awaitable[None]:
         update_db(con)
 
 
-_ = asyncio.create_task(update_db_task(conn))
+try:
+    loop = asyncio.get_running_loop()
+except RuntimeError:
+    loop = None
+
+if loop and loop.is_running():
+    _ = asyncio.create_task(update_db_task(conn))
+else:
+    from threading import Thread
+
+    Thread(target=lambda: asyncio.run(update_db_task(conn)), daemon=True).start()
 
 
 # === Create the reactive.poll object ===============================

--- a/shiny/express/_run.py
+++ b/shiny/express/_run.py
@@ -131,7 +131,7 @@ def create_express_app(file: Path, package_name: str) -> App:
             # catch them here and convert them to a different type of error, because uvicorn
             # specifically catches AttributeErrors and prints an error message that is
             # misleading for Shiny Express. https://github.com/posit-dev/py-shiny/issues/937
-            app_ui = run_express(file, package_name).tagify()
+            app_ui = cast("Tag | TagList", run_express(file, package_name).tagify())
 
     except AttributeError as e:
         raise RuntimeError(e) from e
@@ -143,7 +143,7 @@ def create_express_app(file: Path, package_name: str) -> App:
         def app_ui_wrapper(request: Request):
             # Stub session used to pass `app_opts()` checks.
             with session_context(ExpressStubSession()):
-                return run_express(file, package_name).tagify()
+                return cast("Tag | TagList", run_express(file, package_name).tagify())
 
         app_ui = app_ui_wrapper
 

--- a/shiny/ui/_accordion.py
+++ b/shiny/ui/_accordion.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, Optional, TypeVar
+from typing import TYPE_CHECKING, Literal, Optional, TypeVar, cast
 
 from htmltools import Tag, TagAttrs, TagAttrValue, TagChild, css, tags
 
@@ -169,7 +169,7 @@ class AccordionPanel:
         :
             A tagified `resolve()`d value.
         """
-        return self.resolve().tagify()
+        return cast(Tag, self.resolve().tagify())
 
 
 @add_example()

--- a/shiny/ui/_card.py
+++ b/shiny/ui/_card.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional, Protocol
+from typing import Optional, Protocol, cast
 
 from htmltools import (
     HTML,
@@ -438,7 +438,7 @@ class CardItem:
         :
             A tagified :class:`~htmltools.TagList` object.
         """
-        return TagList(self.resolve()).tagify()
+        return cast(TagList, TagList(self.resolve()).tagify())
 
 
 @add_example()

--- a/shiny/ui/_navs.py
+++ b/shiny/ui/_navs.py
@@ -413,7 +413,7 @@ class NavSet:
         nav, content = render_navset(
             *self.args, ul_class=ul_class, id=id, selected=self.selected, context={}
         )
-        return self.layout(nav, content).tagify()
+        return cast("TagList | Tag", self.layout(nav, content).tagify())
 
     def layout(self, nav: Tag, content: Tag) -> TagList | Tag:
         return TagList(nav, self.header, content, self.footer)

--- a/shiny/ui/_sidebar.py
+++ b/shiny/ui/_sidebar.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import warnings
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Literal, Optional
+from typing import TYPE_CHECKING, Literal, Optional, cast
 
 from htmltools import (
     HTML,
@@ -461,7 +461,7 @@ class Sidebar:
     def tagify(self) -> TagList:
         id = self._get_sidebar_id()
         taglist = TagList(self._sidebar_tag(id), self._collapse_tag(id))
-        return taglist.tagify()
+        return cast(TagList, taglist.tagify())
 
 
 @add_example()

--- a/tests/playwright/examples/example_apps.py
+++ b/tests/playwright/examples/example_apps.py
@@ -94,6 +94,8 @@ app_allow_external_errors: typing.List[str] = [
     # yfinance deprecation warning (Pandas 4.0 compatibility)
     "Pandas4Warning: Timestamp.utcnow is deprecated",
     "dt_now = pd.Timestamp.utcnow()",  # continuation of line above
+    "RequestsDependencyWarning: urllib3",
+    "warnings.warn(",
 ]
 app_allow_js_errors: typing.Dict[str, typing.List[str]] = {
     "examples/brownian": ["Failed to acquire camera feed:"],


### PR DESCRIPTION
- Change how the background DB update coroutine is started: check for a running asyncio event loop and use asyncio.create_task when available; otherwise spawn a daemon Thread that runs asyncio.run(update_db_task(conn)). This ensures the updater works both inside existing event loops and in contexts without one (e.g., tests or non-async entrypoints). 
- Also relax the Playwright example test filters by allowing RequestsDependencyWarning for urllib3 and generic warnings.warn entries to suppress unrelated external warnings.