### PR TITLE
fix(tests): Remove infinite Playwright waits and add hang diagnostics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,18 @@ PYTEST_DEPLOYS_BROWSERS:= --browser chromium
 # Per-test timeout (seconds) so a single hung test fails fast with a full
 # thread-stack dump instead of silently consuming the whole CI job.
 PLAYWRIGHT_TEST_TIMEOUT:= 120
+# pytest-timeout defaults to the `signal` (SIGALRM) method on POSIX, but the
+# exception it raises can be swallowed inside Playwright's sync-API event
+# loop, leaving the worker hung until the CI job timeout kills it with no
+# diagnostics. The `thread` method kills the worker process instead, which
+# pytest-xdist reports as a failure while the rest of the run (and its
+# traces/artifacts) completes normally.
+PLAYWRIGHT_TEST_TIMEOUT_METHOD:= thread
+# The thread method's own stack dump goes to the xdist worker's stdout, which
+# is execnet's IPC pipe (lost). pytest's builtin faulthandler writes to the
+# original stderr fd, which xdist workers inherit, so dump every thread's
+# stack shortly *before* the kill to record where the test was hung.
+PLAYWRIGHT_FAULTHANDLER_TIMEOUT:= 110
 # In CI, use one line per test (`-v`) instead of the default dot-progress
 # output. GitHub Actions' log viewer only displays a line once it sees a
 # trailing newline, and pytest's dot mode only emits one every ~80 chars
@@ -219,7 +231,7 @@ install-rsconnect: FORCE
 # `--timeout` bounds each test so a hang fails fast with a thread-stack dump
 # instead of consuming the whole job.
 playwright: install-playwright ## All end-to-end tests with playwright; (TEST_FILE="" from root of repo)
-	pytest $(PLAYWRIGHT_VERBOSE) --timeout=$(PLAYWRIGHT_TEST_TIMEOUT) $(TEST_FILE) $(PYTEST_BROWSERS)
+	pytest $(PLAYWRIGHT_VERBOSE) --timeout=$(PLAYWRIGHT_TEST_TIMEOUT) --timeout-method=$(PLAYWRIGHT_TEST_TIMEOUT_METHOD) -o faulthandler_timeout=$(PLAYWRIGHT_FAULTHANDLER_TIMEOUT) $(TEST_FILE) $(PYTEST_BROWSERS)
 
 playwright-debug: install-playwright ## All end-to-end tests, chrome only, headed; (TEST_FILE="" from root of repo)
 	pytest -c tests/playwright/playwright-pytest.ini $(TEST_FILE)

--- a/tests/playwright/shiny/components/data_frame/html_columns/test_html_columns.py
+++ b/tests/playwright/shiny/components/data_frame/html_columns/test_html_columns.py
@@ -78,8 +78,8 @@ def test_validate_html_columns(
     # Sorting should not work for columns that are HTML columns
     # Verify that the sorting is reset
     with pytest.raises(AssertionError) as e:
-        data_frame.set_sort(3, timeout=0)
-        assert "header-html" in str(e)
+        data_frame.set_sort(3)
+    assert "header-html" in str(e.value)
     data_frame.expect_cell("1", row=0, col=1)
 
     # filter by Individual IDs

--- a/tests/playwright/shiny/inputs/input_task_button/test_input_task_button.py
+++ b/tests/playwright/shiny/inputs/input_task_button/test_input_task_button.py
@@ -13,9 +13,12 @@ def click_extended_task_button(
     current_time: controller.OutputText,
 ) -> str:
     button.expect_state("ready")
-    button.click(timeout=0)
-    button.expect_state("busy", timeout=0)
-    return current_time.get_value(timeout=0)
+    button.click()
+    # The "busy" state only lasts as long as the server-side task (~1.5s), so
+    # this assertion must run promptly; a finite timeout keeps a missed busy
+    # window a fast, diagnosable failure instead of an infinite hang.
+    button.expect_state("busy")
+    return current_time.get_value()
 
 
 def test_input_action_task_button(page: Page, local_app: ShinyAppProc) -> None:
@@ -40,11 +43,11 @@ def test_input_action_task_button(page: Page, local_app: ShinyAppProc) -> None:
         button_task,
         current_time,
     )
-    # Make sure time value updates (before the calculation finishes
-    current_time.expect.not_to_have_text(time1, timeout=500)
-    result.expect_value("3", timeout=0)
+    # Make sure time value updates (before the 1.5s calculation finishes)
+    current_time.expect.not_to_have_text(time1, timeout=1000)
+    result.expect_value("3")
     # After the calculation time plus a buffer, make sure the calculation finishes
-    result.expect_value("5", timeout=(1.5 + 1) * 1000)
+    result.expect_value("5", timeout=10 * 1000)
 
     # set up Blocking test
     y.set("15")
@@ -61,4 +64,4 @@ def test_input_action_task_button(page: Page, local_app: ShinyAppProc) -> None:
     )
     # Make sure time value has not changed after 500ms has ellapsed
     time.sleep(0.5)
-    current_time.expect_value(time_block, timeout=0)
+    current_time.expect_value(time_block)

--- a/tests/playwright/shiny/inputs/input_task_button2/app.py
+++ b/tests/playwright/shiny/inputs/input_task_button2/app.py
@@ -1,4 +1,7 @@
+import tempfile
 import time
+import uuid
+from pathlib import Path
 
 from shiny import App, Inputs, Outputs, Session, module, reactive, render, ui
 
@@ -8,12 +11,22 @@ def button_ui():
     return ui.TagList(
         ui.input_task_button("btn", label="Go"),
         ui.output_text("text_counter"),
+        ui.output_text("release_file"),
     )
 
 
 @module.server
 def button_server(input: Inputs, output: Outputs, session: Session):
     counter = reactive.value(0)
+    # The button stays "busy" only while the click effect runs. Instead of a
+    # hard-coded sleep (which races against how quickly the test can observe
+    # the busy state), hold the effect until the test creates this file. The
+    # path is unique per session so parallel test runs cannot interfere.
+    release_path = Path(tempfile.gettempdir()) / f"task-button2-{uuid.uuid4().hex}"
+
+    @render.text
+    def release_file():
+        return str(release_path)
 
     @render.text
     def text_counter():
@@ -22,7 +35,11 @@ def button_server(input: Inputs, output: Outputs, session: Session):
     @reactive.effect
     @reactive.event(input.btn)
     def increment_counter():
-        time.sleep(0.5)
+        # Deadline so a broken test fails instead of wedging the app forever
+        deadline = time.time() + 30
+        while not release_path.exists() and time.time() < deadline:
+            time.sleep(0.05)
+        release_path.unlink(missing_ok=True)
         counter.set(counter() + 1)
 
 

--- a/tests/playwright/shiny/inputs/input_task_button2/test_input_task_button2.py
+++ b/tests/playwright/shiny/inputs/input_task_button2/test_input_task_button2.py
@@ -1,18 +1,11 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from playwright.sync_api import Page
 
 from shiny.playwright import controller
 from shiny.run import ShinyAppProc
-
-
-def click_extended_task_button(
-    button: controller.InputTaskButton,
-) -> None:
-    button.expect_state("ready")
-    button.click(timeout=0)
-    button.expect_state("busy", timeout=0)
-    button.expect_state("ready", timeout=0)
 
 
 def test_input_action_task_button(page: Page, local_app: ShinyAppProc) -> None:
@@ -22,11 +15,20 @@ def test_input_action_task_button(page: Page, local_app: ShinyAppProc) -> None:
         "Button clicked 0 times"
     )
 
-    # Extended task
     button_task = controller.InputTaskButton(page, "mod1-btn")
     button_task.expect_label_ready("Go")
     button_task.expect_auto_reset(True)
-    click_extended_task_button(button_task)
+
+    # The app holds the button's click handler (and therefore its "busy"
+    # state) until this file exists, so the busy assertion below cannot miss
+    # the busy window, no matter how slowly the test executes.
+    release_file = Path(controller.OutputText(page, "mod1-release_file").get_value())
+
+    button_task.expect_state("ready")
+    button_task.click()
+    button_task.expect_state("busy")
+    release_file.touch()
+    button_task.expect_state("ready", timeout=10 * 1000)
 
     controller.OutputText(page, "mod1-text_counter").expect_value(
         "Button clicked 1 times"


### PR DESCRIPTION
## Summary

`test_input_task_button2` (and its sibling `test_input_task_button`) intermittently hung CI shards until the 10-minute GHA step timeout killed the job with no diagnostics (example: [run 28635752609](https://github.com/posit-dev/py-shiny/actions/runs/28635752609/job/84921607606)). Investigation of that job's log plus the Playwright source revealed three stacked problems, each fixed here:

1. **`timeout=0` means "wait forever" in Playwright, not "check immediately".** Only `None` gets the 5s default; `0` disables the timeout entirely. Both task button tests and the html_columns data frame test used it on `click()`/`expect_state()`/`set_sort()`. All infinite waits are removed.

2. **Asserting a transient "busy" state raced the server-side task duration.** The button is only busy while the click effect runs (0.5s in `input_task_button2`); a CI stall between click and assertion missed the window, and with `timeout=0` the test then polled forever. The app now publishes a unique release-file path in an output, and the click handler holds the button busy until the test creates that file — the busy assertion cannot miss regardless of runner speed (verified by injecting a 3s stall between click and assertion). No hard-coded sleeps remain, and the test is ~6s faster.

3. **The 120s per-test backstop from #2281 silently failed to fire.** pytest-timeout's default `signal` (SIGALRM) method raises inside Playwright's sync-API event loop rather than the test greenlet, so the worker stayed wedged (visible in the linked log: the first hung test failed at exactly 120s, the second hung 5+ minutes until the GHA kill). The Makefile now uses `--timeout-method=thread`, which reliably kills the wedged xdist worker so the session completes, traces upload, and the failure summary prints. Because the thread method's own stack dump goes to the worker's stdout (execnet's IPC pipe, lost), `faulthandler_timeout=110` additionally dumps every thread's stack to the original stderr fd — which xdist workers inherit — shortly before the kill, so CI logs show exactly where a hung test was stuck.

Also fixes a latent bug in `test_html_columns.py`: the `assert "header-html" in str(e)` was inside the `pytest.raises` block after the raising statement, so it never executed.

## Verification

- `pytest tests/playwright/shiny/inputs/input_task_button tests/playwright/shiny/inputs/input_task_button2 --browser chromium` passes repeatedly (3x stress run, ~2s per run vs ~13s before).
- `pytest tests/playwright/shiny/components/data_frame/html_columns --browser chromium` passes (pandas + polars).
- Hang handling verified with a synthetic hung test (`expect(...).to_have_attribute(..., timeout=0)` on a state that never appears) under `--numprocesses 2`: the faulthandler stack dump appears in the console at 5s, pytest-timeout kills the worker at 10s, xdist reports the test as FAILED, replaces the worker, and the session completes normally.