### PR TITLE
fix(tests): Reduce data frame Playwright test durations

### DIFF
--- a/shiny/playwright/controller/_output.py
+++ b/shiny/playwright/controller/_output.py
@@ -696,16 +696,8 @@ class OutputDataFrame(UiWithContainer):
         return (
             # Find the direct row
             self.loc_body.locator(f"> tr[data-index='{row}']")
-            # Find all direct td's and th's (these are independent sets)
-            .locator("> td, > th")
-            # Remove all results that contain the `row-number` class
-            .locator(
-                # self
-                "xpath=.",
-                has=self.page.locator(
-                    "xpath=self::*[not(contains(@class, 'row-number'))]"
-                ),
-            )
+            # Find all direct non-row-number td's and th's
+            .locator("> td:not(.row-number), > th:not(.row-number)")
             # Return the first result
             .nth(col)
         )
@@ -1152,9 +1144,6 @@ class OutputDataFrame(UiWithContainer):
                 timeout=timeout,
                 modifiers=clickModifier,
             )
-            # Wait for arrows to react a little bit
-            # This could possible be changed to a `wait_for_change`, but 150ms should be fine
-            self.page.wait_for_timeout(150)
 
         # Reset arrow sorting by clicking on the arrows until none are found
         sortingArrows = self.loc_column_label.locator("svg.sort-arrow")
@@ -1235,11 +1224,16 @@ class OutputDataFrame(UiWithContainer):
         timeout
             The maximum time to wait for the action to complete. Defaults to `None`.
         """
+
+        def fill_if_needed(input_el: Locator, value: str) -> None:
+            if input_el.input_value(timeout=timeout) != value:
+                input_el.fill(value, timeout=timeout)
+
         # reset all filters
         all_input_locs = self.loc_column_filter.locator("> input, > div > input")
         for i in range(all_input_locs.count()):
             input_el = all_input_locs.nth(i)
-            input_el.fill("", timeout=timeout)
+            fill_if_needed(input_el, "")
 
         if filter is None:
             return
@@ -1262,19 +1256,13 @@ class OutputDataFrame(UiWithContainer):
             filterColumn = self.loc_column_filter.nth(filterInfo["col"])
 
             if isinstance(filterInfo["value"], str):
-                filterColumn.locator("> input").fill(filterInfo["value"])
+                fill_if_needed(filterColumn.locator("> input"), filterInfo["value"])
             elif isinstance(filterInfo["value"], (tuple, list)):
                 header_inputs = filterColumn.locator("> div > input")
                 if filterInfo["value"][0] is not None:
-                    header_inputs.nth(0).fill(
-                        str(filterInfo["value"][0]),
-                        timeout=timeout,
-                    )
+                    fill_if_needed(header_inputs.nth(0), str(filterInfo["value"][0]))
                 if filterInfo["value"][1] is not None:
-                    header_inputs.nth(1).fill(
-                        str(filterInfo["value"][1]),
-                        timeout=timeout,
-                    )
+                    fill_if_needed(header_inputs.nth(1), str(filterInfo["value"][1]))
             else:
                 raise ValueError(
                     "Invalid filter value. Must be a string or a tuple/list of two numbers."

--- a/shiny/playwright/controller/_output.py
+++ b/shiny/playwright/controller/_output.py
@@ -1145,10 +1145,22 @@ class OutputDataFrame(UiWithContainer):
                 modifiers=clickModifier,
             )
 
+        def click_sort_arrow(loc: Locator) -> None:
+            arrow_el = loc.element_handle(timeout=timeout)
+            if arrow_el is None:
+                return
+            old_class = arrow_el.get_attribute("class")
+            click_loc(loc)
+            self.page.wait_for_function(
+                "([el, oldClass]) => !el.isConnected || el.getAttribute('class') !== oldClass",
+                arg=[arrow_el, old_class],
+                timeout=timeout,
+            )
+
         # Reset arrow sorting by clicking on the arrows until none are found
         sortingArrows = self.loc_column_label.locator("svg.sort-arrow")
         while sortingArrows.count() > 0:
-            click_loc(sortingArrows.first)
+            click_sort_arrow(sortingArrows.first)
 
         # Quit early if no sorting is needed
         if sort is None:

--- a/shiny/playwright/controller/_output.py
+++ b/shiny/playwright/controller/_output.py
@@ -1147,8 +1147,6 @@ class OutputDataFrame(UiWithContainer):
 
         def click_sort_arrow(loc: Locator) -> None:
             arrow_el = loc.element_handle(timeout=timeout)
-            if arrow_el is None:
-                return
             old_class = arrow_el.get_attribute("class")
             click_loc(loc)
             self.page.wait_for_function(

--- a/shiny/ui/_theme.py
+++ b/shiny/ui/_theme.py
@@ -5,7 +5,7 @@ import pathlib
 import re
 import tempfile
 import textwrap
-from typing import TYPE_CHECKING, Any, Literal, Optional, Sequence, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Literal, Optional, Sequence, TypeVar
 
 if TYPE_CHECKING:
     from brand_yml import Brand
@@ -529,12 +529,9 @@ class Theme:
             **args,
         }
 
-        self._css = cast(
-            str,
-            sass.compile(  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
-                string=self.to_sass(),
-                **args,
-            ),
+        self._css = sass.compile(  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+            string=self.to_sass(),
+            **args,
         )
 
         return self._css

--- a/shiny/ui/_theme.py
+++ b/shiny/ui/_theme.py
@@ -529,10 +529,12 @@ class Theme:
             **args,
         }
 
-        self._css = sass.compile(  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+        css = sass.compile(  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
             string=self.to_sass(),
             **args,
         )
+        assert isinstance(css, str)
+        self._css = css
 
         return self._css
 

--- a/tests/playwright/shiny/brand_kitchensink/test_brand_yml.py
+++ b/tests/playwright/shiny/brand_kitchensink/test_brand_yml.py
@@ -11,7 +11,9 @@ app = create_example_fixture("brand")
 
 
 def test_brand_yml_kitchensink(page: Page, app: ShinyAppProc) -> None:
-    page.goto(app.url)
+    # Remote font loads can keep WebKit/Firefox CI waiting for the full load event.
+    # The assertions below only need the DOM and computed CSS.
+    page.goto(app.url, wait_until="domcontentloaded")
 
     expected_styles = {
         "value_box_primary": {

--- a/tests/playwright/shiny/components/chat/update_user_input/test_chat_update_user_input.py
+++ b/tests/playwright/shiny/components/chat/update_user_input/test_chat_update_user_input.py
@@ -45,9 +45,7 @@ def test_validate_chat_update_user_input(page: Page, local_app: ShinyAppProc) ->
     expect(chat.loc_input).not_to_be_focused()
 
     # Input remains cleared if previously clear (have to clear the input first)
-    chat.loc_input.focus()
-    while chat.loc_input.inner_text().strip():
-        chat.loc_input.press("Backspace")
+    chat.loc_input.fill("")
 
     chat.expect_user_input("")
 

--- a/tests/playwright/shiny/components/chat/update_user_input/test_chat_update_user_input.py
+++ b/tests/playwright/shiny/components/chat/update_user_input/test_chat_update_user_input.py
@@ -45,7 +45,9 @@ def test_validate_chat_update_user_input(page: Page, local_app: ShinyAppProc) ->
     expect(chat.loc_input).not_to_be_focused()
 
     # Input remains cleared if previously clear (have to clear the input first)
-    chat.loc_input.fill("")
+    chat.loc_input.focus()
+    chat.loc_input.press("ControlOrMeta+A")
+    chat.loc_input.press("Backspace")
 
     chat.expect_user_input("")
 

--- a/tests/playwright/shiny/components/data_frame/html_columns/app.py
+++ b/tests/playwright/shiny/components/data_frame/html_columns/app.py
@@ -1,4 +1,3 @@
-import pkgutil
 import random
 import string
 from typing import Any, cast
@@ -10,17 +9,28 @@ from htmltools import HTMLDependency
 from shiny import App, Inputs, Outputs, Session, render, ui
 from shiny.render import CellPatch
 
-pd_penguins = palmerpenguins.load_penguins_raw()
-pl_penguins = pl.read_csv(
-    cast(
-        bytes,
-        pkgutil.get_data(
-            "palmerpenguins",
-            "data/penguins-raw.csv",
-        ),
-    ),
-    null_values="NA",
-)
+HTML_COLUMNS_SAMPLE_ROWS = [
+    0,
+    1,
+    2,
+    3,
+    8,
+    9,
+    33,
+    39,
+    40,
+    41,
+    42,
+    43,
+    44,
+    45,
+    47,
+    150,
+    151,
+]
+
+pd_penguins = palmerpenguins.load_penguins_raw().iloc[HTML_COLUMNS_SAMPLE_ROWS].copy()
+pl_penguins = pl.from_pandas(pd_penguins)
 
 
 def random_generator():
@@ -47,11 +57,7 @@ def make_heading(y: Any) -> Any:
 def make_island_content(z: Any) -> ui.TagList:
     return ui.TagList(
         ui.input_checkbox(f"checkbox_{z}_{random_generator()}", f"{z}"),
-        ui.tags.img(
-            src="https://dka575ofm4ao0.cloudfront.net/pages-transactional_logos/retina/276517/posit-logo-fullcolor-TM.png",
-            height="20%",
-            width="20%",
-        ),
+        ui.tags.span(str(z)),
     )
 
 
@@ -101,11 +107,7 @@ pl_penguins = (
             [
                 ui.div(
                     ui.input_checkbox(f"checkbox_{x}_{random_generator()}", f"{x}"),
-                    ui.tags.img(
-                        src="https://dka575ofm4ao0.cloudfront.net/pages-transactional_logos/retina/276517/posit-logo-fullcolor-TM.png",
-                        height="20%",
-                        width="20%",
-                    ),
+                    ui.tags.span(str(x)),
                 )
                 for x in pl_penguins["Island"]
             ],

--- a/tests/playwright/shiny/components/data_frame/html_columns/app.py
+++ b/tests/playwright/shiny/components/data_frame/html_columns/app.py
@@ -65,9 +65,9 @@ studyName = pd_penguins["studyName"].copy().astype("object")
 # Set the first value of the column to an html object so the column is treated as object by narwhals (not str)
 studyName[0] = htmlDep
 pd_penguins["studyName"] = studyName
-pd_penguins["Species"] = pd_penguins["Species"].apply(make_underlined_html)
-pd_penguins["Region"] = pd_penguins["Region"].apply(make_heading)
-pd_penguins["Island"] = pd_penguins["Island"].apply(make_island_content)
+pd_penguins["Species"] = [make_underlined_html(x) for x in pd_penguins["Species"]]
+pd_penguins["Region"] = [make_heading(x) for x in pd_penguins["Region"]]
+pd_penguins["Island"] = [make_island_content(x) for x in pd_penguins["Island"]]
 # Convert column 5 (Stage) to object dtype before assigning HTML objects (required for pandas 3.0+)
 pd_penguins["Stage"] = pd_penguins["Stage"].astype("object")
 

--- a/tests/playwright/shiny/components/data_frame/html_columns/app.py
+++ b/tests/playwright/shiny/components/data_frame/html_columns/app.py
@@ -65,9 +65,15 @@ studyName = pd_penguins["studyName"].copy().astype("object")
 # Set the first value of the column to an html object so the column is treated as object by narwhals (not str)
 studyName[0] = htmlDep
 pd_penguins["studyName"] = studyName
-pd_penguins["Species"] = [make_underlined_html(x) for x in pd_penguins["Species"]]
+pd_penguins["Species"] = cast(
+    Any,
+    [make_underlined_html(x) for x in pd_penguins["Species"]],
+)
 pd_penguins["Region"] = [make_heading(x) for x in pd_penguins["Region"]]
-pd_penguins["Island"] = [make_island_content(x) for x in pd_penguins["Island"]]
+pd_penguins["Island"] = cast(
+    Any,
+    [make_island_content(x) for x in pd_penguins["Island"]],
+)
 # Convert column 5 (Stage) to object dtype before assigning HTML objects (required for pandas 3.0+)
 pd_penguins["Stage"] = pd_penguins["Stage"].astype("object")
 

--- a/tests/playwright/shiny/components/data_frame/row_selection/app.py
+++ b/tests/playwright/shiny/components/data_frame/row_selection/app.py
@@ -1,17 +1,11 @@
-import pkgutil
-
-import palmerpenguins
+import pandas as pd
 import polars as pl
 from narwhals.stable.v1.typing import IntoDataFrame
 
 from shiny import App, Inputs, Outputs, Session, module, reactive, render, ui
 
-pd_penguins = palmerpenguins.load_penguins_raw()
-pl_penguins = pl.read_csv(
-    pkgutil.get_data(  # pyright: ignore[reportArgumentType]
-        "palmerpenguins", "data/penguins-raw.csv"
-    )
-)
+pd_penguins = pd.DataFrame({"row": range(344)})
+pl_penguins = pl.DataFrame(pd_penguins)
 
 
 def make_ui(title: str):


### PR DESCRIPTION
## Summary

Fixes #2313.

Reduces runtime for slow data frame Playwright tests by removing unnecessary controller waits and shrinking oversized test fixtures while preserving existing coverage.

 ## Why these tests were 10× slower, and how the commit addresses each cause:

 1. Fixed 150ms sleep per sort click (set_sort in _output.py). html_columns makes
 ~15+ sort clicks and df_methods ~10+, so this alone was 2–3s per test. Removed.
 2. No-op filter fills: set_filter reset every filter input with .fill("") even
 when already empty; each fill triggers focus/re-render waits. New fill_if_needed
 skips unchanged inputs. Benefits html_columns and df_methods.
 3. External CDN image per row (html_columns app): every Island cell loaded a Posit
 logo from cloudfront — hundreds of network fetches per page load. Replaced with a
 span. Likely the single biggest win for the ~18s html_columns test.
 4. Oversized datasets: html_columns rendered 344 penguin rows × HTML widgets; now a
 17-row subset whose row indices were chosen so every unchanged test assertion
 (sample numbers 1–4, 9, 10, 34, 40–46, 48, 151, 152; IDs N25A2/N29A2) still holds —
 the test file is untouched, so coverage is preserved. row_selection rendered 4 full
 penguin tables; now a single-column 344-row frame, preserving the asserted
 grid_row_count == 344 and selection indices.
 5. Slower xpath cell locator replaced with CSS td:not(.row-number) — equivalent,
 simpler, marginally faster per call (called constantly via expect_cell).
 6. df_methods has no app change, but it already uses a 6-row iris subset — its cost
 was the controller sleeps/fills (fixed here) plus the 13s fixture setup tracked
 separately in #2314.

# Improvements


Test | Before mean | After mean | Savings
-- | -- | -- | --
html_columns chromium/pandas | 19.24s | 13.94s | 5.30s, 28%
html_columns chromium/polars | 17.42s | 11.68s | 5.74s, 33%
row_selection webkit | 19.26s | 17.57s | 1.69s, 9%
df_methods firefox/pandas | 10.27s | 8.85s | 1.42s, 14%
df_methods webkit/pandas | 15.06s | 14.66s | 0.40s, 3%
df_methods webkit/polars | 9.17s | 7.14s | 2.03s, 22%


