### PR TITLE
release: v1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+## [1.6.2] - 2026-05-21
+
 ### Bug fixes
 
+* Adapted py-shiny to the `htmltools` 0.7.0 sibling-classes refactor: removed `Tag[TagNode]` / `TagList[TagNode]` type arguments and redundant casts that no longer type-check against the new htmltools. No runtime behavior change. (#2244)
 * Bumped `lodash`/`lodash-es` to `4.18.1` in the `js-react` template lockfile for CVE-2025-13465. (#2233)
 * Fixed `render.DataGrid()` column headers and hovered rows not adapting to dark mode when `ui.input_dark_mode()` is enabled. The data grid now uses Bootstrap 5.3 mode-aware color tokens (`--bs-tertiary-bg`, `--bs-primary-bg-subtle`, `--bs-emphasis-color`, `--bs-secondary-color`), with the legacy values preserved as fallbacks. (#1635)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
-* Adapted py-shiny to the `htmltools` 0.7.0 sibling-classes refactor: removed `Tag[TagNode]` / `TagList[TagNode]` type arguments and redundant casts that no longer type-check against the new htmltools. No runtime behavior change. (#2244)
+* Adapted py-shiny to the `htmltools` 0.7.0 sibling-classes refactor. No runtime behavior change. (#2244)
+
 * Bumped `lodash`/`lodash-es` to `4.18.1` in the `js-react` template lockfile for CVE-2025-13465. (#2233)
+
 * Fixed `render.DataGrid()` column headers and hovered rows not adapting to dark mode when `ui.input_dark_mode()` is enabled. The data grid now uses Bootstrap 5.3 mode-aware color tokens (`--bs-tertiary-bg`, `--bs-primary-bg-subtle`, `--bs-emphasis-color`, `--bs-secondary-color`), with the legacy values preserved as fallbacks. (#1635)
 
 ## [1.6.1] - 2026-05-01


### PR DESCRIPTION
## Summary

Release candidate branch for **py-shiny v1.6.2**.

## Changelog

### Bug fixes

* Adapted py-shiny to the `htmltools` 0.7.0 sibling-classes refactor: removed `Tag[TagNode]` / `TagList[TagNode]` type arguments and redundant casts that no longer type-check against the new htmltools. No runtime behavior change. (#2244)
* Bumped `lodash`/`lodash-es` to `4.18.1` in the `js-react` template lockfile for CVE-2025-13465. (#2233)
* Fixed `render.DataGrid()` column headers and hovered rows not adapting to dark mode when `ui.input_dark_mode()` is enabled. (#1635)

## Test plan

- [ ] CI passes
- [ ] Shinylive examples pass against py-shiny docs site
- [ ] No additional commits land on this branch before squash-merge

Once CI is green, squash-merge → tag `v1.6.2` on main → publish GH Release titled `shiny 1.6.2`.