### PR TITLE
fix(tests): skip dogfood connect; wait for DOM

### DIFF
--- a/tests/playwright/examples/example_apps.py
+++ b/tests/playwright/examples/example_apps.py
@@ -179,9 +179,8 @@ def validate_example(page: Page, ex_app_path: str) -> None:
 
     page.on("console", on_console_msg)
 
-    # Makes sure the app is closed when exiting the code block
     with sa:
-        page.goto(sa.url)
+        page.goto(sa.url, wait_until="domcontentloaded")
 
         app_name = os.path.basename(os.path.dirname(ex_app_path))
         short_app_path = f"{os.path.basename(os.path.dirname(os.path.dirname(ex_app_path)))}/{app_name}"

--- a/tests/playwright/utils/deploy_utils.py
+++ b/tests/playwright/utils/deploy_utils.py
@@ -280,8 +280,14 @@ def local_deploys_app_url_fixture(
             yield next(shinyapp_proc_gen).url
         elif deploy_location in deploy_locations:
 
-            if deploy_location == "connect" and not (server_url and api_key):
-                pytest.skip("Connect server url or api key not found. Cannot deploy.")
+            if deploy_location == "connect":
+                if server_url and "dogfood" in server_url:
+                    # TODO: dogfood server does not have public links now, the team will migrate to spinning their own connect server in the future.
+                    pytest.skip(
+                        "dogfood server does not have public links now, the team will migrate to spinning their own connect server in the future."
+                    )
+                if not (server_url and api_key):
+                    pytest.skip("Connect server url or api key not found. Cannot deploy.")
             if (
                 deploy_location == "shinyapps"
                 and shinyappsio_name

--- a/tests/playwright/utils/deploy_utils.py
+++ b/tests/playwright/utils/deploy_utils.py
@@ -287,7 +287,9 @@ def local_deploys_app_url_fixture(
                         "dogfood server does not have public links now, the team will migrate to spinning their own connect server in the future."
                     )
                 if not (server_url and api_key):
-                    pytest.skip("Connect server url or api key not found. Cannot deploy.")
+                    pytest.skip(
+                        "Connect server url or api key not found. Cannot deploy."
+                    )
             if (
                 deploy_location == "shinyapps"
                 and shinyappsio_name


### PR DESCRIPTION
Improve Playwright test stability: in deploy_utils, skip Connect deployments when server_url contains "dogfood" (dogfood lacks public links) and still skip when server_url or api_key are missing; in example_apps, use page.goto(sa.url, wait_until="domcontentloaded") to reduce timing flakiness.