### PR TITLE
chore: Clean up packaging config for warning-free builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other changes
 
+* Packaging metadata now uses a PEP 639 SPDX license expression instead of the deprecated `license` table and license classifier, and stale `MANIFEST.in` rules were removed. Building the package (e.g. with `uv build`) no longer emits setuptools deprecation or manifest warnings. Wheel and sdist contents are unchanged. (#2304)
+
 * `shiny.run.run_shiny_app()` (and therefore `shiny.pytest.create_app_fixture()`) now picks random app ports from a disjoint per-worker port range when running under pytest-xdist, instead of the full 1024-49151 range shared by all workers. This prevents parallel test workers from racing to bind the same port and from reusing each other's recycled ports. When not running under pytest-xdist, the behavior is unchanged: ports are picked from `random_port()`'s full default range (1024-49151). (#2297)
 
 ## [1.6.3] - 2026-06-01

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,14 +1,8 @@
 include LICENSE
 
 recursive-include tests *
-recursive-exclude * __pycache__
-recursive-exclude * shiny_bookmarks
-recursive-exclude * *.py[co]
-
-recursive-include docs *.rst conf.py Makefile make.bat *.jpg *.png *.gif
 
 recursive-include shiny/www *
-recursive-include shiny/experimental/www *
 recursive-include shiny/templates *
 
 prune shiny/api-examples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,15 +3,23 @@ requires = ["setuptools>=77", "wheel", "setuptools_scm>=8.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
+# Declare package data explicitly (instead of the default include-package-data
+# manifest scan) so build_py does not warn that asset/template directories are
+# "absent from the `packages` configuration". The second glob is needed because
+# `**` does not match hidden files (the package templates ship .gitignore files).
+include-package-data = false
+
+[tool.setuptools.package-data]
+shiny = ["**", "**/.gitignore"]
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["shiny*"]
 # Keep `false` so only directories with an `__init__.py` are packaged as code.
 # `true` would register every asset/template directory (shiny/www/..., etc.) as
 # a PEP 420 namespace package and sweep in any stray directory or .py file that
-# lands under shiny/, over-exposing the package surface. The cost of `false` is
-# cosmetic: build_py warns that those data directories are "absent from the
-# `packages` configuration" while still bundling them via include-package-data.
+# lands under shiny/, over-exposing the package surface. Those directories are
+# instead shipped as data files via the package-data globs above.
 namespaces = false
 
 [tool.setuptools.exclude-package-data]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [build-system]
-requires = ["setuptools>=60", "wheel", "setuptools_scm>=8.0"]
+requires = ["setuptools>=77", "wheel", "setuptools_scm>=8.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["shiny*"]
-namespaces = false
+namespaces = true
 
 [tool.setuptools.exclude-package-data]
 "*" = ["api-examples/**"]
@@ -22,11 +22,11 @@ authors = [{ name = "Winston Chang", email = "winston@posit.co" }]
 description = "A web development framework for Python."
 readme = "README.md"
 requires-python = ">=3.10"
-license = { text = "MIT" }
+license = "MIT"
+license-files = ["LICENSE"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,13 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["shiny*"]
-namespaces = true
+# Keep `false` so only directories with an `__init__.py` are packaged as code.
+# `true` would register every asset/template directory (shiny/www/..., etc.) as
+# a PEP 420 namespace package and sweep in any stray directory or .py file that
+# lands under shiny/, over-exposing the package surface. The cost of `false` is
+# cosmetic: build_py warns that those data directories are "absent from the
+# `packages` configuration" while still bundling them via include-package-data.
+namespaces = false
 
 [tool.setuptools.exclude-package-data]
 "*" = ["api-examples/**"]


### PR DESCRIPTION
## Summary

With this PR, wheel and sdist contents are byte-for-byte identical to the baseline, and `uv build` is fully warning-free.

`uv build` (or any setuptools-based build) currently emits a wall of warnings: 3 `SetuptoolsDeprecationWarning` blocks about license metadata, 7 `MANIFEST.in` "no files found matching" warnings, and ~110 informational `_Warning: Package '...' is absent from the packages configuration` lines. This PR removes the causes of all three groups. Artifact contents were verified via `RECORD` and `tar -tzf` file-list diffs; the only metadata difference is that the wheel METADATA now carries `License-Expression: MIT` / `License-File: LICENSE`.

### 1. PEP 639 license metadata (`pyproject.toml`)

`license = { text = "MIT" }` → `license = "MIT"` (SPDX expression) plus `license-files = ["LICENSE"]`, and the deprecated `License :: OSI Approved :: MIT License` classifier is removed. Both old forms are deprecated by setuptools with a 2027-02-18 removal date. The build requirement is bumped from `setuptools>=60` to `setuptools>=77`, the first version that understands SPDX license expressions.

### 2. Explicit package data instead of the manifest scan (`pyproject.toml`)

The `_Warning: Package ... is absent` lines come from the default `include-package-data` path: build_py reverse-engineers the manifest and warns every time it copies data files out of a directory that package discovery skipped (all of `shiny/www/...`, `shiny/templates/...`, etc., since they have no `__init__.py`). This PR sets `include-package-data = false` and declares the data explicitly:

```toml
[tool.setuptools.package-data]
shiny = ["**", "**/.gitignore"]
```

The explicit-glob code path performs no "does this look like a package?" check, so the warnings disappear. The second glob is required because `**` does not match hidden files and `shiny/templates/package/` ships `.gitignore` files as template content.

Notably, `packages.find.namespaces = false` is kept and now documented with a comment. The alternative fix (namespace-mode discovery, which was in effect before #2126 switched it off as a side effect of a config rewrite) would silence the warnings too, but it registers every asset directory as a PEP 420 namespace package and sweeps in any stray directory or `.py` file that lands under `shiny/`, over-exposing the package surface.

### 3. Stale rules removed (`MANIFEST.in`)

Each of these produced a "no files found matching" / "no previously-included files" warning because it matches nothing:

* Sphinx-era `recursive-include docs *.rst conf.py Makefile make.bat ...` — those files no longer exist.
* `recursive-include shiny/experimental/www *` — directory no longer exists.
* `recursive-exclude * __pycache__ / shiny_bookmarks / *.py[co]` — redundant because setuptools_scm already restricts the sdist to git-tracked files.

## Verification

From a checkout of this branch:

```bash
uv build 2>&1 | grep -iE "warning|deprecat" | grep -v "_deprecated\|_deprecate.scss\|deprecated/"
```

produces no output (the trailing `grep -v` only strips source filenames that contain the word "deprecated"). To confirm artifact contents are unchanged, build on `main` and on this branch, then diff `tar -tzf` output for the sdists and the `RECORD` file lists for the wheels — they are identical: 743 `shiny/www` asset files retained, template `.gitignore` files retained, `api-examples` and `__pycache__` still excluded. The wheel METADATA gains `License-Expression: MIT` and `License-File: LICENSE`.