### PR TITLE
Security: Potential Information Disclosure in Error Handling

### DIFF
--- a/shiny/_error.py
+++ b/shiny/_error.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import logging
 from typing import cast
 
 import starlette.exceptions as exceptions
 import starlette.responses as responses
 from starlette.types import ASGIApp, Receive, Scope, Send
+
+logger = logging.getLogger(__name__)
 
 
 class ErrorMiddleware:
@@ -22,7 +25,7 @@ class ErrorMiddleware:
             return await self.app(scope, receive, send)
         except exceptions.HTTPException as e:
             resp = responses.PlainTextResponse(
-                e.detail,
+                "An error occurred",
                 e.status_code,
                 headers=cast(
                     "dict[str, str]",
@@ -32,9 +35,7 @@ class ErrorMiddleware:
             )
             await resp(scope, receive, send)
         except Exception as e:
-            # Seems super weird this is just going to stdout, should we use logger or
-            # at least stderr?
-            print("Unhandled error: " + str(e))
+            logger.exception("Unhandled error: %s", e)
             resp = responses.PlainTextResponse(
                 "An internal server error occurred", 500, media_type="text/plain"
             )


### PR DESCRIPTION
## Summary

Security: Potential Information Disclosure in Error Handling

## Problem

**Severity**: `Medium` | **File**: `shiny/_error.py:L28`

In shiny/_error.py, the ErrorMiddleware catches generic exceptions and prints them to stdout with `print("Unhandled error: " + str(e))`, then returns a generic 500 message. However, the HTTPException handler returns `e.detail` directly in the response body without sanitization. If `e.detail` contains sensitive information, it could be leaked to the client. Additionally, the comment in the code suggests uncertainty about proper logging.

## Solution

Sanitize or limit the detail returned in HTTPException responses. Use proper structured logging instead of print statements. Consider logging full exception details server-side while returning generic messages to clients.

## Changes

- `shiny/_error.py` (modified)