### PR TITLE
feat: Add `id` argument to `session.destroy()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### New features
+
+* `session.destroy()` now accepts an optional module `id`. The parent that inserted a module's UI under an `id` can tear down that module's scope with `session.destroy(id)`, without the module having to hand back a cleanup handle. (#TODO)
+
 ### Bug fixes
 
 * Fixed `ui.input_submit_textarea()` failing inside module namespaces. The internal submit button's ID was built from the already-resolved (namespaced) textarea ID, causing a double-namespace when `input_task_button` resolved it again. (#2262)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New features
 
-* `session.destroy()` now accepts an optional module `id`. The parent that inserted a module's UI under an `id` can tear down that module's scope with `session.destroy(id)`, without the module having to hand back a cleanup handle. (#TODO)
+* `session.destroy()` now accepts an optional module `id`. The parent that inserted a module's UI under an `id` can tear down that module's scope with `session.destroy(id)`, without the module having to hand back a cleanup handle. (#2264)
 
 ### Bug fixes
 

--- a/shiny/express/_stub_session.py
+++ b/shiny/express/_stub_session.py
@@ -69,7 +69,7 @@ class ExpressStubSession(Session):
     ) -> None:
         return
 
-    async def destroy(self) -> None:
+    async def destroy(self, id: Id | None = None) -> None:
         return
 
     def make_scope(self, id: Id) -> Session:

--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -262,13 +262,32 @@ class Session(ABC):
         """
 
     @abstractmethod
-    async def destroy(self) -> None:
+    async def destroy(self, id: Id | None = None) -> None:
         """
         Destroy this session or module scope, including all descendant scopes.
 
         Fires all registered destroy callbacks, then removes all namespaced
         state from the session. This does not alter the UI; use
         :func:`~shiny.ui.remove_ui` to remove UI elements.
+
+        Pass an ``id`` to tear down a **child** module scope instead of this
+        one. The parent that inserted a module's UI under an ``id`` can tear it
+        down by that same ``id`` with ``session.destroy(id)``, without the
+        module having to hand anything back:
+
+        ```python
+        @reactive.effect
+        @reactive.event(input.add)
+        def _():
+            ui.insert_ui(my_module_ui("editor"), selector="#container")
+            my_module_server("editor")
+
+        @reactive.effect
+        @reactive.event(input.remove)
+        async def _():
+            ui.remove_ui(selector="#editor")
+            await session.destroy("editor")
+        ```
 
         The following categories of state are cleaned up:
 
@@ -340,6 +359,12 @@ class Session(ABC):
         my_module_server("editor", result=saved_data)
         # saved_data is still valid after the module is destroyed
         ```
+
+        Parameters
+        ----------
+        id
+            Optional module ``id`` whose child scope should be destroyed. When
+            ``None`` (the default), the current scope is destroyed.
 
         See Also
         --------
@@ -651,6 +676,22 @@ async def _invoke_destroy_callbacks(
         callbacks = callbacks_by_ns.pop(ns_key, None)
         if callbacks is not None:
             await callbacks.invoke()
+
+
+def _validate_destroy_id(id: Id) -> None:
+    """
+    Validate the ``id`` passed to ``session.destroy(id)``.
+
+    Must be a single, non-empty string. (When ``id`` is a plain ``str``, the
+    permitted character set is additionally enforced by ``make_scope()`` via
+    ``validate_id()``.)
+    """
+    if not isinstance(id, str) or id == "":
+        raise ValueError(
+            "`id` must be a single, non-empty string. Pass a module `id` to "
+            'tear down that scope (e.g. `session.destroy("my_module")`), or '
+            "call `destroy()` with no `id` to destroy the current scope."
+        )
 
 
 # ======================================================================================
@@ -1338,8 +1379,12 @@ class AppSession(Session):
             self._destroy_callbacks_by_ns[ns_key] = _new_destroy_callbacks()
         self._destroy_callbacks_by_ns[ns_key].register(wrap_async(fn))
 
-    async def destroy(self) -> None:
-        await _invoke_destroy_callbacks(self._destroy_callbacks_by_ns, "")
+    async def destroy(self, id: Id | None = None) -> None:
+        if id is None:
+            await _invoke_destroy_callbacks(self._destroy_callbacks_by_ns, "")
+        else:
+            _validate_destroy_id(id)
+            await self.make_scope(id).destroy()
 
     # ==========================================================================
     # Misc
@@ -1496,7 +1541,13 @@ class SessionProxy(Session):
                 destroy_cbs[ns_key] = _new_destroy_callbacks()
             destroy_cbs[ns_key].register(wrap_async(fn))
 
-    async def destroy(self) -> None:
+    async def destroy(self, id: Id | None = None) -> None:
+        # When `id` is given, destroy that child scope rather than this scope.
+        if id is not None:
+            _validate_destroy_id(id)
+            await self.make_scope(id).destroy()
+            return
+
         destroy_cbs: dict[str, _utils.AsyncCallbacks] | None = getattr(
             self._root_session, "_destroy_callbacks_by_ns", None
         )

--- a/tests/pytest/test_destroy.py
+++ b/tests/pytest/test_destroy.py
@@ -1582,3 +1582,120 @@ async def test_dead_destroy_callbacks_silently_skipped():
     # Invoking destroy on the proxy should not raise, even though the Value's
     # weak callback is now dead.
     await proxy.destroy()
+
+
+# ---------------------------------------------------------------------------
+# session.destroy(id) — tear down a child module scope by id
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_root_destroy_by_id_fires_scope_callbacks():
+    """root.destroy(id) tears down the named module scope using only its id."""
+    root = _make_real_app_session()
+    scope = root.make_scope("mod1")
+
+    called: list[str] = []
+    scope.on_destroy(lambda: called.append("x"))  # pyright: ignore[reportArgumentType]
+
+    assert called == []
+    # Destroy the scope from the root session using only its id
+    await root.destroy("mod1")
+    assert called == ["x"]
+
+
+@pytest.mark.asyncio
+async def test_root_destroy_by_id_destroys_reactive_state():
+    """root.destroy(id) destroys reactive objects created in that scope."""
+    root = _make_real_app_session()
+    scope = root.make_scope("mod1")
+
+    with session_context(scope):
+        counter = Value(0)
+
+        @effect()
+        def my_effect():
+            pass
+
+    await root.destroy("mod1")
+
+    # Value is destroyed
+    with isolate():
+        assert counter.is_set() is False
+    # Effect is destroyed
+    assert my_effect._destroyed is True
+
+
+@pytest.mark.asyncio
+async def test_destroy_by_id_equivalent_to_make_scope_destroy():
+    """root.destroy(id) removes the scope's namespaced inputs, leaving others."""
+    root = _make_real_app_session()
+    root.make_scope("mymod")
+
+    root.input._map["mymod-x"] = Value(1, read_only=True)
+    root.input._map["other"] = Value(2, read_only=True)
+
+    await root.destroy("mymod")
+
+    assert "mymod-x" not in root.input._map
+    assert "other" in root.input._map
+
+
+@pytest.mark.asyncio
+async def test_module_destroy_by_id_tears_down_nested_child():
+    """parent.destroy(child_id) destroys the child scope, leaving the parent."""
+    root = _make_real_app_session()
+    parent = root.make_scope("parent")
+    child = parent.make_scope("child")
+
+    child_called: list[str] = []
+    parent_called: list[str] = []
+    child.on_destroy(
+        lambda: child_called.append("c")
+    )  # pyright: ignore[reportArgumentType]
+    parent.on_destroy(
+        lambda: parent_called.append("p")
+    )  # pyright: ignore[reportArgumentType]
+
+    # Destroy the child from the parent session using only its (local) id
+    await parent.destroy("child")
+    assert child_called == ["c"]
+    # Parent itself remains alive
+    assert parent_called == []
+
+
+@pytest.mark.asyncio
+async def test_destroy_by_id_unknown_is_noop():
+    """Destroying an unknown id is a harmless no-op."""
+    root = _make_real_app_session()
+    # Should not raise
+    await root.destroy("never_created")
+
+
+@pytest.mark.asyncio
+async def test_destroy_by_id_validates_id():
+    """destroy(id) rejects non-string and empty-string ids."""
+    root = _make_real_app_session()
+    with pytest.raises(ValueError, match="single, non-empty string"):
+        await root.destroy("")
+    with pytest.raises(ValueError, match="single, non-empty string"):
+        await root.destroy(cast(Any, 1))
+    with pytest.raises(ValueError, match="single, non-empty string"):
+        await root.destroy(cast(Any, ["a", "b"]))
+
+
+@pytest.mark.asyncio
+async def test_module_destroy_by_id_validates_id():
+    """SessionProxy.destroy(id) validates the id too."""
+    root = _make_real_app_session()
+    proxy = root.make_scope("parent")
+    with pytest.raises(ValueError, match="single, non-empty string"):
+        await proxy.destroy("")
+
+
+@pytest.mark.asyncio
+async def test_destroy_by_id_does_not_leak_bookmark_exclude():
+    """make_scope + destroy(id) leaves the root bookmark exclude list unchanged."""
+    root = _make_real_app_session()
+    before = len(root.bookmark._on_get_exclude)
+    root.make_scope("mod1")
+    await root.destroy("mod1")
+    assert len(root.bookmark._on_get_exclude) == before


### PR DESCRIPTION
## Summary

Port of https://github.com/rstudio/shiny/pull/4372#issuecomment-4577644625 — adds an optional `id` argument to `session.destroy()`.

py-shiny already had `session.destroy()` / `session.on_destroy()` (from #2209). This PR adds the `id` parameter so that a parent which inserted a module's UI under an `id` can tear down that module's scope **by the same `id`**, without the module having to hand back a cleanup handle:

```python
@reactive.effect
@reactive.event(input.add)
def _():
    ui.insert_ui(my_module_ui("editor"), selector="#container")
    my_module_server("editor")

@reactive.effect
@reactive.event(input.remove)
async def _():
    ui.remove_ui(selector="#editor")
    await session.destroy("editor")
```

## Changes

- `Session.destroy()` (ABC), `AppSession.destroy()`, and `SessionProxy.destroy()` now accept an optional `id`. When given, they tear down that child module scope; when `None` (the default), behavior is unchanged.
- Added `_validate_destroy_id()` — rejects non-string / empty-string ids with an actionable message (plain-string character validation is still enforced downstream by `make_scope()` → `validate_id()`).
- `ExpressStubSession.destroy()` signature updated to match (still a no-op).
- Added unit tests: destroy-by-id on root and module sessions, nested child teardown (parent survives), unknown-id no-op, id validation on both `AppSession` and `SessionProxy`, and no bookmark-exclude leak.

## Difference from R Shiny

In R, the root `session$destroy()` with no `id` throws (root teardown goes through `close()`). In py-shiny, `AppSession.destroy()` with no `id` is the internal session-end teardown, so this PR keeps that behavior intact and only makes `id` additive. The user-facing `session.destroy("editor")` works identically from both the top-level server (`AppSession`) and inside a module (`SessionProxy`).