### PR TITLE
fix: Prevent tabset ID collisions in pages with many navsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added `offcanvas()` for creating sliding Bootstrap Offcanvas panels that appear from a viewport edge. Panels can be triggered by a UI element, revealed programmatically with `show_offcanvas()`, or controlled by id with `hide_offcanvas()` and `toggle_offcanvas()`. (#2279)
 
+### Bug fixes
+
+* Fixed rare tabset ID collisions in pages with many navsets. Randomly generated `data-tabsetid` values were drawn from a pool of ~1 million, so a page with dozens of tabsets could occasionally produce two navsets with the same ID (a birthday collision), resulting in duplicate DOM ids and broken tab switching. IDs are now drawn from a pool of 9 trillion. (#2296)
+
 ## [1.6.3] - 2026-06-01
 
 ### New features

--- a/shiny/ui/_navs.py
+++ b/shiny/ui/_navs.py
@@ -1685,4 +1685,10 @@ def navset_title(
 
 
 def nav_random_int() -> str:
-    return private_random_int(1000, 1000000)
+    # A page can contain dozens of tabsets, and each render must produce unique
+    # IDs: a duplicate `data-tabsetid` yields duplicate `tab-<tabsetid>-<index>`
+    # DOM ids, which breaks Bootstrap tab targeting and any locator keyed on the
+    # tabset ID. The pool is sized so that birthday collisions are effectively
+    # impossible, while keeping IDs as fixed-width digit strings below 2**53 in
+    # case they are ever handled as numbers in JavaScript.
+    return private_random_int(10**12, 10**13 - 1)

--- a/tests/pytest/test_navs.py
+++ b/tests/pytest/test_navs.py
@@ -13,6 +13,7 @@ from shiny._deprecated import ShinyDeprecationWarning
 from shiny._utils import private_seed
 from shiny.ui._navs import (
     NavbarOptions,
+    nav_random_int,
     navbar_options,
     navbar_options_resolve_deprecated,
 )
@@ -44,19 +45,19 @@ def test_navset_tab_markup():
         x = ui.navset_tab(a, b, ui.nav_control("Some item"), menu)
 
     assert TagList(x).render()["html"] == textwrap.dedent("""\
-        <ul class="nav nav-tabs" data-tabsetid="886440">
+        <ul class="nav nav-tabs" data-tabsetid="7776790190029">
           <li class="nav-item">
-            <a data-bs-toggle="tab" data-toggle="tab" data-value="a" role="tab" class="nav-link active" href="#tab-886440-0">a</a>
+            <a data-bs-toggle="tab" data-toggle="tab" data-value="a" role="tab" class="nav-link active" href="#tab-7776790190029-0">a</a>
           </li>
           <li class="nav-item">
-            <a data-bs-toggle="tab" data-toggle="tab" data-value="b" role="tab" class="nav-link" href="#tab-886440-1">b</a>
+            <a data-bs-toggle="tab" data-toggle="tab" data-value="b" role="tab" class="nav-link" href="#tab-7776790190029-1">b</a>
           </li>
           <li>Some item</li>
           <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle " data-bs-toggle="dropdown" data-value="Menu" href="#" role="button">Menu</a>
-            <ul class="dropdown-menu" data-tabsetid="404958">
+            <ul class="dropdown-menu" data-tabsetid="1710475945045">
               <li>
-                <a data-bs-toggle="tab" data-toggle="tab" data-value="c" role="tab" class="dropdown-item" href="#tab-404958-0">c</a>
+                <a data-bs-toggle="tab" data-toggle="tab" data-value="c" role="tab" class="dropdown-item" href="#tab-1710475945045-0">c</a>
               </li>
               <li class="dropdown-divider"></li>
               <li class="dropdown-header">Plain text</li>
@@ -65,10 +66,10 @@ def test_navset_tab_markup():
             </ul>
           </li>
         </ul>
-        <div class="tab-content" data-tabsetid="886440">
-          <div class="tab-pane active" role="tabpanel" data-value="a" id="tab-886440-0">a</div>
-          <div class="tab-pane" role="tabpanel" data-value="b" id="tab-886440-1">b</div>
-          <div class="tab-pane" role="tabpanel" data-value="c" id="tab-404958-0">c</div>
+        <div class="tab-content" data-tabsetid="7776790190029">
+          <div class="tab-pane active" role="tabpanel" data-value="a" id="tab-7776790190029-0">a</div>
+          <div class="tab-pane" role="tabpanel" data-value="b" id="tab-7776790190029-1">b</div>
+          <div class="tab-pane" role="tabpanel" data-value="c" id="tab-1710475945045-0">c</div>
         </div>""")
 
 
@@ -77,12 +78,12 @@ def test_navset_pill_markup():
         x = ui.navset_pill(menu, a, id="navset_pill_id")
 
     assert TagList(x).render()["html"] == textwrap.dedent("""\
-        <ul class="nav nav-pills shiny-tab-input" id="navset_pill_id" data-tabsetid="886440">
+        <ul class="nav nav-pills shiny-tab-input" id="navset_pill_id" data-tabsetid="7776790190029">
           <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle active" data-bs-toggle="dropdown" data-value="Menu" href="#" role="button">Menu</a>
-            <ul class="dropdown-menu" data-tabsetid="404958">
+            <ul class="dropdown-menu" data-tabsetid="1710475945045">
               <li>
-                <a data-bs-toggle="tab" data-toggle="tab" data-value="c" role="tab" class="dropdown-item active" href="#tab-404958-0">c</a>
+                <a data-bs-toggle="tab" data-toggle="tab" data-value="c" role="tab" class="dropdown-item active" href="#tab-1710475945045-0">c</a>
               </li>
               <li class="dropdown-divider"></li>
               <li class="dropdown-header">Plain text</li>
@@ -91,12 +92,12 @@ def test_navset_pill_markup():
             </ul>
           </li>
           <li class="nav-item">
-            <a data-bs-toggle="tab" data-toggle="tab" data-value="a" role="tab" class="nav-link" href="#tab-886440-1">a</a>
+            <a data-bs-toggle="tab" data-toggle="tab" data-value="a" role="tab" class="nav-link" href="#tab-7776790190029-1">a</a>
           </li>
         </ul>
-        <div class="tab-content" data-tabsetid="886440">
-          <div class="tab-pane active" role="tabpanel" data-value="c" id="tab-404958-0">c</div>
-          <div class="tab-pane" role="tabpanel" data-value="a" id="tab-886440-1">a</div>
+        <div class="tab-content" data-tabsetid="7776790190029">
+          <div class="tab-pane active" role="tabpanel" data-value="c" id="tab-1710475945045-0">c</div>
+          <div class="tab-pane" role="tabpanel" data-value="a" id="tab-7776790190029-1">a</div>
         </div>""")
 
 
@@ -112,28 +113,28 @@ def test_navset_card_pill_markup():
     assert TagList(x).render()["html"] == textwrap.dedent("""\
         <div class="card bslib-card bslib-mb-spacing html-fill-item html-fill-container" data-bslib-card-init="">
           <div class="card-header">
-            <ul class="nav nav-pills card-header-pills" data-tabsetid="886440">
+            <ul class="nav nav-pills card-header-pills" data-tabsetid="7776790190029">
               <li class="nav-item">
-                <a data-bs-toggle="tab" data-toggle="tab" data-value="a" role="tab" class="nav-link" href="#tab-886440-0">a</a>
+                <a data-bs-toggle="tab" data-toggle="tab" data-value="a" role="tab" class="nav-link" href="#tab-7776790190029-0">a</a>
               </li>
               <li class="nav-item dropdown">
                 <a class="nav-link dropdown-toggle active" data-bs-toggle="dropdown" data-value="Menu" href="#" role="button">Menu</a>
-                <ul class="dropdown-menu" data-tabsetid="404958">
+                <ul class="dropdown-menu" data-tabsetid="1710475945045">
                   <li>
-                    <a data-bs-toggle="tab" data-toggle="tab" data-value="c" role="tab" class="dropdown-item active" href="#tab-404958-0">c</a>
+                    <a data-bs-toggle="tab" data-toggle="tab" data-value="c" role="tab" class="dropdown-item active" href="#tab-1710475945045-0">c</a>
                   </li>
                 </ul>
               </li>
               <li class="nav-item">
-                <a data-bs-toggle="tab" data-toggle="tab" data-value="b" role="tab" class="nav-link" href="#tab-886440-2">b</a>
+                <a data-bs-toggle="tab" data-toggle="tab" data-value="b" role="tab" class="nav-link" href="#tab-7776790190029-2">b</a>
               </li>
             </ul>
           </div>
           <div class="card-body bslib-gap-spacing html-fill-item html-fill-container" style="margin-top:auto;margin-bottom:auto;flex:1 1 auto;">
-            <div class="tab-content html-fill-item html-fill-container" data-tabsetid="886440">
-              <div class="tab-pane html-fill-item html-fill-container bslib-gap-spacing" role="tabpanel" data-value="a" id="tab-886440-0" style="gap:0;padding:0;">a</div>
-              <div class="tab-pane active html-fill-item html-fill-container bslib-gap-spacing" role="tabpanel" data-value="c" id="tab-404958-0" style="gap:0;padding:0;">c</div>
-              <div class="tab-pane html-fill-item html-fill-container bslib-gap-spacing" role="tabpanel" data-value="b" id="tab-886440-2" style="gap:0;padding:0;">b</div>
+            <div class="tab-content html-fill-item html-fill-container" data-tabsetid="7776790190029">
+              <div class="tab-pane html-fill-item html-fill-container bslib-gap-spacing" role="tabpanel" data-value="a" id="tab-7776790190029-0" style="gap:0;padding:0;">a</div>
+              <div class="tab-pane active html-fill-item html-fill-container bslib-gap-spacing" role="tabpanel" data-value="c" id="tab-1710475945045-0" style="gap:0;padding:0;">c</div>
+              <div class="tab-pane html-fill-item html-fill-container bslib-gap-spacing" role="tabpanel" data-value="b" id="tab-7776790190029-2" style="gap:0;padding:0;">b</div>
             </div>
           </div>
           <script data-bslib-card-init="">window.bslib.Card.initializeAllCards();</script>
@@ -152,15 +153,15 @@ def test_navset_bar_markup():
     assert TagList(x).render()["html"] == textwrap.dedent("""\
         <nav class="navbar navbar-expand-md navbar-default" data-bs-theme="auto">
           <div class="container-fluid">
-            <span class="navbar-brand">Page title</span><button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar-collapse-795772" aria-controls="navbar-collapse-795772" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
-            <div id="navbar-collapse-795772" class="collapse navbar-collapse">
-              <ul class="nav navbar-nav nav-underline" data-tabsetid="886440">
+            <span class="navbar-brand">Page title</span><button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar-collapse-9549180827234" aria-controls="navbar-collapse-9549180827234" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
+            <div id="navbar-collapse-9549180827234" class="collapse navbar-collapse">
+              <ul class="nav navbar-nav nav-underline" data-tabsetid="7776790190029">
                 <li class="nav-item dropdown">
                   <a class="nav-link dropdown-toggle active" data-bs-toggle="dropdown" data-value="Menu" href="#" role="button">Menu</a>
-                  <ul class="dropdown-menu" data-tabsetid="404958">
+                  <ul class="dropdown-menu" data-tabsetid="1710475945045">
                     <li class="dropdown-header">Plain text</li>
                     <li>
-                      <a data-bs-toggle="tab" data-toggle="tab" data-value="c" role="tab" class="dropdown-item active" href="#tab-404958-1">c</a>
+                      <a data-bs-toggle="tab" data-toggle="tab" data-value="c" role="tab" class="dropdown-item active" href="#tab-1710475945045-1">c</a>
                     </li>
                   </ul>
                 </li>
@@ -170,8 +171,8 @@ def test_navset_bar_markup():
         </nav>
         <div class="container-fluid html-fill-item html-fill-container">
           Page header
-          <div class="tab-content html-fill-item html-fill-container" data-tabsetid="886440">
-            <div class="tab-pane active html-fill-item html-fill-container bslib-gap-spacing" role="tabpanel" data-value="c" id="tab-404958-1" style="--bslib-navbar-margin:0;;">c</div>
+          <div class="tab-content html-fill-item html-fill-container" data-tabsetid="7776790190029">
+            <div class="tab-pane active html-fill-item html-fill-container bslib-gap-spacing" role="tabpanel" data-value="c" id="tab-1710475945045-1" style="--bslib-navbar-margin:0;;">c</div>
           </div>
           Page footer
         </div>""")
@@ -244,6 +245,16 @@ def test_navbar_options_attribs_in_options_user():
     result = navbar_options_resolve_deprecated(options_user)
     assert isinstance(result, NavbarOptions)
     assert result.attrs == {"class_": "my-navbar"}
+
+
+def test_nav_random_int_no_collisions():
+    # Tabset IDs must not collide within a page: a duplicate `data-tabsetid`
+    # produces duplicate DOM ids (`tab-<tabsetid>-<index>`), which breaks
+    # Bootstrap tab targeting and Playwright locators (see #2296). The ID pool
+    # must be large enough that drawing many IDs never repeats in practice.
+    with private_seed_n():
+        ids = [nav_random_int() for _ in range(10_000)]
+    assert len(set(ids)) == len(ids)
 
 
 def test_navbar_options_mixed_options():


### PR DESCRIPTION
## Problem

[This CI run](https://github.com/posit-dev/py-shiny/actions/runs/28619266837/job/84870650451) failed `test_navset_kitchensink[chromium]` with a Playwright strict-mode violation: `div.tab-content[data-tabsetid='647060'] > div.tab-pane.active` resolved to **2 elements**. Related to the flaky-test analysis in #2285.

## Root cause

`nav_random_int()` drew tabset IDs from a pool of only ~1 million values (`private_random_int(1000, 1000000)`). The navsets kitchensink app renders 28 tabsets per page, so by birthday paradox ~1 in 2600 renders produces two navsets with the same `data-tabsetid` — in the failing run, `navset_underline_default` and `navset_underline_selected` both got `647060`. Evidence in the failure log: Playwright could not use `#tab-647060-1` as a unique locator for the second matched pane and fell back to an ancestor-based locator, proving the DOM contained duplicate ids.

A collision is a real product bug, not just a test issue: duplicate `tab-<tabsetid>-<index>` ids break Bootstrap tab targeting (the nav link's `href`/target resolves to the first matching pane in the document).

Why all 5 flaky reruns failed identically: Express app UI is tagified **once at import** (`shiny/express/_run.py`), so the colliding render is frozen for the app process lifetime.

## Fix

Draw tabset IDs from `private_random_int(10**12, 10**13 - 1)` — a pool of 9 trillion fixed-width 13-digit strings (kept below 2**53 in case JS ever treats them as numbers). Collision probability for a 28-tabset page drops from ~4e-4 to ~4e-11 per render.

## Tests

- New `test_nav_random_int_no_collisions` regression test: draws 10,000 seeded IDs and asserts uniqueness. Fails deterministically against the old pool (~50 expected duplicates), passes with the new one.
- Updated the hardcoded seeded tabset IDs in `tests/pytest/test_navs.py` markup expectations.
- Verified locally: `tests/pytest/test_navs.py` (15 passed), full unit suite (776 passed), and the kitchensink Playwright test on chromium (1 passed). Black/isort/flake8 clean; pyright error counts unchanged vs. main.

## Note (possible follow-up)

Other `private_random_int` call sites have the same theoretical hazard, notably `ui/_toolbar.py` (`btn-label-` ids from a pool of only 9000) and `busy_indicators.py`. Left out of scope to keep this change focused.