### PR TITLE
fix(tests): Wait for data frame re-mount after reset before sorting

### DIFF
--- a/tests/playwright/shiny/components/data_frame/df_methods/test_df_methods.py
+++ b/tests/playwright/shiny/components/data_frame/df_methods/test_df_methods.py
@@ -28,7 +28,15 @@ def test_dataframe_methods(page: Page, local_app: ShinyAppProc, tab_name: str) -
     update_filter = controller.InputActionButton(page, f"{tab_name}-update_filter")
 
     def reset_data_frame():
+        # Clicking reset invalidates the data frame output, which re-mounts the
+        # client-side table with fresh (unsorted / unfiltered) state. Wait for the
+        # current table element to be replaced before interacting with the data
+        # frame again; otherwise a subsequent action (e.g. a sort click) can race
+        # the re-mount and be silently discarded. The output values below are not
+        # sufficient synchronization as they may already have their expected values.
+        old_table = data_frame.loc_table.element_handle()
         reset_df.click()
+        page.wait_for_function("el => !el.isConnected", arg=old_table)
         data_view_rows.expect_value("(0, 1, 2, 3, 4, 5)")
         data_view_selected_true.expect_value("[]")
         data_view_selected_false.expect_value("[0, 1, 50, 51, 100, 101]")


### PR DESCRIPTION
## Summary
Fixes the webkit CI flake seen in https://github.com/posit-dev/py-shiny/actions/runs/28638717823/job/84930322450 (`test_df_methods.py::test_dataframe_methods[webkit-pandas]` failed with `data_view_rows` stuck at `(0, 1, 2, 3, 4, 5)` after `set_sort(0)`).

Root cause: clicking the app's reset button calls `_reset_reactives()`, which sets `self._value` to `None`. Since the renderer's `render()` reads `_value` (via `selection_modes()`), every reset click invalidates the data frame output and re-sends the full payload. On the client, `ShinyDataFrameOutput.renderValue()` unmounts the React root and mounts a fresh grid with empty sort/filter state. The test's first `reset_data_frame()` call runs while the table is already in its initial state, so its `expect_value` assertions pass immediately without waiting for that re-render round trip. The subsequent `set_sort(0)` header click then races the client-side table re-mount and gets silently discarded on slow runners (webkit CI), leaving the table unsorted forever. Every later `reset_data_frame()` call self-synchronizes because at least one expected output value actually changes.

The fix makes `reset_data_frame()` deterministic: grab a handle to the current `<table>` element before clicking reset, then wait for that element to detach (i.e. the re-mount completed) before asserting values or interacting further.

## Verification
Ran `tests/playwright/shiny/components/data_frame/df_methods/test_df_methods.py` locally 3x on webkit and 1x on chromium (both pandas and polars params) — all pass. Also verified the synchronization holds with an artificially delayed app (0.4s `asyncio.sleep` in the `iris_df` render, which widens the race window well past what CI sees).