### PR TITLE
fix(tests): Wait for data frame re-render after selection mode change

### DIFF
--- a/tests/playwright/shiny/components/data_frame/example/test_data_frame.py
+++ b/tests/playwright/shiny/components/data_frame/example/test_data_frame.py
@@ -277,6 +277,11 @@ def _filter_test_impl(
     snapshot: Any,
 ):
     controller.InputSelect(page, "selection_mode").set("none")
+    # Changing the selection mode re-renders the data frame on the server. Wait
+    # for the new table to arrive (multi-row selection is now disabled) before
+    # interacting with the filter inputs; otherwise the re-render can steal
+    # focus mid-test.
+    expect(grid.locator("table")).to_have_attribute("aria-multiselectable", "false")
 
     filters = grid.locator("tr.filters")
 


### PR DESCRIPTION
## Summary

Fixes a flaky failure in `test_filter_table` (seen in [this CI run](https://github.com/posit-dev/py-shiny/actions/runs/28612669961/job/84848733433)) where `expect(page.get_by_placeholder("Max (20)", exact=True)).to_be_attached()` timed out.

Root cause: `_filter_test_impl` (shared by `test_filter_grid` and `test_filter_table`) starts by setting `selection_mode` to `"none"`, which makes the server re-execute the `grid()` render and push a fresh data frame to the client. None of the subsequent assertions distinguished the old DOM from the new one, so on a slow CI runner the re-render could land right after the test focused the min filter input — remounting the filter inputs, dropping focus, and clearing the focus-dependent placeholders between the `Min (1)` and `Max (20)` assertions.

The fix waits for the re-render to commit before touching the filter inputs, using the table's `aria-multiselectable` attribute, which flips from `"true"` (default `selection_mode="rows"`) to `"false"` once the `"none"` render arrives. No sleeps or retries.

## Verification

Reproduced the exact CI failure locally by adding a temporary 1s delay to the app's `grid()` render plus a pause between the two placeholder assertions — this produced the identical `AssertionError: Locator expected to be attached` on `Max (20)`. With the new wait in place, the test passed even with those race amplifiers still active. With the amplifiers removed, all 10 tests in the file pass on chromium:

```bash
pytest tests/playwright/shiny/components/data_frame/example/test_data_frame.py --browser chromium
```