### PR TITLE
fix(tests): Replace shared Playwright page when navigation wedges

### DIFF
--- a/tests/playwright/conftest.py
+++ b/tests/playwright/conftest.py
@@ -26,18 +26,21 @@ here = PurePath(__file__).parent
 here_root = here.parent.parent
 
 
-# Make a single page fixture that can be used by all tests
-@pytest.fixture(scope="session")
-# By using a single page, the browser is only launched once and all tests run in the same tab / page.
-def session_page(browser: BrowserContext) -> Page:
+# Attribute set on a Page once it can no longer navigate (e.g. its WebKit web
+# process crashed). The `page` fixture replaces a page marked this way.
+_NAVIGATION_WEDGED_ATTR = "_shiny_navigation_wedged"
+
+
+def _new_session_page(browser: BrowserContext) -> Page:
     """
-    Create a new page within the given browser context.
+    Create a shared page whose `goto()` verifies the navigation committed.
     Parameters:
         browser (BrowserContext): The browser context in which to create the new page.
     Returns:
         Page: The newly created page.
     """
     page = browser.new_page()
+    page.on("crash", lambda page: setattr(page, _NAVIGATION_WEDGED_ATTR, True))
     original_goto = page.goto
 
     def goto_and_verify_commit(url: str, **kwargs: typing.Any) -> Response | None:
@@ -45,7 +48,10 @@ def session_page(browser: BrowserContext) -> Page:
         # `about:blank` reset performed by the function-scoped `page` fixture:
         # `goto()` returns normally but the page never leaves `about:blank`,
         # so every subsequent locator wait times out. When that happens,
-        # retry the navigation once.
+        # retry the navigation once. If the retry is also swallowed, the page
+        # is wedged and no future navigation will commit either, so mark it
+        # for replacement and fail fast; a flaky rerun then gets a fresh page
+        # instead of timing out on the same broken one.
         response = original_goto(url, **kwargs)
         if url != "about:blank" and page.url == "about:blank":
             logging.warning(
@@ -53,26 +59,68 @@ def session_page(browser: BrowserContext) -> Page:
                 url,
             )
             response = original_goto(url, **kwargs)
+            if page.url == "about:blank":
+                setattr(page, _NAVIGATION_WEDGED_ATTR, True)
+                raise RuntimeError(
+                    f"Navigation to {url} did not commit after retry; "
+                    "the shared page will be replaced on the next test attempt"
+                )
         return response
 
     page.goto = goto_and_verify_commit  # pyright: ignore[reportAttributeAccessIssue]
     return page
 
 
+@pytest.fixture(scope="session")
+def _session_page_holder() -> list[Page]:
+    """
+    Session-scoped holder for the shared page.
+    By using a single page, the browser is only launched once and all tests run
+    in the same tab / page. The holder (rather than a plain session-scoped page
+    fixture) lets the `page` fixture replace the shared page if it becomes
+    unusable mid-session.
+    """
+    return []
+
+
 @pytest.fixture(scope="function")
 # By going to `about:blank`, we _reset_ the page to a known state before each test.
 # It is not perfect, but it is faster than making a new page for each test.
 # This must be done before each test
-def page(session_page: Page) -> Page:
+def page(browser: BrowserContext, _session_page_holder: list[Page]) -> Page:
     """
-    Reset the given page to a known state before each test.
-    The page is built on the session_page, which is maintained over the full session.
-    The page will visit "about:blank" to reset between apps.
+    Reset the shared page to a known state before each test.
+    The page is maintained over the full session and reset by visiting
+    "about:blank" between apps. If the page has become unusable (crashed or
+    wedged so navigations no longer commit), it is replaced with a new page.
     The default viewport size is set to 1920 x 1080 (1080p) for each test function.
     Parameters:
-        session_page (Page): The page to reset.
+        browser (BrowserContext): The browser context used to create replacement pages.
+        _session_page_holder (list[Page]): Holder for the shared page.
     """
-    session_page.goto("about:blank")
+    session_page = _session_page_holder[0] if _session_page_holder else None
+    if session_page is not None:
+        if session_page.is_closed() or getattr(
+            session_page, _NAVIGATION_WEDGED_ATTR, False
+        ):
+            logging.warning("Shared page is unusable; replacing it with a new page")
+            if not session_page.is_closed():
+                session_page.close()
+            session_page = None
+        else:
+            try:
+                session_page.goto("about:blank")
+            except Exception:
+                logging.warning(
+                    "Shared page failed to reset to about:blank; replacing it with a new page"
+                )
+                session_page.close()
+                session_page = None
+    if session_page is None:
+        _session_page_holder.clear()
+        session_page = _new_session_page(browser)
+        _session_page_holder.append(session_page)
+        session_page.goto("about:blank")
     # Reset screen size to 1080p
     session_page.set_viewport_size({"width": 1920, "height": 1080})
     return session_page


### PR DESCRIPTION
## Problem

#2294 added a one-shot `goto()` retry for WebKit navigations that get swallowed after the `about:blank` reset. [This CI run](https://github.com/posit-dev/py-shiny/actions/runs/28620161996/job/84873621143?pr=2294) shows that retry is insufficient: in the failing job, 3 consecutive tests × 4 flaky reruns each logged the retry warning and the page **still** stayed on `about:blank` — 12 consecutive swallowed navigations. Once the shared session page wedges (e.g. its WebKit web process dies), no amount of retrying `goto()` on the same page recovers it, so every remaining test on that worker burns 30s timeouts and fails.

## Fix

The shared page is now kept in a session-scoped holder so the function-scoped `page` fixture can replace it when it becomes unusable:

- If the post-retry navigation still hasn't committed, the page is marked as wedged and the wrapper raises immediately (fail fast instead of a 30s locator timeout).
- A `crash` event listener also marks the page as wedged.
- The `page` fixture replaces a wedged/closed page (or one that fails its `about:blank` reset) with a fresh page, so the flaky rerun actually gets a working page.

## Verification

- `tests/playwright/shiny/components/toolbar/toolbar_special/` passes locally on WebKit (15 passed).
- Verified the recovery path with a temporary test: marking the page wedged in one test causes the next test to receive a fresh, working page, and a healthy page is reused (not replaced) across tests.
- `pyright` clean on `tests/playwright/conftest.py`; black/isort/flake8 clean.