### PR TITLE
ci: Reduce Playwright job timeout from 60 to 10 minutes

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -150,7 +150,8 @@ jobs:
           browser: ${{ matrix.browser }}
 
       - name: Run End-to-End tests
-        timeout-minutes: 60
+        # Healthy shards finish in ~4 minutes; kill stragglers quickly
+        timeout-minutes: 10
         run: |
           make playwright-shiny SUB_FILE=". --numprocesses 3 --num-shards 4 --shard-id ${{ matrix.shard }} ${{ steps.browsers.outputs.playwright-diagnostic-args }}" ${{ steps.browsers.outputs.browsers }}
       - uses: actions/upload-artifact@v6
@@ -225,7 +226,8 @@ jobs:
           browser: ${{ matrix.browser }}
 
       - name: Run example app tests
-        timeout-minutes: 60
+        # Healthy shards finish in ~4 minutes; kill stragglers quickly
+        timeout-minutes: 10
         run: |
           make playwright-examples SUB_FILE=". --numprocesses 3 --num-shards 4 --shard-id ${{ matrix.shard }} ${{ steps.browsers.outputs.playwright-diagnostic-args }}" ${{ steps.browsers.outputs.browsers }}
       - uses: actions/upload-artifact@v6
@@ -281,7 +283,8 @@ jobs:
           browser: ${{ matrix.browser }}
 
       - name: Run playwright tests for AI generated apps
-        timeout-minutes: 60
+        # Healthy shards finish in ~4 minutes; kill stragglers quickly
+        timeout-minutes: 10
         run: |
           make playwright-ai SUB_FILE=". --numprocesses 3 --num-shards 2 --shard-id ${{ matrix.shard }} ${{ steps.browsers.outputs.playwright-diagnostic-args }}" ${{ steps.browsers.outputs.browsers }}
       - uses: actions/upload-artifact@v6


### PR DESCRIPTION
## Summary
The three Playwright CI jobs (`playwright-shiny`, `playwright-examples`, `playwright-ai`) had `timeout-minutes: 60` on their test steps, so a single wedged shard could hold the workflow open for a full hour. Across the three most recent successful runs, the slowest of the ~130 Playwright shards completed in 3.8 minutes total (including checkout and environment setup, which the step-level timeout doesn't even count). This PR lowers the test-step timeout to 10 minutes — still roughly 3–5x the observed worst case — so straggling jobs are killed quickly instead of blocking the run. `playwright-deploys-precheck` already had a 5-minute timeout and is unchanged.

## Verification
CI on this PR exercises the changed workflow directly: all Playwright jobs should pass well within the new 10-minute step timeout.