### PR TITLE
chore: Prep CHANGELOG for development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+
+
 ## [1.6.2] - 2026-05-21
 
 ### Bug fixes


### PR DESCRIPTION
## Summary

Adds two blank lines under the `## [UNRELEASED]` header in `CHANGELOG.md` so future contributors have room to add entries between releases. Matches the convention from prior "Start new version" commits (e.g. 2bb6ffed). No code changes — markdown spacing only.

## Verification

`git diff main...` shows only the two added blank lines under `## [UNRELEASED]` in `CHANGELOG.md`.