### PR TITLE
fix(tests): Retry WebKit navigation swallowed by about:blank reset

### DIFF
--- a/tests/playwright/conftest.py
+++ b/tests/playwright/conftest.py
@@ -2,12 +2,14 @@
 # such as examples/example_apps.py
 from __future__ import annotations
 
+import logging
 import os
+import typing
 from inspect import signature
 from pathlib import PurePath
 
 import pytest
-from playwright.sync_api import BrowserContext, BrowserType, Page
+from playwright.sync_api import BrowserContext, BrowserType, Page, Response
 
 from shiny.pytest import ScopeName as ScopeName
 from shiny.pytest import create_app_fixture
@@ -35,7 +37,26 @@ def session_page(browser: BrowserContext) -> Page:
     Returns:
         Page: The newly created page.
     """
-    return browser.new_page()
+    page = browser.new_page()
+    original_goto = page.goto
+
+    def goto_and_verify_commit(url: str, **kwargs: typing.Any) -> Response | None:
+        # WebKit occasionally swallows a navigation issued right after the
+        # `about:blank` reset performed by the function-scoped `page` fixture:
+        # `goto()` returns normally but the page never leaves `about:blank`,
+        # so every subsequent locator wait times out. When that happens,
+        # retry the navigation once.
+        response = original_goto(url, **kwargs)
+        if url != "about:blank" and page.url == "about:blank":
+            logging.warning(
+                "Navigation to %s did not commit (page still on about:blank); retrying one time",
+                url,
+            )
+            response = original_goto(url, **kwargs)
+        return response
+
+    page.goto = goto_and_verify_commit  # pyright: ignore[reportAttributeAccessIssue]
+    return page
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
## Why

`test_input_action_task_button[webkit]` flaked in CI ([failing job](https://github.com/posit-dev/py-shiny/actions/runs/28617843861/job/84865962399)) with `element(s) not found` for `#mod1-text_counter` — a *static* element in the app page — and the pytest traceback shows the page was still at `about:blank` when the 5s expect timed out. So `page.goto(local_app.url)` returned without the navigation ever committing.

The playwright suite reuses a single session-scoped page that is reset with `goto("about:blank")` between tests, and WebKit occasionally swallows the very next navigation. Any test's opening `page.goto(...)` can hit this, so per-test hardening (e.g., a longer timeout) can't help: the page never navigates at all.

## What

In `tests/playwright/conftest.py`, the `session_page` fixture now wraps `page.goto()`: if a navigation to a real URL returns while the page is still on `about:blank`, it logs a warning and retries the navigation one time. The guard can't false-positive on redirects or bookmark-style URL rewrites, since any committed navigation leaves `about:blank`. The warning makes future occurrences visible in CI logs.

## Verification

- Synthetic test of the retry path (first `goto` forced to no-op on webkit): the wrapper detects the stuck page, retries, and lands on the target URL.
- `input_task_button2` plus the bookmark-module tests (query-string navigation — the riskiest case for a retry guard) pass 3x each on webkit and chromium locally.
- `black`, `isort`, and `pyright` clean on the changed file.