### PR TITLE
fix: Update chat Playwright tests for shinychat 0.5.x

### DIFF
--- a/tests/playwright/shiny/components/chat/basic/test_chat_basic.py
+++ b/tests/playwright/shiny/components/chat/basic/test_chat_basic.py
@@ -43,9 +43,9 @@ def test_validate_chat_basic(page: Page, local_app: ShinyAppProc) -> None:
     message_state = controller.OutputCode(page, "message_state")
     message_state_expected = tuple(
         [
-            {"content": f"\n{user_message}", "role": "user"},
-            {"content": f"You said: \n{user_message}", "role": "assistant"},
-            {"content": f"{user_message2}", "role": "user"},
+            {"content": user_message, "role": "user"},
+            {"content": f"You said: {user_message}", "role": "assistant"},
+            {"content": user_message2, "role": "user"},
             {"content": f"You said: {user_message2}", "role": "assistant"},
         ]
     )

--- a/tests/playwright/shiny/components/chat/update_user_input/test_chat_update_user_input.py
+++ b/tests/playwright/shiny/components/chat/update_user_input/test_chat_update_user_input.py
@@ -46,7 +46,7 @@ def test_validate_chat_update_user_input(page: Page, local_app: ShinyAppProc) ->
 
     # Input remains cleared if previously clear (have to clear the input first)
     chat.loc_input.focus()
-    while chat.loc_input.input_value():
+    while chat.loc_input.inner_text().strip():
         chat.loc_input.press("Backspace")
 
     chat.expect_user_input("")


### PR DESCRIPTION
### Problem

`shinychat` is declared as `>=0.1.0` (unpinned), and the 0.5.x release changed the chat input from a `<textarea>` to a contenteditable div (`[role="textbox"]`). This broke two Playwright tests that have been failing on CI since that release.

**`test_validate_chat_update_user_input[firefox]`** — called `chat.loc_input.input_value()` directly, which Playwright only supports on `<input>`, `<textarea>`, and `<select>` elements. Firefox doesn't allow it on a contenteditable div:

```
Locator.input_value: Error: Node is not an <input>, <textarea> or <select> element
waiting for locator("#chat").locator("> .shiny-chat-input").locator("[role=\"textbox\"]")
```

**`test_validate_chat_basic[webkit, firefox]`** — expected user message content with a leading `\n` (a quirk of the old textarea where the field retained a stale newline). The contenteditable in 0.5.x doesn't produce that prefix, so the `message_state` comparison failed.

### Fix

- Replace `chat.loc_input.input_value()` with `chat.loc_input.inner_text().strip()`, which works on contenteditable elements across all browsers.
- Remove the `\n` prefix from the expected message content in `test_validate_chat_basic` to match the corrected 0.5.x behaviour.