### PR TITLE
chore(release-skill): Document py-shinylive GH Release title requirement

### DIFF
--- a/.claude/skills/py-shiny-release/references/release-phases.md
+++ b/.claude/skills/py-shiny-release/references/release-phases.md
@@ -181,10 +181,10 @@ Repo: `posit-dev/py-shinylive`
 - [ ] **PRE-RELEASE GATE**: Present release summary (package, version, shinylive JS version, changelog) and get explicit user confirmation before proceeding
 - [ ] Squash merge the RC PR into main via GitHub (this is the release commit)
 - [ ] Tag the squash commit on main: `git checkout main && git pull && git tag vX.Y.Z && git push origin vX.Y.Z`
-- [ ] Create GH Release
+- [ ] Create GH Release with title **`shinylive X.Y.Z`** (NOT `py-shinylive X.Y.Z` and NOT `vX.Y.Z`). The `.github/workflows/build.yml` "Deploy to PyPI" step is gated by `if: startsWith(github.event.release.name, 'shinylive')` — if the release title does not start with `shinylive`, the publish step silently skips and the package never reaches PyPI even though the workflow reports success.
 - [ ] Wait for PyPI publish to succeed
 
-If PyPI fails, delete tag and release, fix, redo.
+If PyPI fails, delete tag and release, fix, redo. If the publish step was skipped because of a mistitled release (e.g. `py-shinylive X.Y.Z`), delete the GH Release object only (keep the tag) and recreate it with title `shinylive X.Y.Z` — this re-fires the `release: published` event and the publish step will then match the `startsWith('shinylive')` predicate.
 
 Ask user: "Is py-shinylive being released this cycle?"
 


### PR DESCRIPTION
## Summary

Discovered during the v1.6.2 release train: `posit-dev/py-shinylive`'s
`.github/workflows/build.yml` gates the PyPI publish step on
`startsWith(github.event.release.name, 'shinylive')`. A release titled
`py-shinylive v0.8.8` (or `v0.8.8`) silently skips the publish step —
workflow reports success, but nothing is uploaded to PyPI.

This patch updates Phase 7 of the py-shiny release skill to:

- Explicitly require the GH Release title to start with `shinylive`
  (e.g. `shinylive 0.8.8`), matching every prior release on
  https://github.com/posit-dev/py-shinylive/releases.
- Explain the failure mode so it can be diagnosed quickly.
- Document the recovery path: delete the GH Release object only
  (keep the tag), recreate it with the correct title — this re-fires
  the `release: published` event and the publish step then runs.

## Test plan

- [x] Skill file edits viewed in markdown preview render correctly.
- [ ] Next py-shinylive release follows the updated phase verbatim.