### PR TITLE
chore(docs): Bump shinylive to >=0.8.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ doc = [
     "jupyter",
     "jupyter_client < 8.0.0",
     "tabulate",
-    "shinylive>=0.8.8",
+    "shinylive>=0.8.9",
     "pydantic>=2.7.4",
     "quartodoc>=0.8.1",
     "griffe>=1.3.2,<2.0.0",


### PR DESCRIPTION
Bumps the `shinylive` doc dependency to `>=0.8.9` (just released) so the docs site builds against the assets shipping py-shiny 1.6.3.

Part of the py-shiny v1.6.3 release train. See #2266.