### PR TITLE
fix(tests): Remove per-page-load network call from dataframe example

### DIFF
--- a/examples/dataframe/app.py
+++ b/examples/dataframe/app.py
@@ -4,6 +4,20 @@ import shinyswatch
 
 from shiny import App, Inputs, Outputs, Session, reactive, render, req, ui
 
+# A static subset of `sns.get_dataset_names()`. Calling that function makes a
+# network request to GitHub on every page load, which is unreliable in CI.
+dataset_names = [
+    "anagrams",
+    "anscombe",
+    "attention",
+    "diamonds",
+    "iris",
+    "mpg",
+    "penguins",
+    "tips",
+    "titanic",
+]
+
 
 def app_ui(req):
     dark = True if "dark" in req.query_params else None
@@ -13,7 +27,7 @@ def app_ui(req):
             ui.tags.meta(name="viewport", content="width=device-width, initial-scale=1")
         ),
         light_dark_switcher(dark),
-        ui.input_select("dataset", "Dataset", sns.get_dataset_names()),
+        ui.input_select("dataset", "Dataset", dataset_names),
         ui.input_select(
             "selection_mode",
             "Selection mode",

--- a/tests/playwright/shiny/components/data_frame/example/test_data_frame.py
+++ b/tests/playwright/shiny/components/data_frame/example/test_data_frame.py
@@ -241,6 +241,7 @@ def test_single_selection(
     assert detail_text() == snapshot
 
 
+@pytest.mark.flaky(reruns=reruns, delay=reruns_delay)
 def test_filter_grid(
     page: Page,
     data_frame_app: ShinyAppProc,
@@ -252,6 +253,7 @@ def test_filter_grid(
     _filter_test_impl(page, data_frame_app, grid, summary, snapshot)
 
 
+@pytest.mark.flaky(reruns=reruns, delay=reruns_delay)
 def test_filter_table(
     page: Page,
     data_frame_app: ShinyAppProc,
@@ -371,6 +373,7 @@ def _filter_test_impl(
     expect(summary).to_have_text(re.compile(" of 20"))
 
 
+@pytest.mark.flaky(reruns=reruns, delay=reruns_delay)
 def test_filter_disable(page: Page, data_frame_app: ShinyAppProc):
     page.goto(data_frame_app.url)
 


### PR DESCRIPTION
## Problem

PR #2299's `playwright-shiny (3.12, chromium, 0)` job failed in `test_filter_disable` with the page showing **Internal Server Error** ([job log](https://github.com/posit-dev/py-shiny/actions/runs/28635116949/job/84919748169)).

Root cause: `examples/dataframe/app.py` calls `sns.get_dataset_names()` inside `app_ui()`, which makes a live request to GitHub on **every page load** (seaborn never caches this call). CI hit a transient `ConnectionResetError: [Errno 104]` from GitHub, so the page render raised and the test found no `tr.filters` element. The same network blip also broke `sns.load_dataset()` calls in the server effect.

## Fix

- Replace `sns.get_dataset_names()` with a static list of dataset names (includes all datasets the tests use: `anagrams` as the default first entry, `attention`, `diamonds`). This removes the per-page-load network dependency entirely.
- Add the file's standard `@pytest.mark.flaky(reruns=reruns, delay=reruns_delay)` marker to the three tests that lacked it (`test_filter_grid`, `test_filter_table`, `test_filter_disable`) to cover transient resets during first-time `sns.load_dataset()` downloads (those are cached in `~/seaborn-data` afterward).

## Verification

All 10 tests in `tests/playwright/shiny/components/data_frame/example/test_data_frame.py` pass locally on chromium.