### PR TITLE
ci: Bump actions/cache to v5 to remove Node.js 20 deprecation warning

### DIFF
--- a/.github/py-shiny/setup-playwright-remote/action.yaml
+++ b/.github/py-shiny/setup-playwright-remote/action.yaml
@@ -56,7 +56,7 @@ runs:
 
     - name: Restore cached Playwright image
       id: restore-image-cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ${{ steps.image-cache-key.outputs.cache-dir }}
         key: ${{ steps.image-cache-key.outputs.cache-key }}
@@ -120,7 +120,7 @@ runs:
 
     - name: Persist Playwright image cache
       if: steps.pull-image.outputs.pulled == 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: ${{ steps.image-cache-key.outputs.cache-dir }}
         key: ${{ steps.image-cache-key.outputs.cache-key }}


### PR DESCRIPTION
## Summary

- Bumps `actions/cache/restore` and `actions/cache/save` from `v4` to `v5` in `.github/py-shiny/setup-playwright-remote/action.yaml`.
- GitHub Actions runners surface this CI warning today: `Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache/restore@v4.` Starting June 2, 2026 the runner forces Node.js 24, and Node.js 20 is removed on September 16, 2026 (see [GitHub changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)).
- `actions/cache@v5` runs on Node.js 24, clearing the deprecation warning.

## Test plan

- [ ] CI runs without the `Node.js 20 actions are deprecated` warning on jobs that use the Playwright remote setup composite action (e.g., `test-narwhals-integration`, `playwright-*`).