### PR TITLE
ci: Bump pinned htmltools to v0.7.0 in deploy tests

### DIFF
--- a/.github/workflows/deploy-tests.yaml
+++ b/.github/workflows/deploy-tests.yaml
@@ -86,11 +86,11 @@ jobs:
           uv pip uninstall shiny htmltools
           uv pip install shiny htmltools
 
-      - name: Install GitHub shiny@v1.4.0 and htmltools@v0.6.0 (uninstall PyPI versions)
+      - name: Install GitHub shiny@v1.4.0 and htmltools@v0.7.0 (uninstall PyPI versions)
         if: ${{ matrix.config.github_shiny }}
         run: |
           uv pip uninstall shiny htmltools
-          uv pip install "htmltools @ git+https://github.com/posit-dev/py-htmltools.git@v0.6.0" "shiny @ git+https://github.com/posit-dev/py-shiny.git@v1.4.0"
+          uv pip install "htmltools @ git+https://github.com/posit-dev/py-htmltools.git@v0.7.0" "shiny @ git+https://github.com/posit-dev/py-shiny.git@v1.4.0"
 
       - name: Install rsconnect (PyPI)
         if: ${{ matrix.config.pypi_rsconnect }}


### PR DESCRIPTION
## Why

The **Run deploy tests** workflow has been failing consistently. Its `github-shiny-dev-rsconnect-dogfood` matrix job errored on every example app with:

```
ImportError: cannot import name 'TagifiedTag' from 'htmltools'
```

That job is the only config that pins old releases (`shiny@v1.4.0` + `htmltools@v0.6.0`). The pinned `htmltools` was fine until a newer `shinychat` was published: the current `shinychat` (installed transitively and **not** downgraded by the pin step) imports `TagifiedTag`, which only exists in `htmltools >= 0.7.0`. With htmltools forced back to 0.6.0, `shinychat` can't import, so every app under test fails to boot.

This bumps the pinned `htmltools` from `v0.6.0` to `v0.7.0` so the up-to-date `shinychat` can import again. The `v0.7.0` tag exists upstream on py-htmltools, and py-shiny itself already requires `htmltools>=0.7.0`.

## Note

This job still pins `shiny@v1.4.0`; if it continues to fail after this fix, that pin may also need a bump. But the immediate `TagifiedTag` import error is resolved here.