### PR TITLE
fix(test): Bound e2e tests with a per-test timeout, verbose CI output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,21 @@ clean-js: FORCE
 SUB_FILE:=
 PYTEST_BROWSERS:= --browser webkit --browser firefox --browser chromium
 PYTEST_DEPLOYS_BROWSERS:= --browser chromium
+# Per-test timeout (seconds) so a single hung test fails fast with a full
+# thread-stack dump instead of silently consuming the whole CI job.
+PLAYWRIGHT_TEST_TIMEOUT:= 120
+# In CI, use one line per test (`-v`) instead of the default dot-progress
+# output. GitHub Actions' log viewer only displays a line once it sees a
+# trailing newline, and pytest's dot mode only emits one every ~80 chars
+# (terminal-width wrapping) -- with a small shard, that can be the entire
+# run, hiding all progress until the very end. `-v` emits a newline per test,
+# so CI shows real-time progress and where a hang starts. Left off locally
+# since the default dot output is nicer for interactive use.
+ifeq ($(CI),true)
+PLAYWRIGHT_VERBOSE:= -v
+else
+PLAYWRIGHT_VERBOSE:=
+endif
 
 
 # Full test path to playwright tests
@@ -201,8 +216,10 @@ install-rsconnect: FORCE
 
 
 # All end-to-end tests with playwright
+# `--timeout` bounds each test so a hang fails fast with a thread-stack dump
+# instead of consuming the whole job.
 playwright: install-playwright ## All end-to-end tests with playwright; (TEST_FILE="" from root of repo)
-	pytest $(TEST_FILE) $(PYTEST_BROWSERS)
+	pytest $(PLAYWRIGHT_VERBOSE) --timeout=$(PLAYWRIGHT_TEST_TIMEOUT) $(TEST_FILE) $(PYTEST_BROWSERS)
 
 playwright-debug: install-playwright ## All end-to-end tests, chrome only, headed; (TEST_FILE="" from root of repo)
 	pytest -c tests/playwright/playwright-pytest.ini $(TEST_FILE)


### PR DESCRIPTION
## Summary
`playwright-shiny (3.12, webkit, 2)` was observed hanging on CI for the full 60-minute step timeout with zero log output (confirmed via GitHub Actions run history — a single stuck test silently consumed the whole job).
Adds `--timeout=120` (pytest-timeout, default signal method) to `make playwright`, so any single hung test now fails after 120s with a full thread-stack dump (all threads, plus the exact line the test was stuck on) instead of the whole job stalling silently.
Switches to `-v` (one line per test) only when `CI=true` (GitHub Actions sets this automatically). GitHub's log viewer only displays a line once it sees a trailing newline; pytest's default dot-progress mode emits a newline only every ~80 characters of terminal width, so with a small shard (77 items) nearly the entire run's progress can sit on one line that never displays until it wraps — hiding exactly where a hang starts. `-v` forces a newline per test. Local runs keep the default compact dot output.
Confirmed pytest already flushes stdout after every test result (`_pytest/terminal.py`'s `pytest_runtest_logreport`), so no `PYTHONUNBUFFERED` workaround is needed — verified locally that both dot-mode and `-v` mode stream live without it.

## Verification
- Ran `pytest -v --timeout=3 <hanging test>` locally: test failed after 3s with `Failed: Timeout (>3.0s) from pytest-timeout.` and a full stack dump pointing at the exact hung line.
- Ran `make -n playwright-shiny ...` with and without `CI=true` to confirm `-v` is only added when `CI=true`.
- Ran a real chromium e2e test locally through `make`'s underlying pytest invocation to confirm normal (non-hung) tests still pass with the new flags.