### PR TITLE
ci: Remove Playwright diagnostic flags that never recorded anything

### DIFF
--- a/.github/py-shiny/pytest-browsers/action.yaml
+++ b/.github/py-shiny/pytest-browsers/action.yaml
@@ -9,20 +9,10 @@ inputs:
     description: 'Force all pytest browsers to used when testing'
     required: false
     default: 'false'
-  disable-playwright-diagnostics:
-    description: 'Disable playwright diagnostics: tracing, video, screenshot'
-    required: false
-    default: 'true'
 outputs:
   browsers:
     description: 'pytest browsers to use'
     value: ${{ steps.browsers.outputs.browsers }}
-  has-playwright-diagnostics:
-    description: 'Whether playwright diagnostics have been enabled'
-    value: ${{ steps.browsers.outputs.has-playwright-diagnostics }}
-  playwright-diagnostic-args:
-    description: 'Args to supply to `make playwright` like commands.'
-    value: ${{ steps.browsers.outputs.playwright-diagnostic-args }}
 runs:
   using: "composite"
   steps:
@@ -32,16 +22,6 @@ runs:
         id: browsers
         run: |
           # Determine which browsers to use
-
-          if [ "${{ inputs.disable-playwright-diagnostics }}" == "true" ]; then
-            echo "Disabling playwright diagnostics!"
-            echo 'has-playwright-diagnostics=false' >> "$GITHUB_OUTPUT"
-            echo 'playwright-diagnostic-args=--tracing off --video off --screenshot off' >> "$GITHUB_OUTPUT"
-          else
-            echo "Using playwright diagnostics!"
-            echo 'has-playwright-diagnostics=true' >> "$GITHUB_OUTPUT"
-            echo 'playwright-diagnostic-args=--tracing=retain-on-failure --screenshot=only-on-failure --full-page-screenshot --video off --output=test-results' >> "$GITHUB_OUTPUT"
-          fi
 
           if [ "${{ inputs.browser }}" != "" ]; then
             BROWSER="${{ inputs.browser }}"

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -140,9 +140,6 @@ jobs:
         id: browsers
         with:
           browser: ${{ matrix.browser }}
-          # If anything other than `true`, it will heavily reduce webkit performance
-          # Related: https://github.com/microsoft/playwright/issues/18119
-          disable-playwright-diagnostics: ${{ matrix.browser == 'webkit' || matrix.browser == 'firefox' }}
 
       - name: Setup remote Playwright
         uses: ./.github/py-shiny/setup-playwright-remote
@@ -153,13 +150,7 @@ jobs:
         # Healthy shards finish in ~4 minutes; kill stragglers quickly
         timeout-minutes: 10
         run: |
-          make playwright-shiny SUB_FILE=". --numprocesses 3 --num-shards 4 --shard-id ${{ matrix.shard }} ${{ steps.browsers.outputs.playwright-diagnostic-args }}" ${{ steps.browsers.outputs.browsers }}
-      - uses: actions/upload-artifact@v6
-        if: failure() && steps.browsers.outputs.has-playwright-diagnostics
-        with:
-          name: "playright-shiny-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.browser }}-shard${{ matrix.shard }}-results"
-          path: test-results/
-          retention-days: 5
+          make playwright-shiny SUB_FILE=". --numprocesses 3 --num-shards 4 --shard-id ${{ matrix.shard }}" ${{ steps.browsers.outputs.browsers }}
 
   playwright-examples:
     if: github.event_name != 'release'
@@ -197,9 +188,6 @@ jobs:
         id: browsers
         with:
           browser: ${{ matrix.browser }}
-          # If anything other than `true`, it will heavily reduce webkit performance
-          # Related: https://github.com/microsoft/playwright/issues/18119
-          disable-playwright-diagnostics: ${{ matrix.browser == 'webkit' || matrix.browser == 'firefox' }}
 
       - name: Install node.js
         uses: actions/setup-node@v6
@@ -229,13 +217,7 @@ jobs:
         # Healthy shards finish in ~4 minutes; kill stragglers quickly
         timeout-minutes: 10
         run: |
-          make playwright-examples SUB_FILE=". --numprocesses 3 --num-shards 4 --shard-id ${{ matrix.shard }} ${{ steps.browsers.outputs.playwright-diagnostic-args }}" ${{ steps.browsers.outputs.browsers }}
-      - uses: actions/upload-artifact@v6
-        if: failure() && steps.browsers.outputs.has-playwright-diagnostics
-        with:
-          name: "playright-examples-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.browser }}-shard${{ matrix.shard }}-results"
-          path: test-results/
-          retention-days: 5
+          make playwright-examples SUB_FILE=". --numprocesses 3 --num-shards 4 --shard-id ${{ matrix.shard }}" ${{ steps.browsers.outputs.browsers }}
 
   playwright-ai:
     if: github.event_name != 'release'
@@ -273,9 +255,6 @@ jobs:
         id: browsers
         with:
           browser: ${{ matrix.browser }}
-          # If anything other than `true`, it will heavily reduce webkit performance
-          # Related: https://github.com/microsoft/playwright/issues/18119
-          disable-playwright-diagnostics: ${{ matrix.browser == 'webkit' || matrix.browser == 'firefox' }}
 
       - name: Setup remote Playwright
         uses: ./.github/py-shiny/setup-playwright-remote
@@ -286,13 +265,7 @@ jobs:
         # Healthy shards finish in ~4 minutes; kill stragglers quickly
         timeout-minutes: 10
         run: |
-          make playwright-ai SUB_FILE=". --numprocesses 3 --num-shards 2 --shard-id ${{ matrix.shard }} ${{ steps.browsers.outputs.playwright-diagnostic-args }}" ${{ steps.browsers.outputs.browsers }}
-      - uses: actions/upload-artifact@v6
-        if: failure() && steps.browsers.outputs.has-playwright-diagnostics
-        with:
-          name: "playright-ai-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.browser }}-shard${{ matrix.shard }}-results"
-          path: test-results/
-          retention-days: 5
+          make playwright-ai SUB_FILE=". --numprocesses 3 --num-shards 2 --shard-id ${{ matrix.shard }}" ${{ steps.browsers.outputs.browsers }}
 
   playwright-deploys-precheck:
     if: github.event_name != 'release'
@@ -332,13 +305,6 @@ jobs:
           DEPLOY_APPS: "false"
         run: |
           make playwright-deploys
-
-      - uses: actions/upload-artifact@v6
-        if: failure()
-        with:
-          name: "playright-examples-${{ runner.os }}-${{ matrix.python-version }}-results"
-          path: test-results/
-          retention-days: 5
 
   test-narwhals-integration:
     runs-on: ubuntu-latest

--- a/tests/playwright/playwright-pytest.ini
+++ b/tests/playwright/playwright-pytest.ini
@@ -5,12 +5,12 @@ asyncio_mode=strict
 # --durations-min <n>: Require that the top `k` slowest durations are longer than `n` seconds
 # --browser <name>: browser type to run on playwright
 # --numprocesses auto: number of testing workers. auto is number of (virtual) cores
-# --video=retain-on-failure: playwright saves recording of any failed test
-# --tracing=retain-on-failure: playwright saves trace of any failed test
-# --video=on: Always save playwright recording for every test
-# --tracing=on: Always save playwright trace for every test
+# NOTE: pytest-playwright's --tracing/--video/--screenshot options have no
+# effect in this test suite: conftest.py overrides the `page` fixture with a
+# session-shared page created directly from the browser, which bypasses the
+# plugin's `context` fixture where those artifacts are recorded.
 # -vv: Extra extra verbose output
 # # --headed: Headed browser testing
 # # -r P: Show extra test summary info: (f)ailed, (E)rror, (s)kipped, (x)failed, (X)passed, (p)assed, (P)assed with output, (a)ll except passed (p/P), or (A)ll. (w)arnings...
 # --maxfail=1: Stop after 1 failure has occurred
-addopts = --strict-markers --durations=6 --durations-min=5.0 --browser chromium --numprocesses auto -vvv --maxfail=1 --headed --tracing=on --slowmo=250
+addopts = --strict-markers --durations=6 --durations-min=5.0 --browser chromium --numprocesses auto -vvv --maxfail=1 --headed --slowmo=250


### PR DESCRIPTION
## Summary

The Playwright diagnostics plumbing (tracing, video, screenshots) has never produced any artifacts in this repo, so this PR removes it. The root cause: `tests/playwright/conftest.py` overrides the `page` fixture with a session-shared page created directly from the browser, which bypasses pytest-playwright's `context` fixture — the place where `--tracing`/`--video`/`--screenshot` artifacts are actually recorded. As a result the "diagnostics enabled" chromium jobs recorded nothing, and every `test-results/` artifact upload found no files (no recent failed run has a single `*-results` artifact).

Changes:

- `pytest-browsers` action: remove the `disable-playwright-diagnostics` input and the `has-playwright-diagnostics` / `playwright-diagnostic-args` outputs.
- `pytest.yaml`: drop the diagnostic args from all three `make playwright-*` invocations and remove four `upload-artifact` steps for `test-results/` that never had files to upload. (Those steps also ran on every failure regardless of the toggle, because the string `'false'` is truthy in `if:` expressions.)
- `playwright-pytest.ini` (local `make playwright-debug` config): remove the no-op `--tracing=on` and document why these flags don't work here, so they don't get re-added expecting output.

## Verification

Locally, `pytest -c tests/playwright/playwright-pytest.ini <any test> --tracing=on` completes with no `test-results/` directory created anywhere — confirming the flags were dead. After this change, `make playwright-debug TEST_FILE=tests/playwright/shiny/inputs/input_task_button/test_input_task_button.py` still runs headed as before. On CI, the playwright jobs should behave identically (the removed args were no-ops); the only visible difference is the absence of the always-empty artifact upload steps.