### PR TITLE
feat: Add `hard=True` to `session.close()` for terminal session ends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### New features
+
+* `session.close()` now accepts `hard=True` and `message=...` keyword arguments for ending a session terminally from server code (e.g., after a Submit or Log Out action). A hard close sends a `hardDisconnectConfig` custom message to the client carrying the closed-overlay text, closes the websocket with application code `4001` and reason `shiny-hard-disconnect` (which hosting platforms can recognize as "release this worker without holding for reconnect"), and additionally clears the root-level `input`, `_downloads`, `_dynamic_routes`, and `_message_handlers` collections that a soft close leaves in place. `on_ended` callbacks fire **before** the hard cleanup, so teardown code can still read session state. The default closed-overlay text can be set app-wide via `App(hard_disconnect_message=...)`; the per-call `message` argument overrides it. Existing callers of `session.close()` with no arguments are unaffected. The distinct client-side closed-state overlay activates once `shiny.js` is vendored from an R Shiny release that includes the matching client-side handling; until then, the server-side teardown and `4001` close-code emission run as designed.
+
 ## [1.6.3] - 2026-06-01
 
 ### New features

--- a/shiny/_app.py
+++ b/shiny/_app.py
@@ -84,6 +84,11 @@ class App:
         must be a directory, and it will be mounted at `/`. If this is a dictionary,
         each key is a mount point and each value is a file or directory to be served at
         that mount point.
+    hard_disconnect_message
+        Default text shown to end users in the closed-state overlay after a hard
+        disconnect (see :meth:`~shiny.Session.close`). Used as the fallback when
+        ``session.close(hard=True)`` is invoked without a ``message`` argument.
+        ``None`` selects the framework default, ``"This app has closed."``.
     debug
         Whether to enable debug mode.
 
@@ -158,6 +163,7 @@ class App:
         static_assets: Optional[str | Path | Mapping[str, str | Path]] = None,
         # Document type as Literal to have clearer type hints to App author
         bookmark_store: Literal["url", "server", "disable"] = "disable",
+        hard_disconnect_message: str | None = None,
         debug: bool = False,
     ) -> None:
         # Used to store callbacks to be called when the app is shutting down (according
@@ -180,6 +186,8 @@ class App:
         self._init_bookmarking(bookmark_store=bookmark_store, ui=ui)
 
         self._debug: bool = debug
+
+        self._hard_disconnect_message: str | None = hard_disconnect_message
 
         # Settings that the user can change after creating the App object.
         self.lib_prefix: str = LIB_PREFIX

--- a/shiny/express/_stub_session.py
+++ b/shiny/express/_stub_session.py
@@ -51,7 +51,13 @@ class ExpressStubSession(Session):
     def is_stub_session(self) -> Literal[True]:
         return True
 
-    async def close(self, code: int = 1001) -> None:
+    async def close(
+        self,
+        code: int = 1001,
+        *,
+        hard: bool = False,
+        message: str | None = None,
+    ) -> None:
         return
 
     # This is needed so that Outputs don't throw an error.

--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -82,6 +82,15 @@ if TYPE_CHECKING:
     from ..bookmark._serializers import Unserializable
 
 
+# WebSocket close code used by `session.close(hard=True)`. In the private
+# application range (4000-4999); reserved for "this session is terminal — do
+# not reconnect or reattach." Hosting platforms (Shiny Server, Connect) can
+# recognize this to release worker pools without waiting for a reconnect grace.
+HARD_DISCONNECT_CLOSE_CODE: int = 4001
+HARD_DISCONNECT_REASON: str = "shiny-hard-disconnect"
+HARD_DISCONNECT_DEFAULT_MESSAGE: str = "This app has closed."
+
+
 class ConnectionState(enum.Enum):
     Start = 0
     Running = 1
@@ -215,9 +224,54 @@ class Session(ABC):
 
     @add_example("session_close")
     @abstractmethod
-    async def close(self, code: int = 1001) -> None:
+    async def close(
+        self,
+        code: int = 1001,
+        *,
+        hard: bool = False,
+        message: str | None = None,
+    ) -> None:
         """
         Close the session.
+
+        By default, performs a soft close: the websocket is shut down and Shiny
+        tears down output observers and reactive scopes, but root inputs,
+        client data, downloads, dynamic routes, and message handlers survive
+        in memory until the session is garbage-collected.
+
+        When ``hard=True``, performs a complete teardown:
+
+        - Sends a closed-overlay message (``hardDisconnectConfig`` custom
+          message) to the browser so the page can render a distinct
+          "this app has closed" state.
+        - Closes the websocket with application close code ``4001`` and
+          reason ``"shiny-hard-disconnect"`` so hosting platforms can
+          recognize "do not hold this worker for a reconnect grace period."
+        - Additionally clears the root-level ``input``, ``clientdata``,
+          ``_downloads``, ``_dynamic_routes``, and ``_message_handlers``
+          collections, which a soft close leaves in place.
+
+        ``on_ended`` callbacks fire **before** the hard-cleanup step, so
+        teardown code can still read session state.
+
+        Parameters
+        ----------
+        code
+            WebSocket close code. Ignored when ``hard=True`` (which always
+            sends code ``4001``). Defaults to ``1001`` for soft closes.
+        hard
+            If ``True``, perform a hard close (see above). Default ``False``
+            preserves today's behavior for callers that pass no arguments.
+        message
+            Text shown in the browser's closed-state overlay. Falls back to
+            the ``hard_disconnect_message`` argument of :class:`~shiny.App`,
+            then to ``"This app has closed."``. Only meaningful when
+            ``hard=True``; ignored on a soft close.
+
+        See Also
+        --------
+        * :meth:`~shiny.Session.on_ended` - callbacks run before close completes
+        * :meth:`~shiny.Session.destroy` - module-scope teardown without ending the session
         """
 
     @abstractmethod
@@ -765,6 +819,7 @@ class AppSession(Session):
         self._file_upload_manager: FileUploadManager = FileUploadManager()
         self._on_ended_callbacks = _utils.AsyncCallbacks()
         self._has_run_session_ended_tasks: bool = False
+        self._was_hard_close: bool = False
         self._downloads: dict[str, DownloadInfo] = {}
         self._dynamic_routes: dict[str, DynamicRouteHandler] = {}
 
@@ -802,14 +857,64 @@ class AppSession(Session):
                     # Destroy callbacks run after on_ended callbacks so that
                     # on_ended handlers can still read reactive state.
                     await self.destroy()
+                    if self._was_hard_close:
+                        # Hard close: also clear the root-level collections
+                        # that the standard destroy walk leaves in place.
+                        self._hard_close_cleanup()
                 finally:
                     self.app._remove_session(self)
+
+    def _hard_close_cleanup(self) -> None:
+        # Destroy any remaining root-level reactive input values (the standard
+        # destroy walk is namespaced and skips root).
+        for key in list(self.input._map.keys()):
+            value_obj = self.input._map[key]
+            try:
+                value_obj.destroy()
+            except Exception:
+                pass
+            del self.input._map[key]
+
+        self._downloads.clear()
+        self._dynamic_routes.clear()
+        self._message_handlers.clear()
 
     def is_stub_session(self) -> Literal[False]:
         return False
 
-    async def close(self, code: int = 1001) -> None:
-        await self._conn.close(code, None)
+    async def close(
+        self,
+        code: int = 1001,
+        *,
+        hard: bool = False,
+        message: str | None = None,
+    ) -> None:
+        if hard:
+            self._was_hard_close = True
+            effective_message = (
+                message
+                if message is not None
+                else (
+                    self.app._hard_disconnect_message
+                    if self.app._hard_disconnect_message is not None
+                    else HARD_DISCONNECT_DEFAULT_MESSAGE
+                )
+            )
+            # Send the closed-overlay text via the custom-message channel
+            # before closing the socket. WebSocket message ordering is FIFO so
+            # the client receives this and stashes the text before the close
+            # frame arrives.
+            try:
+                await self._send_message(
+                    {"custom": {"hardDisconnectConfig": {"message": effective_message}}}
+                )
+            except Exception:
+                # Best-effort: if the send fails (e.g., client already gone),
+                # still proceed with the hard teardown.
+                pass
+            await self._conn.close(HARD_DISCONNECT_CLOSE_CODE, HARD_DISCONNECT_REASON)
+        else:
+            await self._conn.close(code, None)
         await self._run_session_ended_tasks()
 
     async def _run(self) -> None:
@@ -1590,8 +1695,14 @@ class SessionProxy(Session):
     def is_stub_session(self) -> bool:
         return self._root_session.is_stub_session()
 
-    async def close(self, code: int = 1001) -> None:
-        await self._root_session.close(code)
+    async def close(
+        self,
+        code: int = 1001,
+        *,
+        hard: bool = False,
+        message: str | None = None,
+    ) -> None:
+        await self._root_session.close(code, hard=hard, message=message)
 
     def make_scope(self, id: str) -> Session:
         return self._root_session.make_scope(self.ns(id))

--- a/tests/pytest/test_hard_disconnect.py
+++ b/tests/pytest/test_hard_disconnect.py
@@ -1,0 +1,273 @@
+"""Tests for hard-disconnect: session.close(hard=True, message=...).
+
+Plan A of the hard-disconnect design (server-side only). The matching
+client-side handling (4001 close-code recognition, hardDisconnectConfig
+custom-message handler, distinct closed-state overlay) lives in R shiny's
+srcts and reaches py-shiny when shiny.js is vendored from a release that
+includes Plan A's client-side work.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional, cast
+
+import pytest
+
+from shiny import ui
+from shiny._app import App
+from shiny._connection import MockConnection
+from shiny.session._session import (
+    HARD_DISCONNECT_CLOSE_CODE,
+    HARD_DISCONNECT_DEFAULT_MESSAGE,
+    HARD_DISCONNECT_REASON,
+    AppSession,
+)
+
+
+class RecordingConnection(MockConnection):
+    """MockConnection that records send() and close() invocations."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.sent: list[str] = []
+        self.close_code: Optional[int] = None
+        self.close_reason: Optional[str] = None
+        self.close_called: bool = False
+
+    async def send(self, message: str) -> None:
+        self.sent.append(message)
+
+    async def close(self, code: int, reason: Optional[str]) -> None:
+        self.close_called = True
+        self.close_code = code
+        self.close_reason = reason
+
+
+def _make_session(
+    *, hard_disconnect_message: str | None = None
+) -> tuple[AppSession, RecordingConnection]:
+    conn = RecordingConnection()
+    app = App(ui.TagList(), None, hard_disconnect_message=hard_disconnect_message)
+    session = app._create_session(conn)
+    return session, conn
+
+
+def _custom_messages(conn: RecordingConnection) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for payload in conn.sent:
+        parsed: Any = json.loads(payload)
+        if isinstance(parsed, dict) and "custom" in parsed:
+            out.append(cast("dict[str, Any]", parsed["custom"]))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# App() arg plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_app_defaults_hard_disconnect_message_to_none():
+    app = App(ui.TagList(), None)
+    assert app._hard_disconnect_message is None
+
+
+def test_app_stores_hard_disconnect_message():
+    app = App(ui.TagList(), None, hard_disconnect_message="Bye!")
+    assert app._hard_disconnect_message == "Bye!"
+
+
+# ---------------------------------------------------------------------------
+# session.close() — soft close (backward compatible)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_soft_close_uses_supplied_code_and_no_custom_message():
+    session, conn = _make_session()
+
+    await session.close()  # no args -> soft
+
+    assert conn.close_called is True
+    assert conn.close_code == 1001
+    assert conn.close_reason is None
+    assert _custom_messages(conn) == []
+    assert session._was_hard_close is False
+
+
+@pytest.mark.asyncio
+async def test_soft_close_respects_explicit_code():
+    session, conn = _make_session()
+
+    await session.close(code=1008)
+
+    assert conn.close_code == 1008
+    assert conn.close_reason is None
+    assert session._was_hard_close is False
+
+
+# ---------------------------------------------------------------------------
+# session.close(hard=True) — wire protocol
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hard_close_sends_hard_disconnect_config_and_uses_4001():
+    session, conn = _make_session()
+
+    await session.close(hard=True, message="All done.")
+
+    customs = _custom_messages(conn)
+    assert len(customs) == 1
+    assert customs[0] == {"hardDisconnectConfig": {"message": "All done."}}
+
+    assert conn.close_called is True
+    assert conn.close_code == HARD_DISCONNECT_CLOSE_CODE == 4001
+    assert conn.close_reason == HARD_DISCONNECT_REASON == "shiny-hard-disconnect"
+    assert session._was_hard_close is True
+
+
+@pytest.mark.asyncio
+async def test_hard_close_sends_message_before_close():
+    """FIFO ordering: the custom message must be sent before the close frame."""
+    session, conn = _make_session()
+
+    # Capture order: record close as a "sent" sentinel for sequencing.
+    sequence: list[str] = []
+
+    original_send = conn.send
+
+    async def tracked_send(message: str) -> None:
+        sequence.append("send")
+        await original_send(message)
+
+    async def tracked_close(code: int, reason: Optional[str]) -> None:
+        sequence.append("close")
+        conn.close_called = True
+        conn.close_code = code
+        conn.close_reason = reason
+
+    conn.send = tracked_send  # type: ignore[method-assign]
+    conn.close = tracked_close  # type: ignore[method-assign]
+
+    await session.close(hard=True, message="bye")
+
+    assert sequence == ["send", "close"]
+
+
+# ---------------------------------------------------------------------------
+# Message fallback chain
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hard_close_falls_back_to_app_default_when_message_is_none():
+    session, conn = _make_session(hard_disconnect_message="App default text")
+
+    await session.close(hard=True)
+
+    customs = _custom_messages(conn)
+    assert customs[0]["hardDisconnectConfig"] == {"message": "App default text"}
+
+
+@pytest.mark.asyncio
+async def test_hard_close_falls_back_to_framework_default_when_nothing_set():
+    session, conn = _make_session()
+
+    await session.close(hard=True)
+
+    customs = _custom_messages(conn)
+    assert customs[0]["hardDisconnectConfig"] == {
+        "message": HARD_DISCONNECT_DEFAULT_MESSAGE
+    }
+    assert HARD_DISCONNECT_DEFAULT_MESSAGE == "This app has closed."
+
+
+@pytest.mark.asyncio
+async def test_hard_close_per_call_message_overrides_app_default():
+    session, conn = _make_session(hard_disconnect_message="App default text")
+
+    await session.close(hard=True, message="Per-call text wins")
+
+    customs = _custom_messages(conn)
+    assert customs[0]["hardDisconnectConfig"] == {"message": "Per-call text wins"}
+
+
+# ---------------------------------------------------------------------------
+# Root-level cleanup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_soft_close_leaves_root_collections_in_place():
+    session, _conn = _make_session()
+
+    session._downloads["dl1"] = "info"  # type: ignore[assignment]
+    session._dynamic_routes["route1"] = lambda req: None  # type: ignore[arg-type]
+    session.set_message_handler("ping", lambda: "pong")
+
+    await session.close()
+
+    # Soft close: the destroy walk does not touch these root collections.
+    assert "dl1" in session._downloads
+    assert "route1" in session._dynamic_routes
+    assert "ping" in session._message_handlers
+
+
+@pytest.mark.asyncio
+async def test_hard_close_clears_root_collections():
+    session, _conn = _make_session()
+
+    session._downloads["dl1"] = "info"  # type: ignore[assignment]
+    session._dynamic_routes["route1"] = lambda req: None  # type: ignore[arg-type]
+    session.set_message_handler("ping", lambda: "pong")
+
+    await session.close(hard=True, message="bye")
+
+    assert session._downloads == {}
+    assert session._dynamic_routes == {}
+    assert session._message_handlers == {}
+
+
+# ---------------------------------------------------------------------------
+# on_ended ordering: callbacks run BEFORE hard cleanup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_on_ended_callbacks_see_live_state_before_hard_cleanup():
+    session, _conn = _make_session()
+
+    session._downloads["sentinel"] = "still here"  # type: ignore[assignment]
+
+    observed: dict[str, object] = {}
+
+    def on_ended_cb() -> None:
+        observed["downloads_at_callback"] = dict(session._downloads)
+
+    session.on_ended(on_ended_cb)
+
+    await session.close(hard=True)
+
+    assert observed["downloads_at_callback"] == {"sentinel": "still here"}
+    # And after close completes, the root collection is cleared.
+    assert session._downloads == {}
+
+
+# ---------------------------------------------------------------------------
+# SessionProxy.close forwards new kwargs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_session_proxy_forwards_hard_and_message():
+    session, conn = _make_session()
+    proxy = session.make_scope("mod1")
+
+    await proxy.close(hard=True, message="from proxy")
+
+    customs = _custom_messages(conn)
+    assert len(customs) == 1
+    assert customs[0]["hardDisconnectConfig"] == {"message": "from proxy"}
+    assert conn.close_code == 4001
+    assert session._was_hard_close is True


### PR DESCRIPTION
## Summary

Adds an opt-in hard-disconnect path to `session.close()` for ending a session terminally from server code — typically in response to a user action like Submit or Log Out:

```python
@reactive.effect
@reactive.event(input.submit)
async def _():
    await session.close(hard=True, message="Thanks for your submission.")
```

A hard close performs three coordinated tiers:

1. **Wire protocol** — sends a `hardDisconnectConfig` custom message carrying the closed-overlay text, then closes the websocket with code **`4001`** / reason `shiny-hard-disconnect`. Hosting platforms (Shiny Server, Posit Connect) can recognize this as "release the worker without holding for reconnect."
2. **In-process cleanup** — beyond the existing destroy walk, also clears root-level `input`, `_downloads`, `_dynamic_routes`, and `_message_handlers`. `on_ended` callbacks fire **before** this cleanup, so teardown code can still read session state.
3. **Client UX** — the matching client-side handling (recognizing `4001`, stashing the `hardDisconnectConfig` message, rendering a distinct closed-state overlay, firing `shiny:closed`) lives in R Shiny's `srcts/` and reaches py-shiny when `shiny.js` is vendored from a release that includes it. Until then the server side runs as designed; the browser still sees today's grey "disconnected" overlay.

App-level default text is configurable: `App(hard_disconnect_message="…")`. Fallback chain: per-call `message` → app default → `"This app has closed."`.

**Backward compatibility:** existing callers of `session.close()` with no arguments are unaffected — soft close is byte-for-byte unchanged.

This is the py-shiny port of "Plan A" from the upstream hard-disconnect design ([R shiny `feat/hard-disconnect`](https://github.com/rstudio/shiny/tree/feat/hard-disconnect)). The idle-timeout variant ("Plan B") is out of scope for this PR.

## Changes

- `shiny/_app.py` — new `hard_disconnect_message: str | None` kwarg on `App.__init__`
- `shiny/session/_session.py` — `Session.close()` gains `hard` and `message` kwargs; `AppSession.close()` implements the hard path; `SessionProxy.close()` forwards; new `AppSession._hard_close_cleanup()`; new module-level constants `HARD_DISCONNECT_CLOSE_CODE`, `HARD_DISCONNECT_REASON`, `HARD_DISCONNECT_DEFAULT_MESSAGE`
- `shiny/express/_stub_session.py` — signature parity
- `tests/pytest/test_hard_disconnect.py` — 13 unit tests
- `CHANGELOG.md` — entry under `[UNRELEASED]`

## Test Plan

- [x] `pytest tests/pytest/test_hard_disconnect.py` — 13 passed
- [x] `pytest tests/pytest/test_destroy.py tests/pytest/test_hard_disconnect.py` — 88 passed (no regression in adjacent destroy/teardown tests)
- [x] `pytest tests/pytest/ --ignore=tests/pytest/test_theme.py` — 698 passed (theme tests need `libsass`, pre-existing local env issue)
- [x] `pyright shiny/session/_session.py shiny/express/_stub_session.py tests/pytest/test_hard_disconnect.py` — 0 errors
- [x] `black` / `isort` clean on changed files
- [ ] End-to-end browser verification deferred — requires the upstream R Shiny client-side work to be vendored. Server-side wire-protocol behavior (custom message + 4001) is fully covered by the unit tests.

## Out of scope

- Idle-timeout (`hard_disconnect_after`) — separate follow-up
- Client-side TypeScript/SCSS — lives in R Shiny's `srcts/`, arrives via `make upgrade-html-deps`
- Hosting-platform changes in Shiny Server / Connect — separate cross-team work item; py-shiny just emits the contract