### PR TITLE
feat: Add test-mode snapshot preprocessing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * The test-mode snapshot endpoint honors query params `input`/`output`/`export` to select specific blocks (`=1` for a whole block, or a comma-separated list of keys). Unlike R, requesting no blocks returns all three rather than a `400`. (#2269)
 
-* Test-mode snapshot values can now be preprocessed before they are written to the snapshot, e.g. to scrub timestamps or temp paths: `input.set_snapshot_preprocess(id, fn)` for inputs and `my_output.snapshot_preprocess(fn)` for outputs (or the `shiny.testmode.snapshot_preprocess_input()` / `snapshot_preprocess_output()` free functions). Handlers may be synchronous or asynchronous. File inputs automatically scrub each file's `datapath` to its basename, matching Shiny for R. `export_test_values()` moved from `shiny.session` to the new `shiny.testmode` module. (#2282)
+* Test-mode snapshot values can now be preprocessed before they are written to the snapshot, e.g. to scrub timestamps or temp paths: `input.set_snapshot_preprocess(id, fn)` (or `shiny.testmode.snapshot_preprocess_input()`) for inputs and `my_output.snapshot_preprocess(fn)` for outputs. Handlers may be synchronous or asynchronous. File inputs automatically scrub each file's `datapath` to its basename, matching Shiny for R. `export_test_values()` moved from `shiny.session` to the new `shiny.testmode` module. (#2282)
 
 
 ## [1.6.3] - 2026-06-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added test mode, enabled via the `SHINY_TESTMODE=1` environment variable or the `App(test_mode=)` argument (which defaults to that env var). The pytest app-launch fixtures (`local_app`, `create_app_fixture`) now run apps in test mode. (#2269)
 
-* When test mode is enabled, each session can serve a JSON snapshot of its `input`, `output`, and `export` values at `/session/{id}/dataobj/shinytest` (URL available via `session.get_test_snapshot_url()`). App authors can surface internal reactive values with `shiny.session.export_test_values()`. (#2269)
+* When test mode is enabled, each session can serve a JSON snapshot of its `input`, `output`, and `export` values at `/session/{id}/dataobj/shinytest` (URL available via `session.get_test_snapshot_url()`). App authors can surface internal reactive values with `shiny.testmode.export_test_values()`. (#2269)
 
 * Added the `shiny.playwright.controller.AppTestValues` Playwright controller for reading a session's test-mode snapshot (`input`/`output`/`export`) in end-to-end tests. (#2269)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * The test-mode snapshot endpoint honors query params `input`/`output`/`export` to select specific blocks (`=1` for a whole block, or a comma-separated list of keys). Unlike R, requesting no blocks returns all three rather than a `400`. (#2269)
 
+* Test-mode snapshot values can now be preprocessed before they are written to the snapshot, e.g. to scrub timestamps or temp paths: `input.set_snapshot_preprocess(id, fn)` for inputs and `my_output.snapshot_preprocess(fn)` for outputs (or the `shiny.testmode.snapshot_preprocess_input()` / `snapshot_preprocess_output()` free functions). Handlers may be synchronous or asynchronous. File inputs automatically scrub each file's `datapath` to its basename, matching Shiny for R. `export_test_values()` moved from `shiny.session` to the new `shiny.testmode` module. (#2282)
+
 
 ## [1.6.3] - 2026-06-01
 

--- a/docs/_quartodoc-core.yml
+++ b/docs/_quartodoc-core.yml
@@ -277,6 +277,9 @@ quartodoc:
             - session.get_current_session
             - session.require_active_session
             - testmode.export_test_values
+            - testmode.snapshot_preprocess_input
+            - testmode.snapshot_preprocess_output
+            - session.Inputs.set_snapshot_preprocess
             - session.session_context
             - reactive.get_current_context
             - session.ClientData

--- a/docs/_quartodoc-core.yml
+++ b/docs/_quartodoc-core.yml
@@ -276,7 +276,7 @@ quartodoc:
           contents:
             - session.get_current_session
             - session.require_active_session
-            - session.export_test_values
+            - testmode.export_test_values
             - session.session_context
             - reactive.get_current_context
             - session.ClientData

--- a/docs/_quartodoc-core.yml
+++ b/docs/_quartodoc-core.yml
@@ -265,7 +265,7 @@ quartodoc:
         - module.ui
         - module.server
     - title: Test mode
-      desc: Capturing a session's `input`/`output`/`export` state for snapshot testing (`SHINY_TESTMODE`).
+      desc: Capturing a session's `input`/`output`/`export` state for snapshot testing.
       contents:
         - testmode.export_test_values
         - testmode.snapshot_preprocess_input

--- a/docs/_quartodoc-core.yml
+++ b/docs/_quartodoc-core.yml
@@ -264,6 +264,14 @@ quartodoc:
         # uses class.rst template
         - module.ui
         - module.server
+    - title: Test mode
+      desc: Capturing a session's `input`/`output`/`export` state for snapshot testing (`SHINY_TESTMODE`).
+      contents:
+        - testmode.export_test_values
+        - testmode.snapshot_preprocess_input
+        - testmode.snapshot_preprocess_output
+        - session.Inputs.set_snapshot_preprocess
+        - session.Session.get_test_snapshot_url
     - title: Developer facing tools
       desc: ""
       contents:
@@ -276,10 +284,6 @@ quartodoc:
           contents:
             - session.get_current_session
             - session.require_active_session
-            - testmode.export_test_values
-            - testmode.snapshot_preprocess_input
-            - testmode.snapshot_preprocess_output
-            - session.Inputs.set_snapshot_preprocess
             - session.session_context
             - reactive.get_current_context
             - session.ClientData
@@ -289,7 +293,6 @@ quartodoc:
             - session.Session.on_flushed
             - session.Session.on_ended
             - session.Session.dynamic_route
-            - session.Session.get_test_snapshot_url
             - session.Session.close
             - input_handler.input_handlers
         - kind: page

--- a/docs/_quartodoc-core.yml
+++ b/docs/_quartodoc-core.yml
@@ -269,7 +269,6 @@ quartodoc:
       contents:
         - testmode.export_test_values
         - testmode.snapshot_preprocess_input
-        - testmode.snapshot_preprocess_output
         - session.Inputs.set_snapshot_preprocess
         - session.Session.get_test_snapshot_url
     - title: Developer facing tools

--- a/shiny/input_handler.py
+++ b/shiny/input_handler.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict
 
 from .bookmark import serializer_unserializable
 from .bookmark._serializers import can_serialize_input_file, serializer_file_input
+from .testmode import _snapshot_preprocess_file_input
 
 if TYPE_CHECKING:
     from .session import Session
@@ -252,5 +253,6 @@ def _(value: Any, name: ResolvedId, session: Session) -> Any:
     # uploaded the usual way (instead of being restored), this occurs in
     # session$`@uploadEnd`.
     session.input.set_serializer(name, serializer_file_input)
+    session.input.set_snapshot_preprocess(name, _snapshot_preprocess_file_input)
 
     return value_list

--- a/shiny/render/renderer/_renderer.py
+++ b/shiny/render/renderer/_renderer.py
@@ -202,6 +202,31 @@ class Renderer(Generic[IT]):
         """
         self.output_id = output_id
 
+    def snapshot_preprocess(
+        self,
+        fn: Callable[[Any], Any] | Callable[[Any], Awaitable[Any]],
+    ) -> None:
+        """
+        Set a function for preprocessing this output's value in test-mode snapshots.
+
+        When a test snapshot is requested (see `shiny.testmode`), the registered
+        function receives the output's last rendered value and its return value
+        is written to the snapshot instead. Use this to scrub non-deterministic
+        values (timestamps, temp paths, random ids) so snapshots diff cleanly.
+
+        The function may be synchronous or asynchronous. It only affects test
+        snapshots -- never the value sent to the client. Calling again
+        overwrites the previous function. Registration is harmless when test
+        mode is off, so calls can be left in production code.
+
+        Parameters
+        ----------
+        fn
+            A function that takes the output value and returns the value to
+            write to the test snapshot.
+        """
+        self._snapshot_preprocess_fn = wrap_async(fn)
+
     def auto_output_ui(
         self,
         # *
@@ -225,6 +250,7 @@ class Renderer(Generic[IT]):
         super().__init__()
 
         self._auto_registered: bool = False
+        self._snapshot_preprocess_fn: Callable[[Any], Awaitable[Any]] | None = None
 
         # Must be done last
         if callable(_fn):

--- a/shiny/session/__init__.py
+++ b/shiny/session/__init__.py
@@ -2,7 +2,6 @@
 Tools for working within a (user) session context.
 """
 
-from ._export import export_test_values
 from ._session import ClientData, Inputs, Outputs, Session
 from ._utils import (  # noqa: F401
     get_current_session,
@@ -17,5 +16,4 @@ __all__ = (
     "ClientData",
     "get_current_session",
     "require_active_session",
-    "export_test_values",
 )

--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -1335,11 +1335,11 @@ class AppSession(Session):
         elif action == "dataobj" and subpath == "shinytest" and request.method == "GET":
             if not self.app._test_mode:
                 return HTMLResponse("<h1>Not Found</h1>", 404)
-            return self._handle_test_snapshot(request)
+            return await self._handle_test_snapshot(request)
 
         return HTMLResponse("<h1>Not Found</h1>", 404)
 
-    def _handle_test_snapshot(self, request: Request) -> ASGIApp:
+    async def _handle_test_snapshot(self, request: Request) -> ASGIApp:
         # `format`: py-shiny only ever emits JSON. R additionally supports "rds",
         # but there is no RDS equivalent in Python, so any non-"json" value
         # (including "rds") is rejected.
@@ -1373,7 +1373,9 @@ class AppSession(Session):
                 if select_all or want["input"] is not None:
                     inputs = {
                         str(key): _snapshot_safe_value(val)
-                        for key, val in self.input._serialize_test_mode().items()
+                        for key, val in (
+                            await self.input._serialize_test_mode()
+                        ).items()
                     }
                     payload["input"] = _filter_snapshot_block(inputs, want["input"])
 
@@ -1671,6 +1673,10 @@ class SessionProxy(Session):
         self.id = root_session.id
         self.ns = ns
         self.input = Inputs(values=root_session.input._map, ns=ns)
+        # Share snapshot-preprocessor storage with the root session so that
+        # registrations made inside modules are visible to the (root) snapshot
+        # handler, like the shared `_map`.
+        self.input._snapshot_preprocessors = root_session.input._snapshot_preprocessors
         self.output = Outputs(
             self,
             ns=ns,
@@ -1941,12 +1947,21 @@ class Inputs:
     Set this value via `Inputs.set_serializer(id, fn)`.
     """
 
+    _snapshot_preprocessors: dict[str, Callable[[Any], Awaitable[Any]]]
+    """
+    Preprocessors applied to input values in test-mode snapshots.
+
+    Keyed by resolved input id; values are async-wrapped callables. Set via
+    `Inputs.set_snapshot_preprocess(id, fn)`.
+    """
+
     def __init__(
         self, values: dict[str, Value[Any]], ns: Callable[[str], ResolvedId] = Root
     ) -> None:
         self._map = values
         self._ns = ns
         self._serializers = {}
+        self._snapshot_preprocessors = {}
 
     def __setitem__(self, key: str, value: Value[Any]) -> None:
         if not isinstance(value, reactive.Value):
@@ -1989,14 +2004,14 @@ class Inputs:
 
     # Allow access of values as attributes.
     def __setattr__(self, attr: str, value: Value[Any]) -> None:
-        if attr in ("_map", "_ns", "_serializers"):
+        if attr in ("_map", "_ns", "_serializers", "_snapshot_preprocessors"):
             super().__setattr__(attr, value)
             return
 
         self.__setitem__(attr, value)
 
     def __getattr__(self, attr: str) -> Value[Any]:
-        if attr in ("_map", "_ns", "_serializers"):
+        if attr in ("_map", "_ns", "_serializers", "_snapshot_preprocessors"):
             return object.__getattribute__(self, attr)
         return self.__getitem__(attr)
 
@@ -2044,6 +2059,34 @@ class Inputs:
         """
         self._serializers[id] = wrap_async(fn)
 
+    def set_snapshot_preprocess(
+        self,
+        id: str,
+        fn: Callable[[Any], Any] | Callable[[Any], Awaitable[Any]],
+    ) -> None:
+        """
+        Set a function for preprocessing an input value in test-mode snapshots.
+
+        When a test snapshot is requested (see `shiny.testmode`), the registered
+        function receives the input's current value and its return value is
+        written to the snapshot instead. Use this to scrub non-deterministic
+        values (timestamps, temp paths, random ids) so snapshots diff cleanly.
+
+        The function may be synchronous or asynchronous. It only affects test
+        snapshots -- never the live input value. Registering again for the same
+        `id` overwrites the previous function. Registration is harmless when
+        test mode is off, so calls can be left in production code.
+
+        Parameters
+        ----------
+        id
+            The ID of the input value.
+        fn
+            A function that takes the input value and returns the value to
+            write to the test snapshot.
+        """
+        self._snapshot_preprocessors[self._ns(id)] = wrap_async(fn)
+
     async def _serialize(
         self,
         /,
@@ -2080,14 +2123,16 @@ class Inputs:
 
         return serialized_values
 
-    def _serialize_test_mode(self) -> dict[str, Any]:
+    async def _serialize_test_mode(self) -> dict[str, Any]:
         """
         Collect current input values for a test-mode snapshot.
 
         Unlike `_serialize` (used for bookmarking), this applies no bookmark
         serializers and never touches the filesystem; raw values are returned for
         best-effort JSON serialization by the snapshot handler. Client-internal
-        and bookmark inputs are skipped.
+        and bookmark inputs are skipped. Snapshot preprocessors (see
+        `set_snapshot_preprocess`) are applied; a raising preprocessor becomes a
+        visible, non-fatal `__shiny_snapshot_preprocess_error__` marker.
         """
         out: dict[str, Any] = {}
         with reactive.isolate():
@@ -2098,6 +2143,12 @@ class Inputs:
                     val = value()
                 except SilentException:
                     continue
+                preprocess = self._snapshot_preprocessors.get(key)
+                if preprocess is not None:
+                    try:
+                        val = await preprocess(val)
+                    except Exception as e:
+                        val = {"__shiny_snapshot_preprocess_error__": str(e)}
                 out[str(key)] = val
         return out
 

--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -1381,10 +1381,23 @@ class AppSession(Session):
 
                 if select_all or want["output"] is not None:
                     omq = self._outbound_message_queues
-                    outputs: dict[str, Any] = {
-                        str(key): _snapshot_safe_value(val)
-                        for key, val in omq.test_values.items()
-                    }
+                    outputs: dict[str, Any] = {}
+                    for key, val in omq.test_values.items():
+                        # Apply the renderer's snapshot preprocessor, if any.
+                        # (`_outputs` and `test_values` are both keyed by the
+                        # namespaced output name.)
+                        info = self.output._outputs.get(key)
+                        preprocess = (
+                            info.renderer._snapshot_preprocess_fn
+                            if info is not None
+                            else None
+                        )
+                        if preprocess is not None:
+                            try:
+                                val = await preprocess(val)
+                            except Exception as e:
+                                val = {"__shiny_snapshot_preprocess_error__": str(e)}
+                        outputs[str(key)] = _snapshot_safe_value(val)
                     for key, err in omq.test_errors.items():
                         if isinstance(err, dict):
                             message = cast("dict[str, Any]", err).get("message")

--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -612,7 +612,7 @@ class Session(ABC):
         """
         Register named values to include in the test-mode snapshot.
 
-        Internal implementation of the public `shiny.session.export_test_values()`
+        Internal implementation of the public `shiny.testmode.export_test_values()`
         function; call that instead of this method directly.
 
         Each value must be a zero-argument callable (a plain function/`lambda` or
@@ -630,7 +630,7 @@ class Session(ABC):
 
         See Also
         --------
-        * `shiny.session.export_test_values`
+        * `shiny.testmode.export_test_values`
         """
 
     @abstractmethod

--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -57,7 +57,6 @@ from ..bookmark._serializers import serializer_file_input
 from ..http_staticfiles import FileResponse
 from ..input_handler import input_handlers
 from ..module import ResolvedId
-from ..testmode import _snapshot_preprocess_file_input
 from ..otel._attributes import (
     extract_http_attributes,
     extract_source_ref,
@@ -74,6 +73,7 @@ from ..reactive import isolate
 from ..reactive._core import lock
 from ..reactive._core import on_flushed as reactive_on_flushed
 from ..render.renderer import Renderer, RendererT
+from ..testmode import _snapshot_preprocess_file_input
 from ..types import (
     Jsonifiable,
     SafeException,

--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -1389,7 +1389,10 @@ class AppSession(Session):
                 if select_all or want["output"] is not None:
                     omq = self._outbound_message_queues
                     outputs: dict[str, Any] = {}
-                    for key, val in omq.test_values.items():
+                    # Materialize the items: an async preprocessor may yield to
+                    # the event loop mid-iteration, during which a rendering
+                    # output can mutate `test_values`.
+                    for key, val in list(omq.test_values.items()):
                         # Apply the renderer's snapshot preprocessor, if any.
                         # (`_outputs` and `test_values` are both keyed by the
                         # namespaced output name.)
@@ -2075,7 +2078,7 @@ class Inputs:
             The ID of the input value.
         fn
             A function that takes the input value and returns a modified value. The
-            returned value will be used for test snapshots and bookmarking.
+            returned value will be used for bookmarking.
         """
         self._serializers[id] = wrap_async(fn)
 
@@ -2156,7 +2159,10 @@ class Inputs:
         """
         out: dict[str, Any] = {}
         with reactive.isolate():
-            for key, value in self._map.items():
+            # Materialize the items: an async preprocessor may yield to the
+            # event loop mid-iteration, during which the client can add new
+            # inputs to `_map`.
+            for key, value in list(self._map.items()):
                 if _is_internal_snapshot_input(str(key)):
                     continue
                 try:

--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -57,6 +57,7 @@ from ..bookmark._serializers import serializer_file_input
 from ..http_staticfiles import FileResponse
 from ..input_handler import input_handlers
 from ..module import ResolvedId
+from ..testmode import _snapshot_preprocess_file_input
 from ..otel._attributes import (
     extract_http_attributes,
     extract_source_ref,
@@ -1152,6 +1153,12 @@ class AppSession(Session):
 
             # This also occurs during input handler: shiny.file
             self.input.set_serializer(input_id, serializer_file_input)
+
+            # Like R's @uploadEnd: scrub the nondeterministic tempdir out of the
+            # value shown in test-mode snapshots.
+            self.input.set_snapshot_preprocess(
+                ResolvedId(input_id), _snapshot_preprocess_file_input
+            )
 
             # Explicitly return None to signal that the message was handled.
             return None

--- a/shiny/testmode.py
+++ b/shiny/testmode.py
@@ -99,6 +99,22 @@ def snapshot_preprocess_input(
     RuntimeError
         If there is no active session.
 
+    Examples
+    --------
+    ```python
+    from shiny import App, Inputs, Outputs, Session, ui
+    from shiny.testmode import snapshot_preprocess_input
+
+    app_ui = ui.page_fluid(ui.input_text("secret", "Secret", value="hunter2"))
+
+    def server(input: Inputs, output: Outputs, session: Session):
+        # Scrub the value shown in test-mode snapshots; the live input value
+        # is untouched. No effect unless `SHINY_TESTMODE=1` is set.
+        snapshot_preprocess_input("secret", lambda value: "<redacted>")
+
+    app = App(app_ui, server)
+    ```
+
     See Also
     --------
     * `shiny.testmode.snapshot_preprocess_output`
@@ -134,6 +150,28 @@ def snapshot_preprocess_output(
     ValueError
         If no output with `id` is registered on the session. Call this function
         after defining the output.
+
+    Examples
+    --------
+    ```python
+    from datetime import datetime
+
+    from shiny import App, Inputs, Outputs, Session, render, ui
+    from shiny.testmode import snapshot_preprocess_output
+
+    app_ui = ui.page_fluid(ui.output_text_verbatim("stamp"))
+
+    def server(input: Inputs, output: Outputs, session: Session):
+        @render.text
+        def stamp():
+            return f"time = {datetime.now().isoformat()}"
+
+        # Scrub the value shown in test-mode snapshots; the rendered output
+        # is untouched. No effect unless `SHINY_TESTMODE=1` is set.
+        snapshot_preprocess_output("stamp", lambda value: "time = <scrubbed>")
+
+    app = App(app_ui, server)
+    ```
 
     See Also
     --------

--- a/shiny/testmode.py
+++ b/shiny/testmode.py
@@ -1,10 +1,13 @@
-"""Test-mode value exporting (see `SHINY_TESTMODE`)."""
+"""Test-mode tools (see `SHINY_TESTMODE`)."""
 
 from __future__ import annotations
 
 from typing import Any, Callable
 
-from ._utils import require_active_session
+# Import from `shiny.session._utils` directly (not the `shiny.session` package
+# __init__): `shiny.session._session` imports from this module, so importing the
+# package here would be circular.
+from .session._utils import require_active_session
 
 __all__ = ("export_test_values",)
 
@@ -46,7 +49,7 @@ def export_test_values(**kwargs: Callable[[], Any]) -> None:
     --------
     ```python
     from shiny import App, Inputs, Outputs, Session, reactive, ui
-    from shiny.session import export_test_values
+    from shiny.testmode import export_test_values
 
     app_ui = ui.page_fluid(ui.input_slider("n", "n", 0, 100, 20))
 

--- a/shiny/testmode.py
+++ b/shiny/testmode.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, Awaitable, Callable
 
 # Import from `shiny.session._utils` directly (not the `shiny.session` package
@@ -147,3 +148,23 @@ def snapshot_preprocess_output(
             "Call `snapshot_preprocess_output()` after defining the output."
         )
     output_info.renderer.snapshot_preprocess(fn)
+
+
+def _snapshot_preprocess_file_input(value: Any) -> Any:
+    """
+    Scrub a file-input value for test-mode snapshots.
+
+    Replaces each uploaded file's `datapath` with its basename, since the
+    tempdir portion differs on every run (mirrors R's
+    `snapshotPreprocessorFileInput`). Auto-registered for file inputs on upload
+    and on bookmark restore. Non-list or malformed values pass through
+    unchanged.
+    """
+    if not isinstance(value, list):
+        return value
+    out: list[Any] = []
+    for file_info in value:
+        if isinstance(file_info, dict) and isinstance(file_info.get("datapath"), str):
+            file_info = {**file_info, "datapath": Path(file_info["datapath"]).name}
+        out.append(file_info)
+    return out

--- a/shiny/testmode.py
+++ b/shiny/testmode.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Awaitable, Callable
+from typing import Any, Awaitable, Callable, cast
 
 # Import from `shiny.session._utils` directly (not the `shiny.session` package
 # __init__): `shiny.session._session` imports from this module, so importing the
@@ -162,9 +162,13 @@ def _snapshot_preprocess_file_input(value: Any) -> Any:
     """
     if not isinstance(value, list):
         return value
+    files = cast("list[Any]", value)
     out: list[Any] = []
-    for file_info in value:
-        if isinstance(file_info, dict) and isinstance(file_info.get("datapath"), str):
-            file_info = {**file_info, "datapath": Path(file_info["datapath"]).name}
+    for file_info in files:
+        if isinstance(file_info, dict):
+            file_dict = cast("dict[str, Any]", file_info)
+            datapath = file_dict.get("datapath")
+            if isinstance(datapath, str):
+                file_info = {**file_dict, "datapath": Path(datapath).name}
         out.append(file_info)
     return out

--- a/shiny/testmode.py
+++ b/shiny/testmode.py
@@ -83,7 +83,7 @@ def snapshot_preprocess_input(
 
     Uses the current reactive session; equivalent to
     `session.input.set_snapshot_preprocess(id, fn)`. See
-    :meth:`~shiny.session.Inputs.set_snapshot_preprocess` for details. Inside a
+    `shiny.session.Inputs.set_snapshot_preprocess` for details. Inside a
     module, `id` is resolved in the module's namespace.
 
     Parameters
@@ -116,7 +116,7 @@ def snapshot_preprocess_output(
 
     Uses the current reactive session; equivalent to calling
     `.snapshot_preprocess(fn)` on the renderer object registered for `id`. See
-    :meth:`~shiny.render.renderer.Renderer.snapshot_preprocess` for details.
+    `shiny.render.renderer.Renderer.snapshot_preprocess` for details.
     Inside a module, `id` is resolved in the module's namespace.
 
     Parameters

--- a/shiny/testmode.py
+++ b/shiny/testmode.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable
+from typing import Any, Awaitable, Callable
 
 # Import from `shiny.session._utils` directly (not the `shiny.session` package
 # __init__): `shiny.session._session` imports from this module, so importing the
 # package here would be circular.
 from .session._utils import require_active_session
 
-__all__ = ("export_test_values",)
+__all__ = (
+    "export_test_values",
+    "snapshot_preprocess_input",
+    "snapshot_preprocess_output",
+)
 
 
 def export_test_values(**kwargs: Callable[[], Any]) -> None:
@@ -67,3 +71,79 @@ def export_test_values(**kwargs: Callable[[], Any]) -> None:
     """
     session = require_active_session(None)
     session._export_test_values(**kwargs)
+
+
+def snapshot_preprocess_input(
+    id: str,
+    fn: Callable[[Any], Any] | Callable[[Any], Awaitable[Any]],
+) -> None:
+    """
+    Set a function for preprocessing an input value in test-mode snapshots.
+
+    Uses the current reactive session; equivalent to
+    `session.input.set_snapshot_preprocess(id, fn)`. See
+    :meth:`~shiny.session.Inputs.set_snapshot_preprocess` for details. Inside a
+    module, `id` is resolved in the module's namespace.
+
+    Parameters
+    ----------
+    id
+        The ID of the input value.
+    fn
+        A function (synchronous or asynchronous) that takes the input value and
+        returns the value to write to the test snapshot.
+
+    Raises
+    ------
+    RuntimeError
+        If there is no active session.
+
+    See Also
+    --------
+    * `shiny.testmode.snapshot_preprocess_output`
+    """
+    session = require_active_session(None)
+    session.input.set_snapshot_preprocess(id, fn)
+
+
+def snapshot_preprocess_output(
+    id: str,
+    fn: Callable[[Any], Any] | Callable[[Any], Awaitable[Any]],
+) -> None:
+    """
+    Set a function for preprocessing an output value in test-mode snapshots.
+
+    Uses the current reactive session; equivalent to calling
+    `.snapshot_preprocess(fn)` on the renderer object registered for `id`. See
+    :meth:`~shiny.render.renderer.Renderer.snapshot_preprocess` for details.
+    Inside a module, `id` is resolved in the module's namespace.
+
+    Parameters
+    ----------
+    id
+        The ID of the output.
+    fn
+        A function (synchronous or asynchronous) that takes the output value
+        and returns the value to write to the test snapshot.
+
+    Raises
+    ------
+    RuntimeError
+        If there is no active session.
+    ValueError
+        If no output with `id` is registered on the session. Call this function
+        after defining the output.
+
+    See Also
+    --------
+    * `shiny.testmode.snapshot_preprocess_input`
+    """
+    session = require_active_session(None)
+    resolved_id = session.output._ns(id)
+    output_info = session.output._outputs.get(resolved_id)
+    if output_info is None:
+        raise ValueError(
+            f"No output named {id!r} is registered on this session. "
+            "Call `snapshot_preprocess_output()` after defining the output."
+        )
+    output_info.renderer.snapshot_preprocess(fn)

--- a/shiny/testmode.py
+++ b/shiny/testmode.py
@@ -13,7 +13,6 @@ from .session._utils import require_active_session
 __all__ = (
     "export_test_values",
     "snapshot_preprocess_input",
-    "snapshot_preprocess_output",
 )
 
 
@@ -117,75 +116,19 @@ def snapshot_preprocess_input(
 
     See Also
     --------
-    * `shiny.testmode.snapshot_preprocess_output`
+    * `shiny.render.renderer.Renderer.snapshot_preprocess`
     """
     session = require_active_session(None)
     session.input.set_snapshot_preprocess(id, fn)
 
 
-def snapshot_preprocess_output(
-    id: str,
-    fn: Callable[[Any], Any] | Callable[[Any], Awaitable[Any]],
-) -> None:
-    """
-    Set a function for preprocessing an output value in test-mode snapshots.
-
-    Uses the current reactive session; equivalent to calling
-    `.snapshot_preprocess(fn)` on the renderer object registered for `id`. See
-    `shiny.render.renderer.Renderer.snapshot_preprocess` for details.
-    Inside a module, `id` is resolved in the module's namespace.
-
-    Parameters
-    ----------
-    id
-        The ID of the output.
-    fn
-        A function (synchronous or asynchronous) that takes the output value
-        and returns the value to write to the test snapshot.
-
-    Raises
-    ------
-    RuntimeError
-        If there is no active session.
-    ValueError
-        If no output with `id` is registered on the session. Call this function
-        after defining the output.
-
-    Examples
-    --------
-    ```python
-    from datetime import datetime
-
-    from shiny import App, Inputs, Outputs, Session, render, ui
-    from shiny.testmode import snapshot_preprocess_output
-
-    app_ui = ui.page_fluid(ui.output_text_verbatim("stamp"))
-
-    def server(input: Inputs, output: Outputs, session: Session):
-        @render.text
-        def stamp():
-            return f"time = {datetime.now().isoformat()}"
-
-        # Scrub the value shown in test-mode snapshots; the rendered output
-        # is untouched. No effect unless `SHINY_TESTMODE=1` is set.
-        snapshot_preprocess_output("stamp", lambda value: "time = <scrubbed>")
-
-    app = App(app_ui, server)
-    ```
-
-    See Also
-    --------
-    * `shiny.testmode.snapshot_preprocess_input`
-    """
-    session = require_active_session(None)
-    resolved_id = session.output._ns(id)
-    output_info = session.output._outputs.get(resolved_id)
-    if output_info is None:
-        raise ValueError(
-            f"No output named {id!r} is registered on this session. "
-            "Call `snapshot_preprocess_output()` after defining the output."
-        )
-    output_info.renderer.snapshot_preprocess(fn)
+# NOTE: There is deliberately no `snapshot_preprocess_output(id, fn)` free function
+# (the analog of R's `snapshotPreprocessOutput`). Output preprocessors belong to the
+# renderer object itself: call `my_output.snapshot_preprocess(fn)` on the
+# `@render.*` object. An id-keyed free function would have to look up the
+# registered renderer on the current session, which only works after the output is
+# registered (order-dependent) and duplicates the method with worse ergonomics.
+# Inputs have no author-side object to attach to, hence the free function above.
 
 
 def _snapshot_preprocess_file_input(value: Any) -> Any:

--- a/tests/playwright/shiny/test_mode/app.py
+++ b/tests/playwright/shiny/test_mode/app.py
@@ -1,14 +1,21 @@
+from datetime import datetime
+
 from shiny import App, Inputs, Outputs, Session, reactive, render, ui
 from shiny.testmode import export_test_values
 
 app_ui = ui.page_fluid(
     ui.input_text("name", "Name", value="abc"),
+    ui.input_text("secret", "Secret", value="hunter2"),
     ui.input_slider("n", "N", min=0, max=100, value=20),
     ui.output_text_verbatim("double_txt"),
+    ui.output_text_verbatim("stamp"),
 )
 
 
 def server(input: Inputs, output: Outputs, session: Session):
+    # Scrub a sensitive input out of the test-mode snapshot.
+    input.set_snapshot_preprocess("secret", lambda value: "<redacted>")
+
     @reactive.calc
     def doubled() -> int:
         return int(input.n()) * 2
@@ -16,6 +23,13 @@ def server(input: Inputs, output: Outputs, session: Session):
     @render.text
     def double_txt() -> str:
         return f"doubled = {doubled()}"
+
+    @render.text
+    def stamp() -> str:
+        return f"time = {datetime.now().isoformat()}"
+
+    # Scrub the nondeterministic timestamp out of the test-mode snapshot.
+    stamp.snapshot_preprocess(lambda value: "time = <scrubbed>")
 
     # Surface an internal reactive value in the test-mode snapshot.
     export_test_values(doubled=doubled)

--- a/tests/playwright/shiny/test_mode/app.py
+++ b/tests/playwright/shiny/test_mode/app.py
@@ -1,5 +1,5 @@
 from shiny import App, Inputs, Outputs, Session, reactive, render, ui
-from shiny.session import export_test_values
+from shiny.testmode import export_test_values
 
 app_ui = ui.page_fluid(
     ui.input_text("name", "Name", value="abc"),

--- a/tests/playwright/shiny/test_mode/test_app_test_values.py
+++ b/tests/playwright/shiny/test_mode/test_app_test_values.py
@@ -18,6 +18,12 @@ def test_app_test_values(page: Page, local_app: ShinyAppProc) -> None:
     app_values.expect_output("double_txt", "doubled = 40")
     app_values.expect_export("doubled", 40)
 
+    # Snapshot preprocessing: the live input keeps its real value while the
+    # snapshot shows the scrubbed one; same for the timestamp output.
+    controller.InputText(page, "secret").expect_value("hunter2")
+    app_values.expect_input("secret", "<redacted>")
+    app_values.expect_output("stamp", "time = <scrubbed>")
+
     # Raw snapshot shape.
     data = app_values.get()
     assert set(data.keys()) == {"input", "output", "export"}

--- a/tests/pytest/test_test_mode.py
+++ b/tests/pytest/test_test_mode.py
@@ -223,7 +223,8 @@ def test_is_internal_snapshot_input() -> None:
     assert _is_internal_snapshot_input("x") is False
 
 
-def test_serialize_test_mode_collects_and_skips() -> None:
+@pytest.mark.asyncio
+async def test_serialize_test_mode_collects_and_skips() -> None:
     from shiny.session._session import Inputs
 
     inputs = Inputs(dict())
@@ -231,7 +232,7 @@ def test_serialize_test_mode_collects_and_skips() -> None:
     inputs["name"] = reactive.Value("hi")
     inputs[".clientdata_output_x_hidden"] = reactive.Value(True)
 
-    result = inputs._serialize_test_mode()
+    result = await inputs._serialize_test_mode()
     assert result == {"x": 5, "name": "hi"}
 
 
@@ -570,3 +571,105 @@ def test_export_test_values_relocated() -> None:
 
     assert not hasattr(shiny.session, "export_test_values")
     assert "export_test_values" not in shiny.session.__all__
+
+
+@pytest.mark.asyncio
+async def test_input_snapshot_preprocess_applied(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SHINY_TESTMODE", "1")
+    session = _make_app_session()
+    session.input["t"] = reactive.Value("2026-07-02 12:34:56")
+    session.input["x"] = reactive.Value(10)
+
+    # Sync preprocessor
+    session.input.set_snapshot_preprocess("t", lambda value: "<time>")
+
+    # Async preprocessor
+    async def double(value: int) -> int:
+        return value * 2
+
+    session.input.set_snapshot_preprocess("x", double)
+
+    resp = cast(
+        Response,
+        await session._handle_request_impl(_snapshot_request(), "dataobj", "shinytest"),
+    )
+    import orjson
+
+    body = orjson.loads(resp.body)
+    assert body["input"]["t"] == "<time>"
+    assert body["input"]["x"] == 20
+
+
+@pytest.mark.asyncio
+async def test_input_snapshot_preprocess_namespaced(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SHINY_TESTMODE", "1")
+    session = _make_app_session()
+    from shiny._namespaces import ResolvedId
+
+    session.input[ResolvedId("mod1-y")] = reactive.Value(1)
+
+    # Registering through a module proxy namespaces the id and shares storage
+    # with the root session's Inputs.
+    proxy = session.make_scope("mod1")
+    proxy.input.set_snapshot_preprocess("y", lambda value: value + 100)
+
+    resp = cast(
+        Response,
+        await session._handle_request_impl(_snapshot_request(), "dataobj", "shinytest"),
+    )
+    import orjson
+
+    body = orjson.loads(resp.body)
+    assert body["input"]["mod1-y"] == 101
+
+
+@pytest.mark.asyncio
+async def test_input_snapshot_preprocess_error_marker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SHINY_TESTMODE", "1")
+    session = _make_app_session()
+    session.input["bad"] = reactive.Value(1)
+    session.input["ok"] = reactive.Value(2)
+
+    def boom(value: int) -> int:
+        raise RuntimeError("boom")
+
+    session.input.set_snapshot_preprocess("bad", boom)
+
+    resp = cast(
+        Response,
+        await session._handle_request_impl(_snapshot_request(), "dataobj", "shinytest"),
+    )
+    import orjson
+
+    body = orjson.loads(resp.body)
+    # A raising preprocessor becomes a visible, non-fatal marker; other keys
+    # are unaffected.
+    assert body["input"]["bad"] == {"__shiny_snapshot_preprocess_error__": "boom"}
+    assert body["input"]["ok"] == 2
+
+
+@pytest.mark.asyncio
+async def test_input_snapshot_preprocess_reregister_overwrites(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SHINY_TESTMODE", "1")
+    session = _make_app_session()
+    session.input["x"] = reactive.Value(1)
+
+    session.input.set_snapshot_preprocess("x", lambda value: "first")
+    session.input.set_snapshot_preprocess("x", lambda value: "second")
+
+    resp = cast(
+        Response,
+        await session._handle_request_impl(_snapshot_request(), "dataobj", "shinytest"),
+    )
+    import orjson
+
+    body = orjson.loads(resp.body)
+    assert body["input"]["x"] == "second"

--- a/tests/pytest/test_test_mode.py
+++ b/tests/pytest/test_test_mode.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+from types import SimpleNamespace
 from typing import cast
 
 import pytest
@@ -883,3 +885,74 @@ async def test_upload_end_auto_registers_file_scrub(
     assert body["input"]["file1"] == [
         {"name": "a.txt", "size": 1, "type": "text/plain", "datapath": "a.txt"}
     ]
+
+
+@pytest.mark.asyncio
+async def test_snapshot_preprocess_output_namespaced(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SHINY_TESTMODE", "1")
+    session = _make_app_session()
+    proxy = session.make_scope("mod1")
+
+    from shiny import render
+    from shiny.testmode import snapshot_preprocess_output
+
+    @render.text
+    def out1() -> str:
+        return "unused"
+
+    # Register through the module proxy: the output lands under the
+    # namespaced name, and the free function resolves the plain id against
+    # the proxy's namespace.
+    proxy.output(out1)
+    session._outbound_message_queues.set_value("mod1-out1", "hello")
+
+    with session_context(proxy):
+        snapshot_preprocess_output("out1", lambda value: value.upper())
+
+    resp = cast(
+        Response,
+        await session._handle_request_impl(_snapshot_request(), "dataobj", "shinytest"),
+    )
+    import orjson
+
+    body = orjson.loads(resp.body)
+    assert body["output"]["mod1-out1"] == "HELLO"
+
+
+def test_file_restore_handler_registers_snapshot_preprocess(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    # The `shiny.file` input handler (bookmark restore) must register the same
+    # datapath scrubber as `uploadEnd`.
+    import shiny.bookmark._restore_state
+    import shiny.input_handler
+    from shiny._namespaces import ResolvedId
+
+    monkeypatch.setenv("SHINY_TESTMODE", "1")
+    session = _make_app_session()
+
+    (tmp_path / "a.txt").write_text("hello")
+
+    monkeypatch.setattr(
+        shiny.input_handler, "can_serialize_input_file", lambda session: True
+    )
+    monkeypatch.setattr(
+        shiny.bookmark._restore_state,
+        "get_current_restore_context",
+        lambda: SimpleNamespace(dir=str(tmp_path)),
+    )
+
+    handler = shiny.input_handler.input_handlers["shiny.file"]
+    value = {
+        "name": ["a.txt"],
+        "size": [5],
+        "type": ["text/plain"],
+        "datapath": ["a.txt"],
+    }
+    restored = handler(value, ResolvedId("file1"), session)
+
+    assert isinstance(restored, list) and len(restored) == 1
+    assert ResolvedId("file1") in session.input._snapshot_preprocessors

--- a/tests/pytest/test_test_mode.py
+++ b/tests/pytest/test_test_mode.py
@@ -11,7 +11,7 @@ from starlette.responses import Response
 from shiny import App, reactive, ui
 from shiny._connection import MockConnection
 from shiny._utils import is_test_mode
-from shiny.session import export_test_values
+from shiny.testmode import export_test_values
 from shiny.session._session import AppSession, OutBoundMessageQueues
 from shiny.session._utils import (
     session_context,
@@ -561,3 +561,12 @@ async def test_snapshot_endpoint_sortc_param(
         ),
     )
     assert bad.status_code == 400
+
+
+def test_export_test_values_relocated() -> None:
+    # `export_test_values` lives in `shiny.testmode`; the pre-release
+    # `shiny.session` location is gone (PR #2270 was never released).
+    import shiny.session
+
+    assert not hasattr(shiny.session, "export_test_values")
+    assert "export_test_values" not in shiny.session.__all__

--- a/tests/pytest/test_test_mode.py
+++ b/tests/pytest/test_test_mode.py
@@ -763,3 +763,58 @@ async def test_output_snapshot_preprocess_error_marker_and_bypass(
     body = orjson.loads(resp.body)
     assert body["output"]["bad"] == {"__shiny_snapshot_preprocess_error__": "boom"}
     assert body["output"]["errored"] == {"__shiny_output_error__": "kaput"}
+
+
+@pytest.mark.asyncio
+async def test_snapshot_preprocess_free_functions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SHINY_TESTMODE", "1")
+    session = _make_app_session()
+    session.input["x"] = reactive.Value(1)
+
+    from shiny import render
+    from shiny.testmode import snapshot_preprocess_input, snapshot_preprocess_output
+
+    @render.text
+    def out1() -> str:
+        return "unused"
+
+    session.output(out1)
+    session._outbound_message_queues.set_value("out1", "hello")
+
+    with session_context(session):
+        snapshot_preprocess_input("x", lambda value: value + 1)
+        snapshot_preprocess_output("out1", lambda value: value.upper())
+
+    resp = cast(
+        Response,
+        await session._handle_request_impl(_snapshot_request(), "dataobj", "shinytest"),
+    )
+    import orjson
+
+    body = orjson.loads(resp.body)
+    assert body["input"]["x"] == 2
+    assert body["output"]["out1"] == "HELLO"
+
+
+def test_snapshot_preprocess_output_unregistered_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SHINY_TESTMODE", "1")
+    session = _make_app_session()
+
+    from shiny.testmode import snapshot_preprocess_output
+
+    with session_context(session):
+        with pytest.raises(ValueError, match="No output named 'nope'"):
+            snapshot_preprocess_output("nope", lambda value: value)
+
+
+def test_snapshot_preprocess_free_functions_require_session() -> None:
+    from shiny.testmode import snapshot_preprocess_input, snapshot_preprocess_output
+
+    with pytest.raises(RuntimeError):
+        snapshot_preprocess_input("x", lambda value: value)
+    with pytest.raises(RuntimeError):
+        snapshot_preprocess_output("x", lambda value: value)

--- a/tests/pytest/test_test_mode.py
+++ b/tests/pytest/test_test_mode.py
@@ -11,11 +11,11 @@ from starlette.responses import Response
 from shiny import App, reactive, ui
 from shiny._connection import MockConnection
 from shiny._utils import is_test_mode
-from shiny.testmode import export_test_values
 from shiny.session._session import AppSession, OutBoundMessageQueues
 from shiny.session._utils import (
     session_context,
 )
+from shiny.testmode import export_test_values
 
 
 def test_is_test_mode_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/pytest/test_test_mode.py
+++ b/tests/pytest/test_test_mode.py
@@ -768,26 +768,17 @@ async def test_output_snapshot_preprocess_error_marker_and_bypass(
 
 
 @pytest.mark.asyncio
-async def test_snapshot_preprocess_free_functions(
+async def test_snapshot_preprocess_input_free_function(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("SHINY_TESTMODE", "1")
     session = _make_app_session()
     session.input["x"] = reactive.Value(1)
 
-    from shiny import render
-    from shiny.testmode import snapshot_preprocess_input, snapshot_preprocess_output
-
-    @render.text
-    def out1() -> str:
-        return "unused"
-
-    session.output(out1)
-    session._outbound_message_queues.set_value("out1", "hello")
+    from shiny.testmode import snapshot_preprocess_input
 
     with session_context(session):
         snapshot_preprocess_input("x", lambda value: value + 1)
-        snapshot_preprocess_output("out1", lambda value: value.upper())
 
     resp = cast(
         Response,
@@ -797,29 +788,22 @@ async def test_snapshot_preprocess_free_functions(
 
     body = orjson.loads(resp.body)
     assert body["input"]["x"] == 2
-    assert body["output"]["out1"] == "HELLO"
 
 
-def test_snapshot_preprocess_output_unregistered_raises(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("SHINY_TESTMODE", "1")
-    session = _make_app_session()
-
-    from shiny.testmode import snapshot_preprocess_output
-
-    with session_context(session):
-        with pytest.raises(ValueError, match="No output named 'nope'"):
-            snapshot_preprocess_output("nope", lambda value: value)
-
-
-def test_snapshot_preprocess_free_functions_require_session() -> None:
-    from shiny.testmode import snapshot_preprocess_input, snapshot_preprocess_output
+def test_snapshot_preprocess_input_free_function_requires_session() -> None:
+    from shiny.testmode import snapshot_preprocess_input
 
     with pytest.raises(RuntimeError):
         snapshot_preprocess_input("x", lambda value: value)
-    with pytest.raises(RuntimeError):
-        snapshot_preprocess_output("x", lambda value: value)
+
+
+def test_no_snapshot_preprocess_output_free_function() -> None:
+    # Deliberate API decision: output preprocessors attach to the renderer
+    # object (`my_output.snapshot_preprocess(fn)`); there is no id-keyed free
+    # function. See the NOTE in shiny/testmode.py.
+    import shiny.testmode
+
+    assert not hasattr(shiny.testmode, "snapshot_preprocess_output")
 
 
 def test_snapshot_preprocess_file_input_helper() -> None:
@@ -899,20 +883,18 @@ async def test_snapshot_preprocess_output_namespaced(
     proxy = session.make_scope("mod1")
 
     from shiny import render
-    from shiny.testmode import snapshot_preprocess_output
 
     @render.text
     def out1() -> str:
         return "unused"
 
     # Register through the module proxy: the output lands under the
-    # namespaced name, and the free function resolves the plain id against
-    # the proxy's namespace.
+    # namespaced name, and the renderer-attached preprocessor is found via
+    # the shared `_outputs` registry.
     proxy.output(out1)
     session._outbound_message_queues.set_value("mod1-out1", "hello")
 
-    with session_context(proxy):
-        snapshot_preprocess_output("out1", lambda value: value.upper())
+    out1.snapshot_preprocess(lambda value: value.upper())
 
     resp = cast(
         Response,

--- a/tests/pytest/test_test_mode.py
+++ b/tests/pytest/test_test_mode.py
@@ -818,3 +818,68 @@ def test_snapshot_preprocess_free_functions_require_session() -> None:
         snapshot_preprocess_input("x", lambda value: value)
     with pytest.raises(RuntimeError):
         snapshot_preprocess_output("x", lambda value: value)
+
+
+def test_snapshot_preprocess_file_input_helper() -> None:
+    from shiny.testmode import _snapshot_preprocess_file_input
+
+    value = [
+        {
+            "name": "a.txt",
+            "size": 1,
+            "type": "text/plain",
+            "datapath": "/tmp/xyz123/a.txt",
+        },
+        {"name": "b.txt", "size": 2, "type": "text/plain", "datapath": "b.txt"},
+    ]
+    scrubbed = _snapshot_preprocess_file_input(value)
+    assert [f["datapath"] for f in scrubbed] == ["a.txt", "b.txt"]
+    # Original value is not mutated.
+    assert value[0]["datapath"] == "/tmp/xyz123/a.txt"
+
+    # Non-list / malformed values pass through unchanged.
+    assert _snapshot_preprocess_file_input(None) is None
+    assert _snapshot_preprocess_file_input("x") == "x"
+    assert _snapshot_preprocess_file_input([{"name": "no-path"}]) == [
+        {"name": "no-path"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_upload_end_auto_registers_file_scrub(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SHINY_TESTMODE", "1")
+    session = _make_app_session()
+
+    class FakeOp:
+        def finish(self) -> list[dict[str, object]]:
+            return [
+                {
+                    "name": "a.txt",
+                    "size": 1,
+                    "type": "text/plain",
+                    "datapath": "/tmp/xyz123/a.txt",
+                }
+            ]
+
+    monkeypatch.setattr(
+        session._file_upload_manager,
+        "get_upload_operation",
+        lambda job_id: FakeOp(),
+    )
+    handler, _ = session._message_handlers["uploadEnd"]
+    await handler("job1", "file1")
+
+    resp = cast(
+        Response,
+        await session._handle_request_impl(_snapshot_request(), "dataobj", "shinytest"),
+    )
+    import orjson
+
+    body = orjson.loads(resp.body)
+    # The live input value keeps the real tempdir path; only the snapshot is
+    # scrubbed to the basename (matching R's snapshotPreprocessorFileInput).
+    assert body["input"]["file1"] == [
+        {"name": "a.txt", "size": 1, "type": "text/plain", "datapath": "a.txt"}
+    ]

--- a/tests/pytest/test_test_mode.py
+++ b/tests/pytest/test_test_mode.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import SimpleNamespace
-from typing import cast
+from typing import Any, cast
 
 import pytest
 from starlette.requests import Request
@@ -958,7 +958,7 @@ def test_file_restore_handler_registers_snapshot_preprocess(
         "type": ["text/plain"],
         "datapath": ["a.txt"],
     }
-    restored = handler(value, ResolvedId("file1"), session)
+    restored = cast("list[Any]", handler(value, ResolvedId("file1"), session))
 
     assert isinstance(restored, list) and len(restored) == 1
     assert ResolvedId("file1") in session.input._snapshot_preprocessors

--- a/tests/pytest/test_test_mode.py
+++ b/tests/pytest/test_test_mode.py
@@ -865,10 +865,13 @@ async def test_upload_end_auto_registers_file_scrub(
                 }
             ]
 
+    def fake_get_upload_operation(job_id: str) -> FakeOp:
+        return FakeOp()
+
     monkeypatch.setattr(
         session._file_upload_manager,
         "get_upload_operation",
-        lambda job_id: FakeOp(),
+        fake_get_upload_operation,
     )
     handler, _ = session._message_handlers["uploadEnd"]
     await handler("job1", "file1")
@@ -936,8 +939,11 @@ def test_file_restore_handler_registers_snapshot_preprocess(
 
     (tmp_path / "a.txt").write_text("hello")
 
+    def fake_can_serialize_input_file(session: object) -> bool:
+        return True
+
     monkeypatch.setattr(
-        shiny.input_handler, "can_serialize_input_file", lambda session: True
+        shiny.input_handler, "can_serialize_input_file", fake_can_serialize_input_file
     )
     monkeypatch.setattr(
         shiny.bookmark._restore_state,

--- a/tests/pytest/test_test_mode.py
+++ b/tests/pytest/test_test_mode.py
@@ -673,3 +673,93 @@ async def test_input_snapshot_preprocess_reregister_overwrites(
 
     body = orjson.loads(resp.body)
     assert body["input"]["x"] == "second"
+
+
+@pytest.mark.asyncio
+async def test_output_snapshot_preprocess_applied(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SHINY_TESTMODE", "1")
+    session = _make_app_session()
+
+    from shiny import render
+
+    @render.text
+    def out1() -> str:
+        return "unused"
+
+    session.output(out1)
+
+    # Sync preprocessor; simulate the output having rendered.
+    out1.snapshot_preprocess(lambda value: "<scrubbed>")
+    session._outbound_message_queues.set_value("out1", "the time is 12:34")
+
+    @render.text
+    def out2() -> str:
+        return "unused"
+
+    session.output(out2)
+
+    # Async preprocessor
+    async def shout(value: str) -> str:
+        return value.upper()
+
+    out2.snapshot_preprocess(shout)
+    session._outbound_message_queues.set_value("out2", "hello")
+
+    # An output with no preprocessor passes through unchanged, as does a
+    # recorded value with no registered renderer at all.
+    session._outbound_message_queues.set_value("out3", "raw")
+
+    resp = cast(
+        Response,
+        await session._handle_request_impl(_snapshot_request(), "dataobj", "shinytest"),
+    )
+    import orjson
+
+    body = orjson.loads(resp.body)
+    assert body["output"]["out1"] == "<scrubbed>"
+    assert body["output"]["out2"] == "HELLO"
+    assert body["output"]["out3"] == "raw"
+
+
+@pytest.mark.asyncio
+async def test_output_snapshot_preprocess_error_marker_and_bypass(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SHINY_TESTMODE", "1")
+    session = _make_app_session()
+
+    from shiny import render
+
+    @render.text
+    def bad() -> str:
+        return "unused"
+
+    session.output(bad)
+
+    def boom(value: str) -> str:
+        raise RuntimeError("boom")
+
+    bad.snapshot_preprocess(boom)
+    session._outbound_message_queues.set_value("bad", "value")
+
+    # Errored outputs keep their error marker; the preprocessor must NOT run
+    # on them.
+    @render.text
+    def errored() -> str:
+        return "unused"
+
+    session.output(errored)
+    errored.snapshot_preprocess(lambda value: "SHOULD NOT APPEAR")
+    session._outbound_message_queues.set_error("errored", {"message": "kaput"})
+
+    resp = cast(
+        Response,
+        await session._handle_request_impl(_snapshot_request(), "dataobj", "shinytest"),
+    )
+    import orjson
+
+    body = orjson.loads(resp.body)
+    assert body["output"]["bad"] == {"__shiny_snapshot_preprocess_error__": "boom"}
+    assert body["output"]["errored"] == {"__shiny_output_error__": "kaput"}


### PR DESCRIPTION
Closes #2282. Part of #2269; **stacked on #2270** — merge that first. This diff is only the commits on top of it, and GitHub will retarget to `main` automatically once #2270 merges.

## Summary

Shiny for R lets app authors register per-value transforms that run before a value is written to the test snapshot (`snapshotPreprocessInput`, `snapshotPreprocessOutput`). These are essential for scrubbing non-deterministic values (timestamps, temp paths, random ids, session tokens) so snapshots diff cleanly across runs. This PR adds the py-shiny equivalent on top of #2270's test mode.

### API

- **Inputs — `input.set_snapshot_preprocess(id, fn)`**, a method on `Inputs` beside `set_serializer` (its bookmarking analog). Ids resolve through the bound namespace, so module usage just works; the preprocessor store is shared between the root session and module proxies. Also available as the free function `shiny.testmode.snapshot_preprocess_input(id, fn)` (R-parity name) using the current session.
- **Outputs — `my_output.snapshot_preprocess(fn)`**, a method on `Renderer`. R attaches the preprocessor to the render function; the py equivalent is a method on the renderer object. It is read at snapshot time via `OutputInfo.renderer`, so call order relative to registration never matters. Output error markers (`__shiny_output_error__`) bypass preprocessing. There is deliberately **no** `snapshot_preprocess_output(id, fn)` free function: it would be order-dependent (the output must already be registered) and duplicates the method with worse ergonomics — a NOTE in `shiny/testmode.py` records this.
- **New `shiny.testmode` module** housing the app-side test-mode API (parallel to `shiny.bookmark`): `export_test_values()` **relocated** here from `shiny.session` (no shim — #2270 is unreleased), plus `snapshot_preprocess_input()`.

### Behavior

- Preprocessors may be **sync or async** (`wrap_async`, same pattern as bookmark serializers); `Inputs._serialize_test_mode()` and `AppSession._handle_test_snapshot()` became async to await them. Both loops iterate materialized copies so a genuinely-async preprocessor yielding mid-iteration can't hit `dictionary changed size during iteration` if the client concurrently updates inputs/outputs.
- A raising preprocessor becomes a visible, non-fatal `{"__shiny_snapshot_preprocess_error__": str(e)}` marker in the snapshot — same philosophy as #2270's `__shiny_serialization_error__`.
- Registration is always harmless when test mode is off (the snapshot endpoint 404s), so calls can be left in production code. Re-registering overwrites.
- **File inputs are auto-scrubbed** like R (`snapshotPreprocessorFileInput`): each file's `datapath` is reduced to its basename, registered in the `uploadEnd` message handler and the `shiny.file` bookmark-restore input handler — the same two sites that register `serializer_file_input`.

### Intentional deviations / scope

- Output preprocessors attach to the renderer object rather than R's function-attribute mechanism (py renderers are objects; same spirit, better ergonomics), and correspondingly there is no output free function.
- Module-namespaced ids for both blocks, consistent with #2270's export-name namespacing deviation.
- Not included (matching R or deferred): preprocessing the `export` block, `snapshotExclude`, and a decorator form for outputs.

### Docs

- New **"Test mode"** section in the core API reference (`docs/_quartodoc-core.yml`) gathering `export_test_values`, `snapshot_preprocess_input`, `Inputs.set_snapshot_preprocess`, and `Session.get_test_snapshot_url` (pattern follows the Bookmarking section).
- Docstring example for the new free function; CHANGELOG entry.

## Test Plan

- [x] New unit tests in `tests/pytest/test_test_mode.py` (48 total pass): sync + async preprocessors for both blocks; module namespacing for both blocks; error markers; error-marker bypass for errored outputs; re-registration; file auto-scrub via both the `uploadEnd` and bookmark-restore registration sites; input free-function delegation and no-active-session error; a guard test asserting `snapshot_preprocess_output` does not exist; relocation of `export_test_values`.
- [x] E2E: `tests/playwright/shiny/test_mode/` extended with a preprocessed input (`<redacted>`) and output (scrubbed timestamp), asserted via the `AppTestValues` controller alongside the live (unscrubbed) DOM values.
- [x] Full unit suite, black/isort/flake8, and pyright clean; local quartodoc build of the core reference succeeds; CI green across all jobs.