### PR TITLE
fix(tests): Read UserInput.text in chat module test app

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ test = [
     "timezonefinder ; platform_system != 'Windows'",
     "ipyleaflet",
     "shinywidgets",
+    "shinychat>=0.6.0",
     "seaborn",
     "plotnine",
     "plotly",

--- a/tests/playwright/shiny/components/chat/module/app.py
+++ b/tests/playwright/shiny/components/chat/module/app.py
@@ -15,7 +15,8 @@ def chat_mod_server(input: Inputs, output: Outputs, session: Session):
     @chat.on_user_submit
     async def _():
         user = chat.user_input()
-        await chat.append_message(f"You said: {user}")
+        assert user is not None
+        await chat.append_message(f"You said: {user.text}")
 
 
 app_ui = ui.page_fillable(


### PR DESCRIPTION
## Summary

shinychat 0.6.0 changed `Chat.user_input()` to return a `UserInput` named tuple (`text`, `attachments`) instead of a plain string, in order to support the new attachments feature. This broke CI: the module chat test app interpolated the raw return value into a message (`f"You said: {user}"`), which now renders as `You said: UserInput(text='...', attachments=[])` instead of the expected text, failing `test_validate_chat_append_user_message`.

Every other chat test app in the repo already uses the callback-argument form (`async def _(user_input: str)`), which shinychat still supports unchanged — this was the one spot using the no-arg `chat.user_input()` form.

- Read `.text` off the returned `UserInput` tuple instead of interpolating it directly.

## Test plan

- [x] Reproduced the CI failure locally by installing `shinychat==0.6.0` and running the failing test
- [x] Applied the fix and confirmed `test_validate_chat_append_user_message` passes
- [x] Ran all chat + bookmark-chat Playwright tests (15 tests) — all pass
- [x] Ran the full unit test suite (862 tests) — all pass
- [x] `pyright` clean on the changed file and project-wide