### PR TITLE
chore(docs): Bump shinylive to >=0.8.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ doc = [
     "jupyter",
     "jupyter_client < 8.0.0",
     "tabulate",
-    "shinylive>=0.8.6",
+    "shinylive>=0.8.8",
     "pydantic>=2.7.4",
     "quartodoc>=0.8.1",
     "griffe>=1.3.2,<2.0.0",


### PR DESCRIPTION
## Summary

Bump the `shinylive` pin in `pyproject.toml`'s `[doc]` extra from `>=0.8.6` → `>=0.8.8`, so the docs site picks up the new shinylive web assets v0.10.10 that ship alongside py-shiny v1.6.2.

Part of the v1.6.2 release train (Phase 9). See posit-dev/py-shiny#2248.