### PR TITLE
fix(scripts): Reorder bundle so bslib wins cascade ties against shiny.scss

### DIFF
--- a/scripts/_functions_sass.R
+++ b/scripts/_functions_sass.R
@@ -35,15 +35,21 @@ bslib_bs_theme <- function(version, preset = "shiny") {
 bs_full_theme <- function(theme, path_sass_markers) {
   bs_version <- bslib::theme_version(theme)
 
-  bs_bundle(
-    theme,
-    bslib = bslib_component_sass(),
-    shiny = shiny_sass(bs_version),
-    selectize = shiny_sass_selectize(bs_version),
-    ionrangeslider = shiny_sass_ionrangeslider(),
-    daterange = shiny_sass_daterange_picker(),
-    # The next layer must come last so that its text appears where a user layer would
-    marker = sass_layer_file(path_sass_markers),
+  # `shiny` before `theme` so bslib's bs3compat (baked into `theme`) wins cascade
+  # ties against R-shiny's shiny.scss. bs_bundle() requires theme-first, so call
+  # sass::sass_bundle() directly and reapply the bs_theme class.
+  structure(
+    sass::sass_bundle(
+      shiny = shiny_sass(bs_version),
+      theme,
+      bslib = bslib_component_sass(),
+      selectize = shiny_sass_selectize(bs_version),
+      ionrangeslider = shiny_sass_ionrangeslider(),
+      daterange = shiny_sass_daterange_picker(),
+      # The next layer must come last so that its text appears where a user layer would
+      marker = sass_layer_file(path_sass_markers),
+    ),
+    class = class(theme)
   )
 }
 


### PR DESCRIPTION
## Summary

Reorder layers in `bs_full_theme()` so R-shiny's `shiny.scss` emits *before* bslib's bs3compat in the compiled `bootstrap.min.css`. This matches the R-shiny + bslib head order and lets bslib's bs3compat overrides win cascade ties.

`bs_bundle()` requires `theme` first, so drop down to `sass::sass_bundle()` and reapply the `bs_theme` class (mirroring `bs_bundle()`'s own implementation).

## Why

Inside py-shiny's combined bundle, bslib bs3compat sat at byte ~278k and shiny.scss at ~360k. Any 0-3-1 ↔ 0-3-1 specificity tie went to shiny.scss by source order — the opposite of R-shiny + bslib, where R-shiny loads its own `shiny.css` `<link>` *before* bslib's bundle.

Concrete symptom: bslib PR rstudio/bslib#1308 lifts the BS5 radio/checkbox label-margin rule to `.shiny-input-container.shiny-input-{kind}` (0-3-1). That beat shiny.scss's base `-10px` rule (0-2-1) for vertical groups, but tied shiny.scss's `.shiny-input-container-inline` rule (0-3-1) and lost on source order for inline groups.

## Ordering with related PRs

Prerequisite for #2246. The script change must land *before* `make upgrade-html-deps` is re-run, otherwise the regenerated `bootstrap.min.css` keeps the old layer order. Suggested sequence:

1. Merge this PR
2. Merge rstudio/bslib#1308
3. Re-run `make upgrade-html-deps` on #2246's branch, then merge #2246

By itself this PR produces no compiled-output diff.

## Collateral-damage audit

The only same-specificity, same-element conflict between bs3compat and shiny.scss in BS5 mode is the radio/checkbox label-margin rule. Other bs3compat rules (`.well`, `.help-text`, `.glyphicon`, `.navbar-*`, `.nav-tabs > li`, `.dropdown-menu > li`, `pre.shiny-code`, `.float-left/right`, etc.) target selectors shiny.scss does not style. shiny.scss's `.radio`/`.checkbox` usages are prefixed with `.qt5` (different scope). bs3compat's `.radio`/`.checkbox` styling is wrapped in `@if \$bootstrap-version == 4` and doesn't compile for BS5.

Net effect: only the inline radio/checkbox gap changes, and it changes to the value bslib PR #1308 intended.

## Test plan

- [ ] After this + rstudio/bslib#1308 land, re-run `make upgrade-html-deps` and confirm bslib bs3compat rules emit *after* shiny.scss rules in the regenerated `bootstrap.min.css`
- [ ] Visually verify inline `ui.input_radio_buttons()` / `ui.input_checkbox_group()` share the same label-to-options gap as the vertical variants
- [ ] Run Playwright tests