### PR TITLE
ci: Speed up Setup py-shiny with uv workspace venv and dependency caching

### DIFF
--- a/.github/py-shiny/setup/action.yaml
+++ b/.github/py-shiny/setup/action.yaml
@@ -13,10 +13,19 @@ runs:
         with:
           python-version: ${{ inputs.python-version }}
 
+      # On Windows runners the workspace and RUNNER_TEMP are on `D:` but the
+      # setup-python interpreter (and its site-packages) is on `C:`. uv can
+      # only hardlink when its cache is on the same drive as the install
+      # target, so place the cache on `C:` to avoid slow file-copy fallback.
+      # setup-uv respects a pre-existing UV_CACHE_DIR for its cache save/restore.
+      - name: Put `uv` cache on the same drive as Python (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          echo 'UV_CACHE_DIR=C:\uv-cache' >> $GITHUB_ENV
+
       # Installs the `uv` binary directly (no pip bootstrap) and caches uv's
-      # package cache between runs, keyed on pyproject.toml. On Windows the
-      # cache lives on the same drive as the workspace (RUNNER_TEMP), which
-      # lets uv hardlink packages instead of falling back to slow file copies.
+      # package cache between runs, keyed on pyproject.toml + python version.
       - name: Install `uv`
         # Pinned to an exact release; astral-sh/setup-uv has no floating `v8` tag
         uses: astral-sh/setup-uv@v8.2.0

--- a/.github/py-shiny/setup/action.yaml
+++ b/.github/py-shiny/setup/action.yaml
@@ -18,7 +18,7 @@ runs:
       # cache lives on the same drive as the workspace (RUNNER_TEMP), which
       # lets uv hardlink packages instead of falling back to slow file copies.
       - name: Install `uv`
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"

--- a/.github/py-shiny/setup/action.yaml
+++ b/.github/py-shiny/setup/action.yaml
@@ -13,19 +13,15 @@ runs:
         with:
           python-version: ${{ inputs.python-version }}
 
-      # On Windows runners the workspace and RUNNER_TEMP are on `D:` but the
-      # setup-python interpreter (and its site-packages) is on `C:`. uv can
-      # only hardlink when its cache is on the same drive as the install
-      # target, so place the cache on `C:` to avoid slow file-copy fallback.
-      # setup-uv respects a pre-existing UV_CACHE_DIR for its cache save/restore.
-      - name: Put `uv` cache on the same drive as Python (Windows)
-        if: runner.os == 'Windows'
-        shell: bash
-        run: |
-          echo 'UV_CACHE_DIR=C:\uv-cache' >> $GITHUB_ENV
-
       # Installs the `uv` binary directly (no pip bootstrap) and caches uv's
       # package cache between runs, keyed on pyproject.toml + python version.
+      #
+      # `activate-environment` creates and activates a venv in the workspace
+      # instead of installing into setup-python's site-packages. This matters
+      # on Windows runners: the workspace, RUNNER_TEMP (uv's cache), and the
+      # venv are all on the fast `D:` drive, so installs hardlink from the
+      # cache instead of copying files onto the slow `C:` drive where
+      # setup-python's interpreter lives.
       - name: Install `uv`
         # Pinned to an exact release; astral-sh/setup-uv has no floating `v8` tag
         uses: astral-sh/setup-uv@v8.2.0
@@ -33,12 +29,8 @@ runs:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
           cache-suffix: py${{ inputs.python-version }}
-
-      # https://github.com/astral-sh/uv/blob/main/docs/guides/integration/github.md#using-uv-pip
-      - name: Allow uv to use the system Python by default
-        shell: bash
-        run: |
-          echo "UV_SYSTEM_PYTHON=1" >> $GITHUB_ENV
+          activate-environment: true
+          python-version: ${{ inputs.python-version }}
 
       - name: Install dependencies
         shell: bash

--- a/.github/py-shiny/setup/action.yaml
+++ b/.github/py-shiny/setup/action.yaml
@@ -13,15 +13,16 @@ runs:
         with:
           python-version: ${{ inputs.python-version }}
 
-      - name: Upgrade `pip`
-        shell: bash
-        run: |
-          python -m pip install --upgrade pip
-
+      # Installs the `uv` binary directly (no pip bootstrap) and caches uv's
+      # package cache between runs, keyed on pyproject.toml. On Windows the
+      # cache lives on the same drive as the workspace (RUNNER_TEMP), which
+      # lets uv hardlink packages instead of falling back to slow file copies.
       - name: Install `uv`
-        shell: bash
-        run: |
-          pip install uv
+        uses: astral-sh/setup-uv@v8
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+          cache-suffix: py${{ inputs.python-version }}
 
       # https://github.com/astral-sh/uv/blob/main/docs/guides/integration/github.md#using-uv-pip
       - name: Allow uv to use the system Python by default

--- a/.github/py-shiny/setup/action.yaml
+++ b/.github/py-shiny/setup/action.yaml
@@ -18,6 +18,7 @@ runs:
       # cache lives on the same drive as the workspace (RUNNER_TEMP), which
       # lets uv hardlink packages instead of falling back to slow file copies.
       - name: Install `uv`
+        # Pinned to an exact release; astral-sh/setup-uv has no floating `v8` tag
         uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true

--- a/Makefile
+++ b/Makefile
@@ -277,8 +277,12 @@ dist: clean ## builds source and wheel package
 install: dist
 	pip uninstall -y shiny
 	python -m pip install dist/shiny*.whl
-ci-install-wheel: dist FORCE
-	# `uv` version of `make install`
+ci-install-wheel: FORCE
+	# `uv` version of `make install`; `uv build` is much faster than
+	# `pip install build` + `python -m build` as it caches build dependencies
+	rm -fr dist/
+	uv build
+	ls -l dist
 	uv pip uninstall shiny
 	uv pip install dist/shiny*.whl
 


### PR DESCRIPTION
## Problem

`Setup py-shiny` took ~2.5 min on Windows vs ~30s on mac/ubuntu (example: [job](https://github.com/posit-dev/py-shiny/actions/runs/28637148395/job/84925774405?pr=2302)). Breakdown of the 153s on Windows:

- **68s** — `Prepared 210 packages`: downloading + extracting all deps on every run (no cache)
- **41s** — `Installed 213 packages`: installs targeted setup-python's site-packages on the slow `C:` drive
- **24s** — `ci-install-wheel`: `pip install build` + two isolated `python -m build` invocations
- ~8s — `pip install --upgrade pip` + `pip install uv`

## Fix

1. Replace the pip-based uv bootstrap with `astral-sh/setup-uv@v8.2.0` (no floating `v8` tag exists):
   - `enable-cache: true` persists uv's package cache via GitHub Actions cache, keyed on `pyproject.toml` + python version
   - `activate-environment: true` creates/activates a venv in the workspace instead of installing into the system Python. On Windows this puts the venv, uv cache (`RUNNER_TEMP`), and workspace all on the fast `D:` drive, so installs hardlink instead of copying onto `C:`
2. `ci-install-wheel` uses `uv build` instead of `pip install build` + `python -m build`

All downstream CI steps use `uv pip` or console scripts (`pytest`, `playwright`, `pyright`), which resolve to the activated venv.

## Measured results (Windows `check` job, run 28638714579 — cache miss)

| Phase | Before | After |
|---|---|---|
| Resolve | 10s | 6s |
| Prepared (download/extract) | 68s | **10s** |
| Installed | 41s | **3.6s** |
| Wheel build + install | 24s | ~14s |
| **Total setup** | **153s** | **~38s** |

Ubuntu: ~22s, macOS: ~30–60s (also benefit from the uv cache).