### PR TITLE
fix(tests): Isolate app ports per xdist worker and retry Firefox goto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other changes
 
-* `shiny.run.run_shiny_app()` (and therefore `shiny.pytest.create_app_fixture()`) now picks random app ports from a disjoint per-worker port range when running under pytest-xdist, instead of the full 1024-49151 range shared by all workers. This prevents parallel test workers from racing to bind the same port and from reusing each other's recycled ports. (#2297)
+* `shiny.run.run_shiny_app()` (and therefore `shiny.pytest.create_app_fixture()`) now picks random app ports from a disjoint per-worker port range when running under pytest-xdist, instead of the full 1024-49151 range shared by all workers. This prevents parallel test workers from racing to bind the same port and from reusing each other's recycled ports. When not running under pytest-xdist, the behavior is unchanged: ports are picked from `random_port()`'s full default range (1024-49151). (#2297)
 
 ## [1.6.3] - 2026-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other changes
 
-* `shiny.run.run_shiny_app()` (and therefore `shiny.pytest.create_app_fixture()`) now picks random app ports from a disjoint per-worker port range when running under pytest-xdist, instead of the full 1024-49151 range shared by all workers. This prevents parallel test workers from racing to bind the same port and from reusing each other's recycled ports. (#2296)
+* `shiny.run.run_shiny_app()` (and therefore `shiny.pytest.create_app_fixture()`) now picks random app ports from a disjoint per-worker port range when running under pytest-xdist, instead of the full 1024-49151 range shared by all workers. This prevents parallel test workers from racing to bind the same port and from reusing each other's recycled ports. (#2297)
 
 ## [1.6.3] - 2026-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added `offcanvas()` for creating sliding Bootstrap Offcanvas panels that appear from a viewport edge. Panels can be triggered by a UI element, revealed programmatically with `show_offcanvas()`, or controlled by id with `hide_offcanvas()` and `toggle_offcanvas()`. (#2279)
 
+### Other changes
+
+* `shiny.run.run_shiny_app()` (and therefore `shiny.pytest.create_app_fixture()`) now picks random app ports from a disjoint per-worker port range when running under pytest-xdist, instead of the full 1024-49151 range shared by all workers. This prevents parallel test workers from racing to bind the same port and from reusing each other's recycled ports. (#2296)
+
 ## [1.6.3] - 2026-06-01
 
 ### New features

--- a/shiny/_utils.py
+++ b/shiny/_utils.py
@@ -89,8 +89,18 @@ def guess_mime_type(
     return mimetypes.guess_type(url, strict)[0] or default
 
 
+RANDOM_PORT_MIN_DEFAULT = 1024
+"""Default lower bound for `random_port()`: the start of the TCP User Ports range."""
+
+RANDOM_PORT_MAX_DEFAULT = 49151
+"""Default upper bound for `random_port()`: the end of the TCP User Ports range."""
+
+
 def random_port(
-    min: int = 1024, max: int = 49151, host: str = "127.0.0.1", n: int = 20
+    min: int = RANDOM_PORT_MIN_DEFAULT,
+    max: int = RANDOM_PORT_MAX_DEFAULT,
+    host: str = "127.0.0.1",
+    n: int = 20,
 ) -> int:
     """Find an open TCP port
 

--- a/shiny/run/_run.py
+++ b/shiny/run/_run.py
@@ -12,7 +12,7 @@ from types import TracebackType
 from typing import IO, Any, Callable, Generator, List, Optional, TextIO, Type, Union
 
 from .._docstring import no_example
-from .._utils import random_port
+from .._utils import RANDOM_PORT_MAX_DEFAULT, RANDOM_PORT_MIN_DEFAULT, random_port
 
 __all__ = (
     "ShinyAppProc",
@@ -22,8 +22,8 @@ __all__ = (
 )
 
 
-PORT_RANGE_DEFAULT: tuple[int, int] = (1024, 49151)
-"""Port search range when not running under pytest-xdist (mirrors `random_port()`)."""
+PORT_RANGE_DEFAULT: tuple[int, int] = (RANDOM_PORT_MIN_DEFAULT, RANDOM_PORT_MAX_DEFAULT)
+"""Port search range when not running under pytest-xdist: `random_port()`'s defaults."""
 
 WORKER_PORT_RANGE_BASE: int = 21000
 """First port of the range reserved for pytest-xdist worker 0 (``gw0``)."""

--- a/shiny/run/_run.py
+++ b/shiny/run/_run.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import datetime
 import logging
+import os
+import re
 import subprocess
 import sys
 import threading
@@ -18,6 +20,41 @@ __all__ = (
     # For internal use only
     # "shiny_app_gen",
 )
+
+
+PORT_RANGE_DEFAULT: tuple[int, int] = (1024, 49151)
+"""Port search range when not running under pytest-xdist (mirrors `random_port()`)."""
+
+WORKER_PORT_RANGE_BASE: int = 21000
+"""First port of the range reserved for pytest-xdist worker 0 (``gw0``)."""
+
+WORKER_PORT_RANGE_SIZE: int = 300
+"""Number of ports reserved for each pytest-xdist worker."""
+
+WORKER_PORT_RANGE_COUNT: int = 32
+"""Worker numbers wrap after this many workers so all ranges stay below the Linux
+ephemeral port range (32768+), which the OS hands out to outgoing connections."""
+
+
+def port_search_range() -> tuple[int, int]:
+    """
+    Determine the `(min, max)` port search range for a random app port.
+
+    When running under pytest-xdist, each worker gets its own disjoint range of
+    ports derived from the ``PYTEST_XDIST_WORKER`` environment variable (e.g.
+    ``gw0``, ``gw1``, ...). This prevents two workers from racing to bind the same
+    randomly chosen port, and keeps one worker's browser from ever talking to an
+    app started by another worker after a port is recycled.
+
+    Outside of pytest-xdist, the full `random_port()` default range is used.
+    """
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER", "")
+    match = re.fullmatch(r"[a-zA-Z]*(\d+)", worker_id)
+    if match is None:
+        return PORT_RANGE_DEFAULT
+    worker_num = int(match.group(1)) % WORKER_PORT_RANGE_COUNT
+    min_port = WORKER_PORT_RANGE_BASE + worker_num * WORKER_PORT_RANGE_SIZE
+    return (min_port, min_port + WORKER_PORT_RANGE_SIZE - 1)
 
 
 class OutputStream:
@@ -240,7 +277,11 @@ def run_shiny_app(
         A :class:`shiny.run.ShinyAppProc` object representing the running
         Shiny app process.
     """
-    shiny_port = port if port != 0 else random_port()
+    if port != 0:
+        shiny_port = port
+    else:
+        port_min, port_max = port_search_range()
+        shiny_port = random_port(min=port_min, max=port_max)
 
     child = subprocess.Popen(
         [

--- a/tests/playwright/conftest.py
+++ b/tests/playwright/conftest.py
@@ -9,7 +9,9 @@ from inspect import signature
 from pathlib import PurePath
 
 import pytest
-from playwright.sync_api import BrowserContext, BrowserType, Page, Response
+from playwright.sync_api import BrowserContext, BrowserType
+from playwright.sync_api import Error as PlaywrightError
+from playwright.sync_api import Page, Response
 
 from shiny.pytest import ScopeName as ScopeName
 from shiny.pytest import create_app_fixture
@@ -41,12 +43,26 @@ def session_page(browser: BrowserContext) -> Page:
     original_goto = page.goto
 
     def goto_and_verify_commit(url: str, **kwargs: typing.Any) -> Response | None:
+        # Firefox occasionally restarts the initial navigation internally, which
+        # surfaces as `Page.goto: Navigation to "<url>" is interrupted by another
+        # navigation to "<url>"`. The interrupting navigation targets the same
+        # URL, so retrying once is safe.
+        try:
+            response = original_goto(url, **kwargs)
+        except PlaywrightError as err:
+            if f'is interrupted by another navigation to "{url}"' not in str(err):
+                raise
+            logging.warning(
+                "Navigation to %s was interrupted by another navigation to the "
+                "same URL; retrying one time",
+                url,
+            )
+            response = original_goto(url, **kwargs)
         # WebKit occasionally swallows a navigation issued right after the
         # `about:blank` reset performed by the function-scoped `page` fixture:
         # `goto()` returns normally but the page never leaves `about:blank`,
         # so every subsequent locator wait times out. When that happens,
         # retry the navigation once.
-        response = original_goto(url, **kwargs)
         if url != "about:blank" and page.url == "about:blank":
             logging.warning(
                 "Navigation to %s did not commit (page still on about:blank); retrying one time",

--- a/tests/pytest/test_run_port_range.py
+++ b/tests/pytest/test_run_port_range.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pytest
+
+from shiny.run._run import (
+    PORT_RANGE_DEFAULT,
+    WORKER_PORT_RANGE_BASE,
+    WORKER_PORT_RANGE_SIZE,
+    port_search_range,
+)
+
+
+def test_port_search_range_without_xdist(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("PYTEST_XDIST_WORKER", raising=False)
+    assert port_search_range() == PORT_RANGE_DEFAULT
+
+
+def test_port_search_range_with_unparsable_worker_id(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "master")
+    assert port_search_range() == PORT_RANGE_DEFAULT
+
+
+@pytest.mark.parametrize("worker_num", [0, 1, 2, 7, 31])
+def test_port_search_range_is_disjoint_per_worker(
+    monkeypatch: pytest.MonkeyPatch, worker_num: int
+):
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", f"gw{worker_num}")
+    min_port, max_port = port_search_range()
+    assert min_port == WORKER_PORT_RANGE_BASE + worker_num * WORKER_PORT_RANGE_SIZE
+    assert max_port == min_port + WORKER_PORT_RANGE_SIZE - 1
+
+
+def test_port_search_range_wraps_after_worker_cap(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw32")
+    wrapped = port_search_range()
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw0")
+    assert wrapped == port_search_range()
+
+
+def test_port_search_range_stays_below_linux_ephemeral_ports(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # The Linux ephemeral port range starts at 32768. Ports handed to Shiny apps
+    # must stay below it so the OS never assigns one of our ports to an outgoing
+    # connection.
+    for worker_num in range(0, 64):
+        monkeypatch.setenv("PYTEST_XDIST_WORKER", f"gw{worker_num}")
+        min_port, max_port = port_search_range()
+        assert 1024 < min_port < max_port < 32768

--- a/tests/pytest/test_run_port_range.py
+++ b/tests/pytest/test_run_port_range.py
@@ -5,6 +5,7 @@ import pytest
 from shiny.run._run import (
     PORT_RANGE_DEFAULT,
     WORKER_PORT_RANGE_BASE,
+    WORKER_PORT_RANGE_COUNT,
     WORKER_PORT_RANGE_SIZE,
     port_search_range,
 )
@@ -37,13 +38,17 @@ def test_port_search_range_wraps_after_worker_cap(monkeypatch: pytest.MonkeyPatc
     assert wrapped == port_search_range()
 
 
-def test_port_search_range_stays_below_linux_ephemeral_ports(
+def test_worker_port_ranges_stay_within_valid_bounds(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    # The Linux ephemeral port range starts at 32768. Ports handed to Shiny apps
-    # must stay below it so the OS never assigns one of our ports to an outgoing
-    # connection.
-    for worker_num in range(0, 64):
+    # Because worker numbers wrap at WORKER_PORT_RANGE_COUNT, checking
+    # 0..WORKER_PORT_RANGE_COUNT-1 covers every range that can ever be produced.
+    #
+    # Every worker range must stay within random_port()'s default bounds
+    # (PORT_RANGE_DEFAULT) and below 32768, where the Linux ephemeral port range
+    # starts, so the OS never assigns one of our ports to an outgoing connection.
+    for worker_num in range(WORKER_PORT_RANGE_COUNT):
         monkeypatch.setenv("PYTEST_XDIST_WORKER", f"gw{worker_num}")
         min_port, max_port = port_search_range()
-        assert 1024 < min_port < max_port < 32768
+        assert PORT_RANGE_DEFAULT[0] < min_port < max_port < 32768
+        assert max_port < PORT_RANGE_DEFAULT[1]


### PR DESCRIPTION
## Problem

Playwright CI jobs occasionally fail with (e.g. [this job](https://github.com/posit-dev/py-shiny/actions/runs/28619857330/job/84872633512)):

```
playwright._impl._errors.Error: Page.goto: Navigation to "http://127.0.0.1:6679/" is interrupted by another navigation to "http://127.0.0.1:6679/"
```

Two separate hazards contribute to flaky navigation failures:

1. **Cross-worker port collisions/reuse.** Every xdist worker picks random app ports from the same 1024-49151 range. With ~30 apps per worker x 3 workers per job x ~36 jobs per CI run, workers regularly race to bind the same port (currently only mitigated by a bind-error retry), and a stale page from one worker can end up talking to an app started by another worker after a port is recycled.
2. **Firefox internally restarts the initial navigation** right after the `about:blank` page reset, which surfaces as the `interrupted by another navigation to <same url>` error above. This is the Firefox sibling of the WebKit "goto returns but page stays on about:blank" flake handled in #2294 — except this variant *raises*, so #2294's check never runs.

## Changes

- `shiny.run.run_shiny_app()` (and therefore `shiny.pytest.create_app_fixture()`) now picks random ports from a **disjoint per-worker range** (300 ports per worker, derived from `PYTEST_XDIST_WORKER`, all below the Linux ephemeral range). Workers can never collide, and a worker's ports stay stable across runs, making flakes reproducible. A range (rather than one fixed port per worker) is required because some modules keep two module-scoped apps alive at once (e.g. `test_input_slider.py`), and the existing bind-check in `random_port()` handles reuse within a worker's own range.
- The `session_page` goto wrapper now retries once when the navigation is interrupted by another navigation **to the same URL** (safe to retry; different-URL interruptions still raise).

## Testing

- New unit tests for `port_search_range()` (`tests/pytest/test_run_port_range.py`).
- Smoke-tested `run_shiny_app()` under `PYTEST_XDIST_WORKER=gw2`: app binds within 21600-21899 and serves HTTP 200.
- Ran the previously failing `test_input_numeric.py` locally on chromium, and `test_input_numeric.py` + `test_input_text.py` on firefox with `--numprocesses 2`: all pass.