### PR TITLE
test: Trim duplicate app boots from template create tests

### DIFF
--- a/tests/playwright/examples/test_shiny_create.py
+++ b/tests/playwright/examples/test_shiny_create.py
@@ -58,11 +58,26 @@ def assert_created_app_matches_template(
     assert template is not None
 
     source_name = f"app-{mode}.py" if template.express_available else "app.py"
-    assert (Path(dest_dir) / "app.py").read_text() == (
-        template.path / source_name
-    ).read_text()
-    assert not (Path(dest_dir) / "app-core.py").exists()
-    assert not (Path(dest_dir) / "app-express.py").exists()
+    expected_files: dict[Path, Path] = {Path("app.py"): template.path / source_name}
+
+    for source_file in template.path.rglob("*"):
+        if (
+            not source_file.is_file()
+            or "__pycache__" in source_file.parts
+            or source_file.name in {"_template.json", "app-core.py", "app-express.py"}
+        ):
+            continue
+        expected_files[source_file.relative_to(template.path)] = source_file
+
+    actual_files = {
+        file.relative_to(dest_dir)
+        for file in Path(dest_dir).rglob("*")
+        if file.is_file() and "__pycache__" not in file.parts
+    }
+    assert actual_files == set(expected_files)
+
+    for dest_file, source_file in expected_files.items():
+        assert (Path(dest_dir) / dest_file).read_bytes() == source_file.read_bytes()
 
 
 @pytest.mark.flaky(reruns=reruns, reruns_delay=reruns_delay)
@@ -77,7 +92,6 @@ assert len(app_templates) > 0
 assert len(pkg_templates) > 0
 
 
-@pytest.mark.flaky(reruns=reruns, reruns_delay=reruns_delay)
 @pytest.mark.parametrize("app_template", app_templates)
 def test_create_core(app_template: str):
     with tempfile.TemporaryDirectory("example_apps") as tmpdir:
@@ -85,7 +99,6 @@ def test_create_core(app_template: str):
         assert_created_app_matches_template(app_template, tmpdir, mode="core")
 
 
-@pytest.mark.flaky(reruns=reruns, reruns_delay=reruns_delay)
 @pytest.mark.parametrize("app_template", ["basic-app"])
 def test_create_express(app_template: str):
     with tempfile.TemporaryDirectory("example_apps") as tmpdir:

--- a/tests/playwright/examples/test_shiny_create.py
+++ b/tests/playwright/examples/test_shiny_create.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import tempfile
+from pathlib import Path
 
 import pytest
 from example_apps import get_apps, reruns, reruns_delay, validate_example
@@ -10,6 +11,7 @@ from shiny._main_create import (
     GithubRepoLocation,
     parse_github_arg,
     shiny_internal_templates,
+    template_by_name,
 )
 
 
@@ -19,6 +21,7 @@ def subprocess_create(
     *,
     mode: str = "core",
     package_name: str = "",
+    check_duplicate: bool = False,
 ):
     cmd = [
         "shiny",
@@ -33,7 +36,7 @@ def subprocess_create(
         package_name,
     ]
 
-    subprocess.run(cmd)
+    subprocess.run(cmd, check=True)
     assert os.path.isdir(dest_dir)
 
     # Package templates don't have a top-level app.py file
@@ -42,9 +45,24 @@ def subprocess_create(
     else:
         assert os.path.isfile(f"{dest_dir}/pyproject.toml")
 
-    print("\nCheck for duplicate files")
-    with pytest.raises(subprocess.CalledProcessError):
-        subprocess.run(cmd, check=True)
+    if check_duplicate:
+        print("\nCheck for duplicate files")
+        with pytest.raises(subprocess.CalledProcessError):
+            subprocess.run(cmd, check=True)
+
+
+def assert_created_app_matches_template(
+    app_template: str, dest_dir: str, *, mode: str
+) -> None:
+    template = template_by_name(shiny_internal_templates.apps, app_template)
+    assert template is not None
+
+    source_name = f"app-{mode}.py" if template.express_available else "app.py"
+    assert (Path(dest_dir) / "app.py").read_text() == (
+        template.path / source_name
+    ).read_text()
+    assert not (Path(dest_dir) / "app-core.py").exists()
+    assert not (Path(dest_dir) / "app-express.py").exists()
 
 
 @pytest.mark.flaky(reruns=reruns, reruns_delay=reruns_delay)
@@ -61,18 +79,23 @@ assert len(pkg_templates) > 0
 
 @pytest.mark.flaky(reruns=reruns, reruns_delay=reruns_delay)
 @pytest.mark.parametrize("app_template", app_templates)
-def test_create_core(app_template: str, page: Page):
+def test_create_core(app_template: str):
     with tempfile.TemporaryDirectory("example_apps") as tmpdir:
         subprocess_create(app_template, dest_dir=tmpdir)
-        validate_example(page, f"{tmpdir}/app.py")
+        assert_created_app_matches_template(app_template, tmpdir, mode="core")
 
 
 @pytest.mark.flaky(reruns=reruns, reruns_delay=reruns_delay)
 @pytest.mark.parametrize("app_template", ["basic-app"])
-def test_create_express(app_template: str, page: Page):
+def test_create_express(app_template: str):
     with tempfile.TemporaryDirectory("example_apps") as tmpdir:
         subprocess_create(app_template, dest_dir=tmpdir, mode="express")
-        validate_example(page, f"{tmpdir}/app.py")
+        assert_created_app_matches_template(app_template, tmpdir, mode="express")
+
+
+def test_create_duplicate_files_error():
+    with tempfile.TemporaryDirectory("example_apps") as tmpdir:
+        subprocess_create("basic-app", dest_dir=tmpdir, check_duplicate=True)
 
 
 @pytest.mark.flaky(reruns=reruns, reruns_delay=reruns_delay)


### PR DESCRIPTION
## Summary

- Stop `shiny create` tests from booting generated apps that are already covered by `test_template_examples`
- Verify generated app directories against their source templates, including supporting files
- Keep duplicate-file failure coverage in one dedicated test
- Remove stale flaky markers from browser-free create tests

## Evidence

| Scenario | Before | After | Gain |
|---|---:|---:|---:|
| `dashboard-tips` create test | 13.03s pytest / 14.11s real | 3.15s pytest / 4.10s real | 9.88s pytest saved, 76% faster |
| create core+express path, xdist | 8.76s pytest / 9.86s real for 6 tests | 4.29s pytest / 5.73s real for 7 tests | 4.47s pytest saved, 51% faster |
| create core+express path, serial | 17.10s pytest / 18.05s real for 6 tests | 4.24s pytest / 5.21s real for 7 tests | 12.86s pytest saved, 75% faster |
| supporting-file coverage | Missing `shared.py` was not caught | Missing `shared.py` fails the helper | Coverage restored |

Fixes https://github.com/posit-dev/py-shiny/issues/2315
