### PR TITLE
fix: prevent double namespace resolution in input_submit_textarea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Bug fixes
+
+* Fixed `ui.input_submit_textarea()` failing inside module namespaces. The internal submit button's ID was built from the already-resolved (namespaced) textarea ID, causing a double-namespace when `input_task_button` resolved it again. (#2262)
 
 
 ## [1.6.2] - 2026-05-21

--- a/shiny/ui/_input_submit_textarea.py
+++ b/shiny/ui/_input_submit_textarea.py
@@ -112,7 +112,7 @@ def input_submit_textarea(
 
     if button is None:
         button = input_task_button(
-            id=f"{resolved_id}_submit",
+            id=f"{id}_submit",
             class_="btn-sm",
             label=span("\u23ce", class_="bslib-submit-key"),
             icon="Submit",

--- a/tests/pytest/test_toolbar.py
+++ b/tests/pytest/test_toolbar.py
@@ -580,6 +580,27 @@ def test_toolbar_in_text_area_label():
     assert "<label" in rendered
 
 
+def test_input_submit_textarea_inside_module():
+    """Regression test: input_submit_textarea must not double-resolve the namespace.
+
+    The internal submit button's ID is built from the raw `id` argument so that
+    `input_task_button` can apply the module namespace exactly once. If
+    `resolved_id` were used instead, the namespace separator would appear in the
+    raw ID string, causing `validate_id` to raise a ValueError.
+    """
+    from shiny import module
+
+    @module.ui
+    def my_ui():
+        return ui.input_submit_textarea("my_input", "Type here")
+
+    # Should not raise ValueError like 'test_mod-my_input_submit' is not a valid id
+    result = my_ui("test_mod")
+    rendered = str(result)
+    assert "test_mod-my_input" in rendered
+    assert "test_mod-my_input_submit" in rendered
+
+
 def test_toolbar_in_submit_textarea():
     """Test that toolbar works in input_submit_textarea."""
     submit_textarea = ui.input_submit_textarea(

--- a/tests/pytest/test_toolbar.py
+++ b/tests/pytest/test_toolbar.py
@@ -581,12 +581,11 @@ def test_toolbar_in_text_area_label():
 
 
 def test_input_submit_textarea_inside_module():
-    """Regression test: input_submit_textarea must not double-resolve the namespace.
+    """Regression test: input_submit_textarea must not double-namespace the button ID.
 
-    The internal submit button's ID is built from the raw `id` argument so that
-    `input_task_button` can apply the module namespace exactly once. If
-    `resolved_id` were used instead, the namespace separator would appear in the
-    raw ID string, causing `validate_id` to raise a ValueError.
+    The internal submit button's ID should be namespaced exactly once. A previous
+    bug built the button ID from the already-resolved (namespaced) textarea ID,
+    so `input_task_button` would namespace it a second time.
     """
     from shiny import module
 
@@ -594,11 +593,9 @@ def test_input_submit_textarea_inside_module():
     def my_ui():
         return ui.input_submit_textarea("my_input", "Type here")
 
-    # Should not raise ValueError like 'test_mod-my_input_submit' is not a valid id
-    result = my_ui("test_mod")
-    rendered = str(result)
-    assert "test_mod-my_input" in rendered
+    rendered = str(my_ui("test_mod"))
     assert "test_mod-my_input_submit" in rendered
+    assert "test_mod-test_mod-my_input_submit" not in rendered
 
 
 def test_toolbar_in_submit_textarea():


### PR DESCRIPTION
## What broke and why

`input_submit_textarea` creates an internal `input_task_button` for its submit button. It was constructing that button's ID as `f"{resolved_id}_submit"` — using the already-namespaced ID. Since `input_task_button` internally calls `resolve_id` on whatever ID it receives, the module namespace got applied twice. The second `resolve_id` call hits `validate_id` on a string already containing a hyphen (the namespace separator), which raises a `ValueError`.

**Minimal repro:**
```python
from shiny import module, ui

@module.ui
def my_ui():
    return ui.input_submit_textarea('my_input', 'Type here')

my_ui('test_mod')  # ValueError: 'test_mod-my_input_submit' is not a valid id
```

## The fix

One-line change in `shiny/ui/_input_submit_textarea.py`: use `f"{id}_submit"` instead of `f"{resolved_id}_submit"` when creating the default submit button, so `input_task_button` resolves the namespace exactly once.

## Testing

Added `test_input_submit_textarea_inside_module` to `tests/pytest/test_toolbar.py` — the exact minimal repro above, asserting the call doesn't raise and that the rendered HTML contains the correctly namespaced IDs (`test_mod-my_input` and `test_mod-my_input_submit`).