### PR TITLE
fix(tests): Wait for hidden navset selection before bookmarking

### DIFF
--- a/tests/playwright/ai_generated_apps/bookmark/navsets/test_navsets_hidden_bookmarking.py
+++ b/tests/playwright/ai_generated_apps/bookmark/navsets/test_navsets_hidden_bookmarking.py
@@ -43,6 +43,14 @@ def test_navset_hidden_bookmarking(
     mod_navset_btn = controller.InputActionButton(page, f"first-{navset_id}_button")
     mod_navset_btn.click()
 
+    # Selecting a panel in a hidden navset requires a server round trip (button
+    # click -> reactive effect -> `ui.update_navset()` -> client applies the
+    # selection and reports it back to the server). Wait for the selections to
+    # reach the DOM before bookmarking; otherwise the bookmark can serialize
+    # stale navset values.
+    navset_cont.expect_value(f"{navset_id}_c")
+    mod_navset_cont.expect_value(f"{navset_id}_b")
+
     existing_url = page.url
 
     # Click bookmark button


### PR DESCRIPTION
Closes #2287. Part of #2285.

## Summary

Fixes the flaky `test_navset_hidden_bookmarking[chromium-navset_hidden-default-NavsetHidden]` test, which failed in 17 of the last 200 `Run tests` GHA runs with `AssertionError: Locator expected to have attribute 'navset_hidden_default_b'`.

Root cause: unlike the other navset bookmarking tests (where clicking a tab updates the navset input on the client immediately), a hidden navset's selection changes via a full server round trip — action button click → server reactive effect → `ui.update_navset()` message → client applies the selection → client reports the new navset input value back to the server. The test clicked the bookmark button immediately after the last action-button click, so when the bookmark request won the race, the bookmark serialized stale navset input values and the post-reload assertions failed.

The fix adds auto-waiting `expect_value()` assertions for both navsets before clicking the bookmark button. Once the DOM reflects the new selection, the client has already sent the updated navset input over the same ordered WebSocket, so the bookmark is guaranteed to see the correct values. Test-only change; no product code touched.

## Verification

Reproduced the race deterministically by temporarily adding `await asyncio.sleep(0.3)` inside the app's reactive effect (widening the round-trip window): the unmodified test failed with the exact CI error, showing the stale `navset_hidden_default_a` panel after reload. With the fix applied, the test passed even with the artificial delay in place, and passed 5/5 consecutive chromium runs after removing it.

```
.venv/bin/python -m pytest tests/playwright/ai_generated_apps/bookmark/navsets/test_navsets_hidden_bookmarking.py --browser chromium
```