### PR TITLE
test: Add deterministic MarkdownStream auto-scroll test; remove tautological scroll check

### DIFF
--- a/tests/playwright/shiny/components/MarkdownStream/auto_scroll/app.py
+++ b/tests/playwright/shiny/components/MarkdownStream/auto_scroll/app.py
@@ -1,0 +1,41 @@
+import asyncio
+
+from shiny import reactive
+from shiny.express import input, ui
+
+stream = ui.MarkdownStream("auto_scroll_stream")
+
+# Chunks are gated behind button clicks so the test controls stream pacing.
+# This keeps scroll assertions deterministic regardless of machine load.
+chunk_queue: asyncio.Queue[str] = asyncio.Queue()
+
+# Each chunk is taller than the 300px card so a missed auto-scroll is
+# unambiguous: the container ends up far from the bottom, not a few px off.
+FILLER = "\n\n".join(f"Filler paragraph {i} for scroll height." for i in range(12))
+
+
+def make_chunk(i: int) -> str:
+    return f"\n\nCHUNK-{i}-START\n\n{FILLER}\n\nCHUNK-{i}-END\n\n"
+
+
+async def gated_chunks():
+    while True:
+        yield await chunk_queue.get()
+
+
+@reactive.effect
+@reactive.event(input.next_chunk)
+async def _():
+    await chunk_queue.put(make_chunk(input.next_chunk()))
+
+
+@reactive.effect
+async def _():
+    await stream.stream(gated_chunks())
+
+
+ui.input_action_button("next_chunk", "Next chunk")
+
+with ui.card(height="300px", class_="mt-3"):
+    ui.card_header("Auto-scroll stream")
+    stream.ui()

--- a/tests/playwright/shiny/components/MarkdownStream/auto_scroll/app.py
+++ b/tests/playwright/shiny/components/MarkdownStream/auto_scroll/app.py
@@ -3,11 +3,13 @@ import asyncio
 from shiny import reactive
 from shiny.express import input, ui
 
-stream = ui.MarkdownStream("auto_scroll_stream")
+pinned_stream = ui.MarkdownStream("auto_scroll_stream")
+unpinned_stream = ui.MarkdownStream("no_auto_scroll_stream")
 
 # Chunks are gated behind button clicks so the test controls stream pacing.
 # This keeps scroll assertions deterministic regardless of machine load.
-chunk_queue: asyncio.Queue[str] = asyncio.Queue()
+pinned_queue: asyncio.Queue[str] = asyncio.Queue()
+unpinned_queue: asyncio.Queue[str] = asyncio.Queue()
 
 # Each chunk is taller than the 300px card so a missed auto-scroll is
 # unambiguous: the container ends up far from the bottom, not a few px off.
@@ -18,24 +20,34 @@ def make_chunk(i: int) -> str:
     return f"\n\nCHUNK-{i}-START\n\n{FILLER}\n\nCHUNK-{i}-END\n\n"
 
 
-async def gated_chunks():
-    while True:
-        yield await chunk_queue.get()
+def gated_chunks(queue: asyncio.Queue[str]):
+    async def gen():
+        while True:
+            yield await queue.get()
+
+    return gen()
 
 
 @reactive.effect
 @reactive.event(input.next_chunk)
 async def _():
-    await chunk_queue.put(make_chunk(input.next_chunk()))
+    chunk = make_chunk(input.next_chunk())
+    await pinned_queue.put(chunk)
+    await unpinned_queue.put(chunk)
 
 
 @reactive.effect
 async def _():
-    await stream.stream(gated_chunks())
+    await pinned_stream.stream(gated_chunks(pinned_queue))
+    await unpinned_stream.stream(gated_chunks(unpinned_queue))
 
 
 ui.input_action_button("next_chunk", "Next chunk")
 
 with ui.card(height="300px", class_="mt-3"):
-    ui.card_header("Auto-scroll stream")
-    stream.ui()
+    ui.card_header("Auto-scroll stream (pinned to bottom)")
+    pinned_stream.ui()
+
+with ui.card(height="300px", class_="mt-3"):
+    ui.card_header("No auto-scroll stream (stays at top)")
+    unpinned_stream.ui(auto_scroll=False)

--- a/tests/playwright/shiny/components/MarkdownStream/auto_scroll/test_stream_auto_scroll.py
+++ b/tests/playwright/shiny/components/MarkdownStream/auto_scroll/test_stream_auto_scroll.py
@@ -3,7 +3,8 @@ from playwright.sync_api import Page, expect
 from shiny.playwright import controller
 from shiny.run import ShinyAppProc
 
-CONTAINER = ".card-body:has(#auto_scroll_stream)"
+PINNED = ".card-body:has(#auto_scroll_stream)"
+UNPINNED = ".card-body:has(#no_auto_scroll_stream)"
 
 # Read-only check (never mutates scrollTop): true once the container has been
 # at the bottom with a stable scroll position for 3 consecutive polls.
@@ -43,7 +44,7 @@ GROWN_AND_SETTLED_SCRIPT = """(args) => {
 }"""
 
 
-def scroll_state(page: Page) -> dict[str, float]:
+def scroll_state(page: Page, selector: str) -> dict[str, float]:
     return page.evaluate(
         """(sel) => {
             const el = document.querySelector(sel);
@@ -53,73 +54,87 @@ def scroll_state(page: Page) -> dict[str, float]:
                 clientHeight: el.clientHeight,
             };
         }""",
-        CONTAINER,
+        selector,
     )
 
 
-def expect_at_bottom(page: Page, *, timeout: float = 30_000) -> None:
+def expect_at_bottom(page: Page, selector: str, *, timeout: float = 30_000) -> None:
     try:
         page.wait_for_function(
             AT_BOTTOM_STABLE_SCRIPT,
-            arg=CONTAINER,
+            arg=selector,
             polling=250,
             timeout=timeout,
         )
     except Exception as e:
         raise RuntimeError(
-            f"Container never settled at bottom: {scroll_state(page)}"
+            f"{selector} never settled at bottom: {scroll_state(page, selector)}"
         ) from e
+
+
+def expect_not_scrolled(page: Page, selector: str) -> None:
+    state = scroll_state(page, selector)
+    assert state["scrollTop"] < 50, f"{selector} was scrolled: {state}"
 
 
 def next_chunk_and_wait_for_render(
     page: Page, button: controller.InputActionButton, i: int
 ) -> None:
-    height_before = scroll_state(page)["scrollHeight"]
+    heights = {
+        sel: scroll_state(page, sel)["scrollHeight"] for sel in (PINNED, UNPINNED)
+    }
     button.click()
-    stream = page.locator("#auto_scroll_stream")
-    expect(stream).to_contain_text(f"CHUNK-{i}-END", timeout=30_000)
-    page.wait_for_function(
-        GROWN_AND_SETTLED_SCRIPT,
-        arg={"selector": CONTAINER, "minHeight": height_before},
-        polling=250,
-        timeout=30_000,
-    )
+    for stream_id in ("auto_scroll_stream", "no_auto_scroll_stream"):
+        expect(page.locator(f"#{stream_id}")).to_contain_text(
+            f"CHUNK-{i}-END", timeout=30_000
+        )
+    for sel, height_before in heights.items():
+        page.wait_for_function(
+            GROWN_AND_SETTLED_SCRIPT,
+            arg={"selector": sel, "minHeight": height_before},
+            polling=250,
+            timeout=30_000,
+        )
 
 
 def test_auto_scroll_pinning(page: Page, local_app: ShinyAppProc) -> None:
     page.goto(local_app.url)
 
     next_chunk = controller.InputActionButton(page, "next_chunk")
-    stream = page.locator("#auto_scroll_stream")
-    # The empty stream element has zero height, so wait for attachment (not
+    # The empty stream elements have zero height, so wait for attachment (not
     # visibility) before sending the first chunk.
-    expect(stream).to_be_attached(timeout=30_000)
+    expect(page.locator("#auto_scroll_stream")).to_be_attached(timeout=30_000)
+    expect(page.locator("#no_auto_scroll_stream")).to_be_attached(timeout=30_000)
 
     # Chunk 1 creates the overflow; shinychat binds to the scrollable parent on
     # a 200ms throttle, so pinning assertions start once content overflows.
     next_chunk_and_wait_for_render(page, next_chunk, 1)
 
-    # Phase A: while pinned, the container follows each appended chunk.
+    # Phase A: the auto-scroll container follows each appended chunk, while the
+    # auto_scroll=False container (negative control) must never move. This also
+    # proves the at-bottom assertion is not vacuous: the same chunks fail it
+    # when auto-scroll is off.
     for i in (2, 3):
         next_chunk_and_wait_for_render(page, next_chunk, i)
-        expect_at_bottom(page)
+        expect_at_bottom(page, PINNED)
+        expect_not_scrolled(page, UNPINNED)
 
     # Phase B: scrolling away from the bottom unpins; new content must NOT
     # drag the container back down.
-    page.evaluate(f"""() => document.querySelector({CONTAINER!r}).scrollTo(0, 0)""")
+    page.evaluate(f"""() => document.querySelector({PINNED!r}).scrollTo(0, 0)""")
     page.wait_for_function(
-        f"""() => document.querySelector({CONTAINER!r}).scrollTop === 0"""
+        f"""() => document.querySelector({PINNED!r}).scrollTop === 0"""
     )
     next_chunk_and_wait_for_render(page, next_chunk, 4)
-    state = scroll_state(page)
-    assert state["scrollTop"] < 50, f"Unpinned container was scrolled: {state}"
+    expect_not_scrolled(page, PINNED)
 
     # Phase C: scrolling back to the bottom re-pins; the next chunk is
     # followed again.
     page.evaluate(f"""() => {{
-            const el = document.querySelector({CONTAINER!r});
+            const el = document.querySelector({PINNED!r});
             el.scrollTo(0, el.scrollHeight);
         }}""")
-    expect_at_bottom(page)
+    expect_at_bottom(page, PINNED)
     next_chunk_and_wait_for_render(page, next_chunk, 5)
-    expect_at_bottom(page)
+    expect_at_bottom(page, PINNED)
+    expect_not_scrolled(page, UNPINNED)

--- a/tests/playwright/shiny/components/MarkdownStream/auto_scroll/test_stream_auto_scroll.py
+++ b/tests/playwright/shiny/components/MarkdownStream/auto_scroll/test_stream_auto_scroll.py
@@ -1,0 +1,125 @@
+from playwright.sync_api import Page, expect
+
+from shiny.playwright import controller
+from shiny.run import ShinyAppProc
+
+CONTAINER = ".card-body:has(#auto_scroll_stream)"
+
+# Read-only check (never mutates scrollTop): true once the container has been
+# at the bottom with a stable scroll position for 3 consecutive polls.
+# 20px tolerance: shinychat scrolls to the exact bottom, so this only absorbs
+# subpixel rounding; shinychat's own re-pin tolerance is 50px.
+AT_BOTTOM_STABLE_SCRIPT = """(selector) => {
+    const el = document.querySelector(selector);
+    if (!el) return false;
+
+    const atBottom = (el.scrollTop + el.clientHeight) >= (el.scrollHeight - 20);
+    const changed =
+        el.__abLastTop !== el.scrollTop || el.__abLastHeight !== el.scrollHeight;
+    el.__abLastTop = el.scrollTop;
+    el.__abLastHeight = el.scrollHeight;
+
+    if (!atBottom || changed) {
+        el.__abStableCount = 0;
+        return false;
+    }
+    el.__abStableCount = (el.__abStableCount || 0) + 1;
+    return el.__abStableCount >= 2;
+}"""
+
+# True once scrollHeight has grown past minHeight and been stable for 3
+# consecutive polls (i.e. the new chunk has fully rendered and settled).
+GROWN_AND_SETTLED_SCRIPT = """(args) => {
+    const el = document.querySelector(args.selector);
+    if (!el) return false;
+
+    if (el.scrollHeight <= args.minHeight || el.__ghLastHeight !== el.scrollHeight) {
+        el.__ghLastHeight = el.scrollHeight;
+        el.__ghStableCount = 0;
+        return false;
+    }
+    el.__ghStableCount = (el.__ghStableCount || 0) + 1;
+    return el.__ghStableCount >= 2;
+}"""
+
+
+def scroll_state(page: Page) -> dict[str, float]:
+    return page.evaluate(
+        """(sel) => {
+            const el = document.querySelector(sel);
+            return {
+                scrollTop: el.scrollTop,
+                scrollHeight: el.scrollHeight,
+                clientHeight: el.clientHeight,
+            };
+        }""",
+        CONTAINER,
+    )
+
+
+def expect_at_bottom(page: Page, *, timeout: float = 30_000) -> None:
+    try:
+        page.wait_for_function(
+            AT_BOTTOM_STABLE_SCRIPT,
+            arg=CONTAINER,
+            polling=250,
+            timeout=timeout,
+        )
+    except Exception as e:
+        raise RuntimeError(
+            f"Container never settled at bottom: {scroll_state(page)}"
+        ) from e
+
+
+def next_chunk_and_wait_for_render(
+    page: Page, button: controller.InputActionButton, i: int
+) -> None:
+    height_before = scroll_state(page)["scrollHeight"]
+    button.click()
+    stream = page.locator("#auto_scroll_stream")
+    expect(stream).to_contain_text(f"CHUNK-{i}-END", timeout=30_000)
+    page.wait_for_function(
+        GROWN_AND_SETTLED_SCRIPT,
+        arg={"selector": CONTAINER, "minHeight": height_before},
+        polling=250,
+        timeout=30_000,
+    )
+
+
+def test_auto_scroll_pinning(page: Page, local_app: ShinyAppProc) -> None:
+    page.goto(local_app.url)
+
+    next_chunk = controller.InputActionButton(page, "next_chunk")
+    stream = page.locator("#auto_scroll_stream")
+    # The empty stream element has zero height, so wait for attachment (not
+    # visibility) before sending the first chunk.
+    expect(stream).to_be_attached(timeout=30_000)
+
+    # Chunk 1 creates the overflow; shinychat binds to the scrollable parent on
+    # a 200ms throttle, so pinning assertions start once content overflows.
+    next_chunk_and_wait_for_render(page, next_chunk, 1)
+
+    # Phase A: while pinned, the container follows each appended chunk.
+    for i in (2, 3):
+        next_chunk_and_wait_for_render(page, next_chunk, i)
+        expect_at_bottom(page)
+
+    # Phase B: scrolling away from the bottom unpins; new content must NOT
+    # drag the container back down.
+    page.evaluate(f"""() => document.querySelector({CONTAINER!r}).scrollTo(0, 0)""")
+    page.wait_for_function(
+        f"""() => document.querySelector({CONTAINER!r}).scrollTop === 0"""
+    )
+    next_chunk_and_wait_for_render(page, next_chunk, 4)
+    state = scroll_state(page)
+    assert state["scrollTop"] < 50, f"Unpinned container was scrolled: {state}"
+
+    # Phase C: scrolling back to the bottom re-pins; the next chunk is
+    # followed again.
+    page.evaluate(f"""() => {{
+            const el = document.querySelector({CONTAINER!r});
+            el.scrollTo(0, el.scrollHeight);
+        }}""")
+    expect_at_bottom(page)
+    next_chunk_and_wait_for_render(page, next_chunk, 5)
+    expect_at_bottom(page)

--- a/tests/playwright/shiny/components/MarkdownStream/basic/test_stream_basic.py
+++ b/tests/playwright/shiny/components/MarkdownStream/basic/test_stream_basic.py
@@ -3,108 +3,17 @@ from playwright.sync_api import Page, expect
 from shiny.playwright import controller
 from shiny.run import ShinyAppProc
 
-# Single combined check: avoids race where settle-then-check missed in-progress smooth scrolls
-SETTLED_AT_BOTTOM_SCRIPT = """(selector) => {
-    const el = document.querySelector(selector);
-    if (!el) return false;
-
-    el.scrollTop = el.scrollHeight;
-
-    const scrollTop = el.scrollTop;
-    const scrollHeight = el.scrollHeight;
-    const clientHeight = el.clientHeight;
-
-    if (scrollHeight <= clientHeight) return false;
-
-    // 20px tolerance: shinychat uses 10px bottomTolerance + headroom for subpixel rounding
-    const atBottom = (scrollTop + clientHeight) >= (scrollHeight - 20);
-    if (!atBottom) {
-        el.__stableCount = 0;
-        el.__lastScrollTop = undefined;
-        return false;
-    }
-
-    if (el.__lastScrollTop === scrollTop) {
-        el.__stableCount = (el.__stableCount || 0) + 1;
-    } else {
-        el.__stableCount = 0;
-    }
-    el.__lastScrollTop = scrollTop;
-    // Require 3 consecutive polls (750ms) at bottom to rule out mid-animation pauses
-    return el.__stableCount >= 2;
-}"""
-
-
-def expect_element_scrolled_to_bottom(
-    page: Page,
-    selector: str,
-    *,
-    timeout: float = 30_000,
-) -> None:
-    try:
-        page.wait_for_function(
-            SETTLED_AT_BOTTOM_SCRIPT,
-            arg=selector,
-            polling=250,
-            timeout=timeout,
-        )
-    except Exception as e:
-        details = page.evaluate(
-            """(sel) => {
-                const el = document.querySelector(sel);
-                if (!el) return "Element not found";
-                return {
-                    scrollTop: el.scrollTop,
-                    scrollHeight: el.scrollHeight,
-                    clientHeight: el.clientHeight,
-                    stableCount: el.__stableCount,
-                    lastScrollTop: el.__lastScrollTop
-                };
-            }""",
-            selector,
-        )
-        raise RuntimeError(f"Scroll assertion failed for {selector}: {details}") from e
+# Scroll/auto-scroll behavior is covered by the deterministic test in
+# ../auto_scroll/; this test focuses on streaming a large document at full
+# speed, error propagation, and the stream result API.
 
 
 def test_validate_stream_basic(page: Page, local_app: ShinyAppProc) -> None:
-    page.add_init_script("""
-        const style = document.createElement('style');
-        style.innerHTML = '* { scroll-behavior: auto !important; }';
-        document.head.appendChild(style);
-
-        const forceAuto = (original) => {
-            return function(options, ...args) {
-                if (options && typeof options === 'object') {
-                    options.behavior = 'auto';
-                }
-                return original.apply(this, arguments);
-            };
-        };
-
-        Element.prototype.scroll = forceAuto(Element.prototype.scroll);
-        Element.prototype.scrollTo = forceAuto(Element.prototype.scrollTo);
-        Element.prototype.scrollBy = forceAuto(Element.prototype.scrollBy);
-        Element.prototype.scrollIntoView = forceAuto(Element.prototype.scrollIntoView);
-
-        window.scroll = forceAuto(window.scroll);
-        window.scrollTo = forceAuto(window.scrollTo);
-        window.scrollBy = forceAuto(window.scrollBy);
-        """)
     page.goto(local_app.url)
 
     stream = page.locator("#shiny_readme")
     expect(stream).to_be_visible(timeout=30_000)
     expect(stream).to_contain_text("pre-commit uninstall", timeout=30_000)
-
-    page.evaluate(
-        """(sel) => {
-            const el = document.querySelector(sel);
-            if (el) el.scrollTop = el.scrollHeight;
-        }""",
-        ".card-body:has(#shiny_readme)",
-    )
-
-    expect_element_scrolled_to_bottom(page, ".card-body:has(#shiny_readme)")
 
     stream2 = page.locator("#shiny_readme_err")
     expect(stream2).to_be_visible(timeout=30_000)


### PR DESCRIPTION
## Why

Follow-up to #2286 / #2285. The basic MarkdownStream test's scroll check force-scrolled the container inside its polled script (`el.scrollTop = el.scrollHeight`) — a deliberate anti-flake tradeoff accepted in #2261. As a result it validated that the stream rendered and was scrollable, but did not test shinychat's auto-scroll behavior at all (it passed even with `auto_scroll=False`), while still being the source of the suite's worst historical flake (42 of the last 200 CI runs, webkit).

## What

**New `tests/playwright/shiny/components/MarkdownStream/auto_scroll/`** — a test app and test exercising the real pinning contract (from the vendored `markdown-stream.js`: 50px at-bottom tolerance, unpin on scroll-away, re-pin at bottom, `behavior: "instant"` while streaming):

- **Deterministic pacing**: stream chunks are gated behind an action button (fed through `asyncio.Queue`s into the generators consumed by `MarkdownStream.stream()`), so content only advances when the test says so — immune to CI load, the root cause of the original flake.
- **Built-in negative control**: the same chunks stream into a second card with `auto_scroll=False`, which must never move. This keeps the `auto_scroll=False` behavior under test and proves the at-bottom assertion cannot pass vacuously.
- **Phase A (pinned)**: each appended chunk auto-scrolls the container to the bottom; asserted with a *read-only* stabilized poll (no scroll mutation anywhere in the checks).
- **Phase B (unpinned)**: after scrolling to the top, a new chunk must **not** drag the container back down. The assertion waits for the chunk to fully render and settle first, so it can't pass by reading too early. This inverse case (scroll hijacking) had no coverage anywhere.
- **Phase C (re-pinned)**: scrolling back to the bottom resumes following on the next chunk.

Each chunk is taller than the 300px cards, so a missed auto-scroll leaves the container far from the bottom — unambiguous failures.

**Slimmed `basic/test_stream_basic.py`** (−94/+3): removed the force-scroll check, its polling script, the global scroll-API-patching init script, and the manual pre-scroll — the exact code path behind the historical webkit flake. The test keeps its unique coverage: full-speed large-document streaming, stream-error propagation to a notification, and the `reactive.calc` stream result.

## Verification

- Mutation-tested during development: with auto-scroll disabled, Phase A fails with `never settled at bottom: {'scrollTop': 0, ...}`; the removed check passed under the same mutation. The negative-control card now encodes this permanently.
- Stability: 14/14 consecutive local passes of the new test across chromium, firefox, and webkit (~5–13s per run); slimmed basic test verified on chromium and webkit.