### PR TITLE
fix(tests): Reduce slider drag-simulation cost in Playwright tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* The Playwright controllers `InputSlider.set()` and `InputSliderRange.set()` are now ~5-10x faster. The drag simulation previously slept 50ms after every one-pixel mouse move; the sleeps are removed, and on WebKit (where rapid mouse moves within a frame are coalesced, which would skip slider values) each move is instead synchronized with a `requestAnimationFrame` round-trip. (#2311)
+
 * Fixed rare tabset ID collisions in pages with many navsets. Randomly generated `data-tabsetid` values were drawn from a pool of ~1 million, so a page with dozens of tabsets could occasionally produce two navsets with the same ID (a birthday collision), resulting in duplicate DOM ids and broken tab switching. IDs are now drawn from a pool of 9 trillion. (#2296)
 
 ### Other changes

--- a/shiny/playwright/controller/_input_controls.py
+++ b/shiny/playwright/controller/_input_controls.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import time
 import typing
 from typing import Literal
 
@@ -363,34 +362,28 @@ class _InputSliderBase(
         else:
             raise ValueError(f"Invalid direction: {direction}")
 
+        page = self.loc_container.page
+        mouse = page.mouse
+
+        # WebKit coalesces mousemove events delivered within the same frame, which
+        # would skip pixels (and therefore values) during the scan. Waiting for an
+        # animation frame after each move guarantees each move is processed
+        # individually. Chromium and Firefox dispatch input events synchronously.
+        browser = page.context.browser
+        needs_frame_sync = browser is None or browser.browser_type.name == "webkit"
+
+        def sync_move(x: float, y: float) -> None:
+            mouse.move(x, y)
+            if needs_frame_sync:
+                page.evaluate("() => new Promise(requestAnimationFrame)")
+
         # Move mouse to handle center and press down on mouse
-        mouse = self.loc_container.page.mouse
         mouse.move(handle_center.get("x"), handle_center.get("y"))
         mouse.down()
 
-        # Slow it down a bit. Like "type" for text, but to allow the slider label to catch up
-        # This should be done for every `mouse.move()` call
-        sleep_time = 0.05
-
-        def slow_move(x: float, y: float, delay: float = sleep_time) -> None:
-            """
-            Slowly move the mouse to the given coordinates.
-
-            Parameters
-            ----------
-            x
-                The x-coordinate.
-            y
-                The y-coordinate.
-            delay
-                The delay between each move. Defaults to `sleep_time`.
-            """
-            mouse.move(x, y)
-            time.sleep(delay)
-
         # Move all the way to the left
         handle_center_y = handle_center.get("y")
-        slow_move(start_x, handle_center_y, delay=10 * sleep_time)
+        sync_move(start_x, handle_center_y)
 
         # For each pixel in the grid width, check the text label
         pxls: int = 0
@@ -410,7 +403,7 @@ class _InputSliderBase(
                 break
 
             # Not found; move handle to the right
-            slow_move(start_x + pxls, handle_center_y)
+            sync_move(start_x + pxls, handle_center_y)
 
             pxls += pixel_increment
 


### PR DESCRIPTION
## Summary

  The Playwright slider controllers (`InputSlider.set()` and `InputSliderRange.set()`) now run ~5-10x faster by eliminating unnecessary delays in drag simulation.

  Previously, every one-pixel mouse move during slider scanning was followed by a hardcoded `time.sleep(0.05)`, plus a 0.5s initial move to the extreme. For a full-width scan
  (~300-400 pixels), this totaled 15-25 seconds. The `test_input_slider_kitchen` test even included a deliberate full-width failure case.

  The fix removes these sleeps entirely. On WebKit (which coalesces rapid mousemove events within the same animation frame, risking skipped values), each move is synchronized with a
  `requestAnimationFrame` round-trip to guarantee each move is processed individually. Chromium and Firefox dispatch input events synchronously, so they need no delay.

  ## Results

  - Both slider suites (30 tests) × 3 browsers: **28.5s** wall time (previously ~200s+)
  - WebKit dense-slider tests stable across 3 repeat runs
  - All related suites using slider `.set()` pass
  - No test file changes needed; drag interaction remains fully exercised

  Closes #2311.