### PR TITLE
chore: Gitignore .claude/scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,5 +139,6 @@ tests/inspect-ai/scripts/test_metadata.json
 
 # Claude
 /.claude/*.local.*
+/.claude/scheduled_tasks.lock
 docs/plans/
 docs/superpowers/


### PR DESCRIPTION
## Summary

Ignore the `.claude/scheduled_tasks.lock` file used by Claude Code's scheduled-task harness so it doesn't show up as an untracked file during local work.