### PR TITLE
docs: Add Express examples for row, download_link, and showcase_*

### DIFF
--- a/shiny/api-examples/download_link/app-express.py
+++ b/shiny/api-examples/download_link/app-express.py
@@ -1,0 +1,21 @@
+import asyncio
+import random
+from datetime import date
+
+from shiny.express import render, ui
+from shiny.ui import download_link
+
+download_link("downloadData", "Download")
+
+# In Express mode, `@render.download` automatically renders a download button. Wrap it
+# in `ui.hold()` to suppress the button so the `download_link()` above is used instead.
+with ui.hold():
+
+    @render.download(
+        filename=lambda: f"data-{date.today().isoformat()}-{random.randint(100, 999)}.csv"
+    )
+    async def downloadData():
+        await asyncio.sleep(0.25)
+        yield "one,two,three\n"
+        yield "a,1,2\n"
+        yield "b,4,5\n"

--- a/shiny/api-examples/row/app-express.py
+++ b/shiny/api-examples/row/app-express.py
@@ -1,0 +1,22 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+from shiny.express import input, render, ui
+from shiny.ui import column, row
+
+with ui.hold() as hist_plot:
+
+    @render.plot(alt="A histogram")
+    def plot():
+        np.random.seed(19680801)
+        x = 100 + 15 * np.random.randn(437)
+
+        fig, ax = plt.subplots()
+        ax.hist(x, input.n(), density=True)
+        return fig
+
+
+row(
+    column(4, ui.input_slider("n", "N", min=1, max=100, value=20)),
+    column(8, hist_plot),
+)

--- a/shiny/api-examples/showcase_bottom/app-express.py
+++ b/shiny/api-examples/showcase_bottom/app-express.py
@@ -1,0 +1,14 @@
+from icons import piggy_bank
+
+from shiny.express import ui
+from shiny.ui import showcase_bottom
+
+with ui.value_box(
+    showcase=piggy_bank,
+    showcase_layout=showcase_bottom(),
+    theme="purple",
+    full_screen=True,
+):
+    "KPI Title"
+    "$1 Billion Dollars"
+    "Up 30% VS PREVIOUS 30 DAYS"

--- a/shiny/api-examples/showcase_left_center/app-express.py
+++ b/shiny/api-examples/showcase_left_center/app-express.py
@@ -1,0 +1,14 @@
+from icons import piggy_bank
+
+from shiny.express import ui
+from shiny.ui import showcase_left_center
+
+with ui.value_box(
+    showcase=piggy_bank,
+    showcase_layout=showcase_left_center(),
+    theme="bg-gradient-orange-red",
+    full_screen=True,
+):
+    "KPI Title"
+    "$1 Billion Dollars"
+    "Up 30% VS PREVIOUS 30 DAYS"

--- a/shiny/api-examples/showcase_top_right/app-express.py
+++ b/shiny/api-examples/showcase_top_right/app-express.py
@@ -1,0 +1,14 @@
+from icons import piggy_bank
+
+from shiny.express import ui
+from shiny.ui import showcase_top_right
+
+with ui.value_box(
+    showcase=piggy_bank,
+    showcase_layout=showcase_top_right(),
+    theme="text-green",
+    full_screen=True,
+):
+    "KPI Title"
+    "$1 Billion Dollars"
+    "Up 30% VS PREVIOUS 30 DAYS"

--- a/shiny/ui/_bootstrap.py
+++ b/shiny/ui/_bootstrap.py
@@ -36,7 +36,6 @@ from ._utils import get_window_title
 
 # TODO: make a python version of the layout guide?
 @add_example()
-@no_example("express")
 def row(*args: TagChild | TagAttrs, **kwargs: TagAttrValue) -> Tag:
     """
     Responsive row-column based layout
@@ -69,7 +68,6 @@ def row(*args: TagChild | TagAttrs, **kwargs: TagAttrValue) -> Tag:
 
 
 @add_example(example_name="row")
-@no_example("express")
 def column(
     width: int, *args: TagChild | TagAttrs, offset: int = 0, **kwargs: TagAttrValue
 ) -> Tag:

--- a/shiny/ui/_download_button.py
+++ b/shiny/ui/_download_button.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from htmltools import Tag, TagAttrValue, TagChild, css, tags
 
-from .._docstring import add_example, no_example
+from .._docstring import add_example
 from .._shinyenv import is_pyodide
 from ..module import resolve_id
 
@@ -66,7 +66,6 @@ def download_button(
 
 
 @add_example()
-@no_example("express")
 def download_link(
     id: str,
     label: TagChild,

--- a/shiny/ui/_valuebox.py
+++ b/shiny/ui/_valuebox.py
@@ -92,7 +92,6 @@ class ShowcaseLayout:
 
 
 @add_example()
-@no_example("express")
 def showcase_left_center(
     *,
     width: CssUnit = "30%",
@@ -127,7 +126,6 @@ def showcase_left_center(
 
 
 @add_example()
-@no_example("express")
 def showcase_top_right(
     *,
     width: CssUnit = "40%",
@@ -163,7 +161,6 @@ def showcase_top_right(
 
 
 @add_example()
-@no_example("express")
 def showcase_bottom(
     *,
     width: CssUnit = "100%",


### PR DESCRIPTION
Follow-up to #2278. Related to #2330.

## Summary

PR #2278 attempted to add Express example apps for `row()`/`column()`, `download_link()`, and `showcase_left_center()`/`showcase_top_right()`/`showcase_bottom()`, but the drafts failed to start — those functions are intentionally absent from `shiny.express.ui`, so the apps crashed on `ui.row(...)` etc. and were dropped in favor of `@no_example("express")` markers. This PR adds working Express apps for all five example directories and removes the markers so the Express tabs appear in the API docs.

The apps stay Express-idiomatic using existing patterns (same as `event/app-express.py`):

- `row`: imports `row`/`column` from `shiny.ui`, captures the plot with `ui.hold()`, and places `row(column(4, ...), column(8, ...))` as a top-level expression.
- `download_link`: imports `download_link` from `shiny.ui` and wraps `@render.download` in `ui.hold()` to suppress the auto-rendered button (see #2330 for a proposal to make this Express-native via `render.download_link`).
- `showcase_*`: a single `ui.value_box()` context manager with the `ShowcaseLayout` constructor imported from `shiny.ui` (no `layout_columns()` wrapper — with one child it does nothing).

## Verification

- `pytest tests/playwright/examples/test_api_examples.py -k "download_link or showcase_bottom or showcase_left_center or showcase_top_right or row"` — 10 passed (core + express for all five example dirs).
- Docs-build example validation simulated in both modes: `SHINY_ADD_EXAMPLES=true SHINY_MODE=express python -c "import shiny, shiny.express.ui"` and the same with `SHINY_MODE=core` — both import cleanly, so the fail-on-missing-example check from #2278 passes.
- Each app serves HTTP 200 with the expected markup (grid classes, a single `<a class="shiny-download-link">` with no stray button, correct `showcase-*` classes).
