### PR TITLE
ci: Bake playwright npm package into remote Playwright server image

### DIFF
--- a/.github/py-shiny/setup-playwright-remote/action.yaml
+++ b/.github/py-shiny/setup-playwright-remote/action.yaml
@@ -2,6 +2,15 @@
 # as a lazy pull-through cache. GHCR is co-located with the runners, so a hit
 # is a fast pull with no Azure/MCR round-trip; a miss falls back to MCR and
 # pushes the image to GHCR for the next run. No separate mirror workflow.
+#
+# The MCR image ships browsers but strips the playwright npm package and the
+# npm cache from its final layer, so `npx -y playwright run-server` downloads
+# the package from registry.npmjs.org on every container start — silently, and
+# intermittently slower than any startup deadline. To keep the npm registry
+# out of the hot path, we bake `npm install playwright` into a derived
+# `-server` image (built once per version, cached in GHCR) and start the
+# server with `npx --no` so it can never fall back to a network install.
+#
 # The container runs `playwright run-server`; pytest-playwright on the host
 # connects via $PW_TEST_CONNECT_WS_ENDPOINT, so test code is unchanged.
 #
@@ -53,7 +62,8 @@ runs:
         echo "${{ github.token }}" | docker login ghcr.io \
           -u "${{ github.actor }}" --password-stdin
 
-    - name: Ensure Playwright image (GHCR pull-through cache)
+    - name: Ensure Playwright server image (GHCR pull-through cache)
+      id: server-image
       shell: bash
       run: |
         VERSION="${{ steps.resolve-version.outputs.version }}"
@@ -62,41 +72,69 @@ runs:
         # GHCR package names must be lowercase.
         OWNER_REPO="$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')"
         GHCR_REF="ghcr.io/${OWNER_REPO}/playwright:v${VERSION}-noble"
+        # MCR image plus the playwright npm package baked in, so `run-server`
+        # starts without touching the npm registry.
+        SERVER_REF="ghcr.io/${OWNER_REPO}/playwright:v${VERSION}-noble-server"
 
-        # Fast path: image already mirrored to GHCR (co-located with the
-        # runner, no MCR round-trip). Tag it to the MCR name so the rest of
-        # this action is agnostic about where the image came from.
-        if docker pull "$GHCR_REF"; then
-          echo "Pulled $GHCR_REF from GHCR."
-          docker tag "$GHCR_REF" "$MCR_REF"
+        echo "image-ref=$SERVER_REF" >> "$GITHUB_OUTPUT"
+
+        # Fast path: derived server image already in GHCR (co-located with
+        # the runner, no MCR or npm round-trip).
+        if docker pull "$SERVER_REF"; then
+          echo "Pulled $SERVER_REF from GHCR."
           exit 0
         fi
 
-        echo "GHCR miss for $GHCR_REF; falling back to MCR."
+        echo "GHCR miss for $SERVER_REF; building it from the base image."
 
-        # MCR (Azure Front Door) intermittently returns "The request is blocked"
-        # for GitHub Actions runners. Retry a few times before giving up.
-        attempt=1
-        max_attempts=5
-        until docker pull "$MCR_REF"; do
-          if [ "$attempt" -ge "$max_attempts" ]; then
-            echo "Failed to pull $MCR_REF after $attempt attempts" >&2
-            exit 1
-          fi
-          sleep_seconds=$((attempt * 10))
-          echo "docker pull failed (attempt $attempt/$max_attempts); retrying in ${sleep_seconds}s..." >&2
-          sleep "$sleep_seconds"
-          attempt=$((attempt + 1))
-        done
-
-        # Populate GHCR for the next run. Idempotent: concurrent first-runs on
-        # a fresh version push the same digest. A failed push must not fail the
-        # job — we already have the image locally.
-        docker tag "$MCR_REF" "$GHCR_REF"
-        if docker push "$GHCR_REF"; then
-          echo "Mirrored $MCR_REF -> $GHCR_REF."
+        # Base image: prefer the GHCR mirror, fall back to MCR.
+        if docker pull "$GHCR_REF"; then
+          echo "Pulled $GHCR_REF from GHCR."
+          docker tag "$GHCR_REF" "$MCR_REF"
         else
-          echo "Failed to push $GHCR_REF; continuing with local image." >&2
+          echo "GHCR miss for $GHCR_REF; falling back to MCR."
+
+          # MCR (Azure Front Door) intermittently returns "The request is blocked"
+          # for GitHub Actions runners. Retry a few times before giving up.
+          attempt=1
+          max_attempts=5
+          until docker pull "$MCR_REF"; do
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "Failed to pull $MCR_REF after $attempt attempts" >&2
+              exit 1
+            fi
+            sleep_seconds=$((attempt * 10))
+            echo "docker pull failed (attempt $attempt/$max_attempts); retrying in ${sleep_seconds}s..." >&2
+            sleep "$sleep_seconds"
+            attempt=$((attempt + 1))
+          done
+
+          # Populate the GHCR mirror for the next run. Idempotent: concurrent
+          # first-runs on a fresh version push the same digest. A failed push
+          # must not fail the job — we already have the image locally.
+          docker tag "$MCR_REF" "$GHCR_REF"
+          if docker push "$GHCR_REF"; then
+            echo "Mirrored $MCR_REF -> $GHCR_REF."
+          else
+            echo "Failed to push $GHCR_REF; continuing with local image." >&2
+          fi
+        fi
+
+        # Bake the playwright npm package into the server image. The npm
+        # registry is only reachable here, once per version — never at
+        # container start.
+        docker build -t "$SERVER_REF" - <<DOCKERFILE
+        FROM $MCR_REF
+        USER pwuser
+        WORKDIR /home/pwuser
+        RUN npm install playwright@${VERSION}
+        DOCKERFILE
+
+        # Populate GHCR for the next run; a failed push must not fail the job.
+        if docker push "$SERVER_REF"; then
+          echo "Pushed $SERVER_REF."
+        else
+          echo "Failed to push $SERVER_REF; continuing with local image." >&2
         fi
 
     - name: Start Playwright server
@@ -104,16 +142,18 @@ runs:
       run: |
         docker rm -f "${{ inputs.container-name }}" >/dev/null 2>&1 || true
 
+        # No --rm: if the server crashes, the container must survive so the
+        # logs-on-failure step below can read it. `docker rm -f` above cleans
+        # up any leftover container from a previous attempt.
         docker run -d \
           --name "${{ inputs.container-name }}" \
           --ipc=host \
           -p "127.0.0.1:${{ inputs.port }}:${{ inputs.port }}" \
-          --rm \
           --init \
           --workdir /home/pwuser \
           --user pwuser \
-          "mcr.microsoft.com/playwright:v${{ steps.resolve-version.outputs.version }}-noble" \
-          /bin/sh -c "npx -y playwright@${{ steps.resolve-version.outputs.version }} run-server --port ${{ inputs.port }} --host 0.0.0.0"
+          "${{ steps.server-image.outputs.image-ref }}" \
+          /bin/sh -c "npx --no -- playwright run-server --port ${{ inputs.port }} --host 0.0.0.0"
 
     - name: Wait for Playwright server
       shell: bash


### PR DESCRIPTION
## Summary

Fixes the intermittent `Setup remote Playwright` step failure (e.g. [this `playwright-examples (3.11, firefox, 2)` job](https://github.com/posit-dev/py-shiny/actions/runs/28635752609/job/84921607414)) where the readiness check times out after 60s with `WebSocket error: socket hang up` and `docker logs` shows nothing.

**Root cause:** the `mcr.microsoft.com/playwright:*-noble` image deletes the playwright npm package and the npm cache in its final build layer ([Dockerfile.noble](https://github.com/microsoft/playwright/blob/v1.61.0/utils/docker/Dockerfile.noble) removes `/ms-playwright-agent` and `~/.npm`). So the container command `npx -y playwright@<version> run-server` downloaded the package from registry.npmjs.org on **every container start** — silently (hence the empty `docker logs`), with nothing listening on the port in the meantime (docker-proxy accepts the TCP connect then resets it, hence `socket hang up`). When the npm registry is slow from the runner, the install blows past the 60s deadline. Same failure signature observed in runs 28617924863, 28611660379, and 28544845005.

**Fix:** extend the existing GHCR pull-through cache to store a derived `v<version>-noble-server` image with `npm install playwright@<version>` baked in, built once per Playwright version. The server now starts with `npx --no -- playwright run-server`, so container startup never touches the npm registry. On a GHCR miss the base image still comes from the GHCR mirror or MCR (with the existing retry loop), and pushes remain best-effort. Also drops `--rm` from `docker run` so a crashed server's logs survive for the logs-on-failure step (previously the container would be auto-removed and the diagnostics lost).

## Verification

Replicated the action's exact steps locally in Docker: built the derived image with the same inline Dockerfile (`npm install` runs at build time, ~2s), started the container with the same `docker run` flags, and ran the action's exact Python readiness check against firefox. It connected 5s after `docker run`, with `Listening on ws://0.0.0.0:43424/` in the container logs. Inspecting the stock MCR image confirmed no playwright npm package is present (`/ms-playwright-agent` absent, only corepack/npm/yarn installed globally, empty npm cache). In CI, the `playwright-*` jobs in this PR exercise the changed action directly; the first run per version builds and pushes the `-server` tag, subsequent runs pull it.