### PR TITLE
fix(tests): Make task button blocking test deterministic

### DIFF
--- a/tests/playwright/shiny/inputs/input_task_button/app.py
+++ b/tests/playwright/shiny/inputs/input_task_button/app.py
@@ -13,6 +13,14 @@ render_times: list[float] = []
 # renders that ran inside that blocking window.
 block_render_counts = reactive.value[tuple[int, ...]](())
 
+# Start time of the most recent non-blocking (extended task) invocation, and
+# one entry per completed invocation: the number of current_time renders that
+# ran inside that non-blocking window. This is the negative control for
+# block_render_counts: the session keeps flushing during an extended task, so
+# these counts prove the render counter registers renders when they happen.
+nonblock_start: list[float] = []
+nonblock_render_counts = reactive.value[tuple[int, ...]](())
+
 ui.h5("Current time")
 
 
@@ -51,7 +59,18 @@ with ui.layout_sidebar():
     @reactive.event(input.btn_task, ignore_none=False)
     def handle_click():
         # slow_compute.cancel()
+        nonblock_start.append(time.time())
         slow_compute(input.x(), input.y())
+
+    @reactive.effect
+    def record_nonblock_window():
+        slow_compute.result()  # Re-runs this effect when a result arrives
+        t1 = time.time()
+        count = sum(1 for t in render_times if nonblock_start[-1] < t < t1)
+        # Isolate the read so appending does not re-trigger this effect.
+        with reactive.isolate():
+            counts = nonblock_render_counts()
+        nonblock_render_counts.set(counts + (count,))
 
     @reactive.effect
     @reactive.event(input.btn_block, ignore_none=False)
@@ -82,3 +101,9 @@ with ui.layout_sidebar():
     @render.text
     def renders_during_block():
         return ",".join(str(count) for count in block_render_counts())
+
+    ui.h5("Time renders during each non-blocking window")
+
+    @render.text
+    def renders_during_nonblock():
+        return ",".join(str(count) for count in nonblock_render_counts())

--- a/tests/playwright/shiny/inputs/input_task_button/app.py
+++ b/tests/playwright/shiny/inputs/input_task_button/app.py
@@ -24,7 +24,11 @@ nonblock_render_counts = reactive.value[tuple[int, ...]](())
 ui.h5("Current time")
 
 
-@render.text()
+# Rendered as code: the busy-indicator spinner CSS applies
+# `min-height: 32px` to any recalculating output, which makes a plain text
+# output (24px tall) bounce the layout on every tick. A `pre` block is
+# already taller than 32px, so the rapid updates cause no layout shift.
+@render.code
 def current_time() -> str:
     reactive.invalidate_later(0.1)
     render_times.append(time.time())
@@ -92,18 +96,18 @@ with ui.layout_sidebar():
 
     ui.h5("Sum of x and y")
 
-    @render.text
+    @render.code
     def show_result():
         return str(slow_compute.result())
 
     ui.h5("Time renders during each blocking window")
 
-    @render.text
+    @render.code
     def renders_during_block():
         return ",".join(str(count) for count in block_render_counts())
 
     ui.h5("Time renders during each non-blocking window")
 
-    @render.text
+    @render.code
     def renders_during_nonblock():
         return ",".join(str(count) for count in nonblock_render_counts())

--- a/tests/playwright/shiny/inputs/input_task_button/app.py
+++ b/tests/playwright/shiny/inputs/input_task_button/app.py
@@ -1,8 +1,17 @@
 import asyncio
+import time
 from datetime import datetime, timezone
 
 from shiny import reactive, render
 from shiny.express import input, ui
+
+# Timestamps of every current_time render, used to verify that no renders
+# happen while the session is blocked.
+render_times: list[float] = []
+
+# One entry per completed blocking computation: the number of current_time
+# renders that ran inside that blocking window.
+block_render_counts = reactive.value[tuple[int, ...]](())
 
 ui.h5("Current time")
 
@@ -10,6 +19,7 @@ ui.h5("Current time")
 @render.text()
 def current_time() -> str:
     reactive.invalidate_later(0.1)
+    render_times.append(time.time())
     return str(datetime.now(timezone.utc).isoformat())
 
 
@@ -47,7 +57,14 @@ with ui.layout_sidebar():
     @reactive.event(input.btn_block, ignore_none=False)
     async def handle_click2():
         # slow_compute.cancel()
+        t0 = time.time()
         await slow_input_compute(input.x(), input.y())
+        t1 = time.time()
+        # Renders queued while the session was blocked run after t1, so any
+        # timestamp strictly inside the window is a render that happened
+        # while this handler was (supposedly) blocking the session.
+        count = sum(1 for t in render_times if t0 < t < t1)
+        block_render_counts.set(block_render_counts() + (count,))
 
     @reactive.effect
     @reactive.event(input.btn_cancel)
@@ -59,3 +76,9 @@ with ui.layout_sidebar():
     @render.text
     def show_result():
         return str(slow_compute.result())
+
+    ui.h5("Time renders during each blocking window")
+
+    @render.text
+    def renders_during_block():
+        return ",".join(str(count) for count in block_render_counts())

--- a/tests/playwright/shiny/inputs/input_task_button/test_input_task_button.py
+++ b/tests/playwright/shiny/inputs/input_task_button/test_input_task_button.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 from playwright.sync_api import Page
 
 from shiny.playwright import controller
@@ -46,6 +48,14 @@ def test_input_action_task_button(page: Page, local_app: ShinyAppProc) -> None:
     result.expect_value("3")
     # After the calculation time plus a buffer, make sure the calculation finishes
     result.expect_value("5", timeout=10 * 1000)
+
+    # Negative control for the render counter used by the blocking check
+    # below: the session keeps flushing during an extended task, so the second
+    # (clicked) non-blocking window must contain renders. This proves a zero
+    # count means "blocked", not "counter broken". The first (startup) window
+    # overlaps the startup blocking window, so its count is not constrained.
+    renders_during_nonblock = controller.OutputText(page, "renders_during_nonblock")
+    renders_during_nonblock.expect_value(re.compile(r"^\d+,[1-9]\d*$"))
 
     # set up Blocking test
     y.set("15")

--- a/tests/playwright/shiny/inputs/input_task_button/test_input_task_button.py
+++ b/tests/playwright/shiny/inputs/input_task_button/test_input_task_button.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import time
-
 from playwright.sync_api import Page
 
 from shiny.playwright import controller
@@ -53,15 +51,25 @@ def test_input_action_task_button(page: Page, local_app: ShinyAppProc) -> None:
     y.set("15")
     result.expect_value("5")
 
-    # Blocking verification
+    # Blocking verification. The server records how many current_time renders
+    # occur inside each blocking window; this avoids sampling the display on a
+    # timer from the client, which races against in-flight output updates.
+    renders_during_block = controller.OutputText(page, "renders_during_block")
+    # The `ignore_none=False` handler already ran one blocking window at
+    # startup; it must not have allowed any renders either.
+    renders_during_block.expect_value("0")
+
     button_block = controller.InputTaskButton(page, "btn_block")
     button_block.expect_label_busy("\n  \n Blocking...")
     button_block.expect_label_ready("Block compute")
     button_block.expect_auto_reset(True)
-    time_block = click_extended_task_button(
+    click_extended_task_button(
         button_block,
         current_time,
     )
-    # Make sure time value has not changed after 500ms has ellapsed
-    time.sleep(0.5)
-    current_time.expect_value(time_block)
+    # Once the blocking computation finishes, the server reports zero
+    # current_time renders inside the second blocking window.
+    renders_during_block.expect_value("0,0", timeout=10 * 1000)
+    # The time ticker must still be alive afterwards, proving the zero count
+    # came from blocking rather than from a dead ticker.
+    current_time.expect.not_to_have_text(current_time.get_value(), timeout=1000)

--- a/tests/playwright/shiny/inputs/input_task_button/test_input_task_button.py
+++ b/tests/playwright/shiny/inputs/input_task_button/test_input_task_button.py
@@ -10,7 +10,7 @@ from shiny.run import ShinyAppProc
 
 def click_extended_task_button(
     button: controller.InputTaskButton,
-    current_time: controller.OutputText,
+    current_time: controller.OutputCode,
 ) -> str:
     button.expect_state("ready")
     button.click()
@@ -18,15 +18,15 @@ def click_extended_task_button(
     # this assertion must run promptly; a finite timeout keeps a missed busy
     # window a fast, diagnosable failure instead of an infinite hang.
     button.expect_state("busy")
-    return current_time.get_value()
+    return current_time.loc.inner_text()
 
 
 def test_input_action_task_button(page: Page, local_app: ShinyAppProc) -> None:
     page.goto(local_app.url)
     y = controller.InputNumeric(page, "y")
     y.set("4")
-    result = controller.OutputText(page, "show_result")
-    current_time = controller.OutputText(page, "current_time")
+    result = controller.OutputCode(page, "show_result")
+    current_time = controller.OutputCode(page, "current_time")
     # Make sure the time has content
     current_time.expect.not_to_be_empty()
 
@@ -54,7 +54,7 @@ def test_input_action_task_button(page: Page, local_app: ShinyAppProc) -> None:
     # (clicked) non-blocking window must contain renders. This proves a zero
     # count means "blocked", not "counter broken". The first (startup) window
     # overlaps the startup blocking window, so its count is not constrained.
-    renders_during_nonblock = controller.OutputText(page, "renders_during_nonblock")
+    renders_during_nonblock = controller.OutputCode(page, "renders_during_nonblock")
     renders_during_nonblock.expect_value(re.compile(r"^\d+,[1-9]\d*$"))
 
     # set up Blocking test
@@ -64,7 +64,7 @@ def test_input_action_task_button(page: Page, local_app: ShinyAppProc) -> None:
     # Blocking verification. The server records how many current_time renders
     # occur inside each blocking window; this avoids sampling the display on a
     # timer from the client, which races against in-flight output updates.
-    renders_during_block = controller.OutputText(page, "renders_during_block")
+    renders_during_block = controller.OutputCode(page, "renders_during_block")
     # The `ignore_none=False` handler already ran one blocking window at
     # startup; it must not have allowed any renders either.
     renders_during_block.expect_value("0")
@@ -82,4 +82,4 @@ def test_input_action_task_button(page: Page, local_app: ShinyAppProc) -> None:
     renders_during_block.expect_value("0,0", timeout=10 * 1000)
     # The time ticker must still be alive afterwards, proving the zero count
     # came from blocking rather than from a dead ticker.
-    current_time.expect.not_to_have_text(current_time.get_value(), timeout=1000)
+    current_time.expect.not_to_have_text(current_time.loc.inner_text(), timeout=1000)


### PR DESCRIPTION
## Summary

Follow-up to the flaky `test_input_action_task_button[webkit]` failure seen in #2303's CI. The old test sampled the clock display from the client and asserted it stayed frozen for a fixed window, which raced against the last in-flight render and depended on wall-clock margins on loaded CI runners.

- **Deterministic blocking check:** the app now counts `current_time` renders that land strictly inside each blocking window (timestamps recorded server-side around the blocking `await`) and publishes the history as a `renders_during_block` output. A correctly blocking session always yields `0`, so the test reduces to `expect_value("0,0")` — a Playwright auto-waiting assertion on a real condition with no sleeps or timing budgets. The history format (`0` at startup via `ignore_none=False`, then `0,0` after the click) prevents a vacuous pass on the stale startup value.
- **Built-in negative control:** the same counter measures the *non-blocking* extended-task window, where the 0.1s ticker must render (`renders_during_nonblock` asserted nonzero via regex). This proves the zeros in the blocking history mean "blocked", not "counter broken".
- **Flicker fix:** the test app's fast-updating text outputs now use `@render.code`; the busy-indicator `min-height: 32px` made shorter `@render.text` outputs bounce the layout on every 0.1s tick.

The removal of the never-recording Playwright diagnostic flags in CI is split out into its own PR.

## Verification

- The task-button test passed repeatedly locally (chromium and webkit), including after rebasing onto the merged #2303.
- Negative tests: artificially widening the blocking window (real renders inside it) and hard-coding the non-block counter to 0 both made the test fail, confirming each assertion detects the failure it guards against.
- Run it yourself: `make playwright-shiny SUB_FILE="inputs/input_task_button"`.