### PR TITLE
fix: Retain last output value/error in test-mode snapshot when silenced

### DIFF
--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -183,6 +183,19 @@ class OutBoundMessageQueues:
             self.test_values[id] = value
             self.test_errors.pop(id, None)
 
+    def set_silent(self, id: str) -> None:
+        """
+        Record that computing `id`'s value was silently suppressed (e.g. via
+        `req()`), without touching the persistent test-mode record.
+
+        Unlike `set_value(id, None)`, this leaves `test_values`/`test_errors`
+        untouched, so the test-mode snapshot retains the output's last
+        computed value or error (matching Shiny for R) instead of reporting
+        `None`.
+        """
+        self.values[id] = None
+        self.errors.pop(id, None)
+
     def set_error(self, id: str, error: Any) -> None:
         self.errors[id] = error
         # remove from self.values
@@ -2493,7 +2506,7 @@ class Outputs:
                 except SilentCancelOutputException:
                     pass
                 except SilentException:
-                    session._outbound_message_queues.set_value(output_name, None)
+                    session._outbound_message_queues.set_silent(output_name)
                 except Exception as e:
                     # Print traceback to the console
                     traceback.print_exc()

--- a/tests/pytest/test_test_mode.py
+++ b/tests/pytest/test_test_mode.py
@@ -300,6 +300,65 @@ async def test_snapshot_endpoint_returns_state(
 
 
 @pytest.mark.asyncio
+async def test_snapshot_endpoint_silence_after_value_retains_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SHINY_TESTMODE", "1")
+    session = _make_app_session()
+
+    session._outbound_message_queues.set_value("out1", "hello")
+    session._outbound_message_queues.set_silent("out1")
+
+    resp = cast(
+        Response,
+        await session._handle_request_impl(_snapshot_request(), "dataobj", "shinytest"),
+    )
+    import orjson
+
+    body = orjson.loads(resp.body)
+    assert body["output"]["out1"] == "hello"
+
+
+@pytest.mark.asyncio
+async def test_snapshot_endpoint_silence_after_error_retains_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SHINY_TESTMODE", "1")
+    session = _make_app_session()
+
+    session._outbound_message_queues.set_error("out1", {"message": "boom"})
+    session._outbound_message_queues.set_silent("out1")
+
+    resp = cast(
+        Response,
+        await session._handle_request_impl(_snapshot_request(), "dataobj", "shinytest"),
+    )
+    import orjson
+
+    body = orjson.loads(resp.body)
+    assert body["output"]["out1"] == {"__shiny_output_error__": "boom"}
+
+
+@pytest.mark.asyncio
+async def test_snapshot_endpoint_silence_on_first_run_omits_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SHINY_TESTMODE", "1")
+    session = _make_app_session()
+
+    session._outbound_message_queues.set_silent("out1")
+
+    resp = cast(
+        Response,
+        await session._handle_request_impl(_snapshot_request(), "dataobj", "shinytest"),
+    )
+    import orjson
+
+    body = orjson.loads(resp.body)
+    assert "out1" not in body["output"]
+
+
+@pytest.mark.asyncio
 async def test_snapshot_endpoint_404_when_off(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/pytest/test_test_mode.py
+++ b/tests/pytest/test_test_mode.py
@@ -90,6 +90,43 @@ def test_outbound_queue_no_record_when_off() -> None:
     assert omq.test_errors == {}
 
 
+def test_outbound_queue_set_silent_retains_last_value() -> None:
+    omq = OutBoundMessageQueues(record_test_values=True)
+    omq.set_value("out1", 42)
+
+    omq.set_silent("out1")
+
+    # Transient queues: silenced like any other value (client should clear it).
+    assert omq.values["out1"] is None
+    assert "out1" not in omq.errors
+    # Persistent test-mode record: untouched, still reports the last value.
+    assert omq.test_values == {"out1": 42}
+    assert omq.test_errors == {}
+
+
+def test_outbound_queue_set_silent_retains_last_error() -> None:
+    omq = OutBoundMessageQueues(record_test_values=True)
+    omq.set_error("out1", {"message": "boom"})
+
+    omq.set_silent("out1")
+
+    assert omq.values["out1"] is None
+    assert "out1" not in omq.errors
+    # Persistent test-mode record: untouched, still reports the last error.
+    assert omq.test_errors == {"out1": {"message": "boom"}}
+    assert "out1" not in omq.test_values
+
+
+def test_outbound_queue_set_silent_on_first_run_leaves_absent() -> None:
+    omq = OutBoundMessageQueues(record_test_values=True)
+
+    omq.set_silent("out1")
+
+    assert omq.values["out1"] is None
+    assert "out1" not in omq.test_values
+    assert "out1" not in omq.test_errors
+
+
 def test_app_session_wires_record_flag(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("SHINY_TESTMODE", "1")
     session = _make_app_session()


### PR DESCRIPTION
## Summary
- `req()`/`SilentException` on an output previously overwrote its persistent test-mode snapshot record with `null`, discarding the last computed value or error.
- Adds `OutBoundMessageQueues.set_silent()`, which clears the transient client-facing value without touching the persistent `test_values`/`test_errors` record, and points `output_obs`'s `SilentException` handler at it.

Fixes #2283 (follow-up noted during review of #2270).

## Test plan
- [x] `pytest tests/pytest/test_test_mode.py` — new unit tests for `set_silent()` and end-to-end snapshot-endpoint tests (value→silence retains value, error→silence retains error, silence-on-first-run omits the key)
- [x] `pytest tests/pytest/` — full suite, no regressions