### PR TITLE
test: Speed up slider bookmarking test

### DIFF
--- a/tests/playwright/ai_generated_apps/bookmark/input_slider/test_input_slider_express_bookmarking.py
+++ b/tests/playwright/ai_generated_apps/bookmark/input_slider/test_input_slider_express_bookmarking.py
@@ -24,27 +24,27 @@ def test_slider_parameters(page: Page, app: ShinyAppProc) -> None:
     mod_value1.expect_value("Slider value: 50")
 
     # Change the basic slider value
-    slider1.set("75")
-    value1.expect_value("Slider value: 75")
+    slider1.set("0")
+    value1.expect_value("Slider value: 0")
 
     # Change the module slider value
-    mod_slider1.set("25")
-    mod_value1.expect_value("Slider value: 25")
+    mod_slider1.set("0")
+    mod_value1.expect_value("Slider value: 0")
 
     # click bookmark button
     bookmark_button = controller.InputBookmarkButton(page)
     bookmark_button.click()
 
     # Change the basic slider value again
-    slider1.set("100")
-    value1.expect_value("Slider value: 100")
+    slider1.set("1")
+    value1.expect_value("Slider value: 1")
 
     # Change the module slider value again
-    mod_slider1.set("0")
-    mod_value1.expect_value("Slider value: 0")
+    mod_slider1.set("1")
+    mod_value1.expect_value("Slider value: 1")
 
     # Reload the page to test bookmark
     page.reload()
 
-    value1.expect_value("Slider value: 75")
-    mod_value1.expect_value("Slider value: 25")
+    value1.expect_value("Slider value: 0")
+    mod_value1.expect_value("Slider value: 0")


### PR DESCRIPTION
## Summary
- Reduce the generated slider bookmarking test runtime by using low-end slider values
- Keep the existing `InputSlider.set()` path while avoiding long pixel-by-pixel drags
- Preserve bookmarking coverage for both plain and module slider values after reload

Fixes #2310