### PR TITLE
docs: Slim CLAUDE.md and extract deep-dives to reference files

### DIFF
--- a/.claude/references/architecture.md
+++ b/.claude/references/architecture.md
@@ -1,0 +1,180 @@
+# Architecture
+
+Deep-dive into py-shiny's internals. Key implementation files are listed with
+each section; the "Key Files" section of `CLAUDE.md` has the consolidated list.
+
+## Reactive System
+
+Implementation: `shiny/reactive/_core.py` (graph machinery),
+`shiny/reactive/_reactives.py` (primitives).
+
+The reactive system is based on a **push-pull** model with three core abstractions:
+
+- **Context**: Tracks reactive dependencies during execution. When a reactive
+  consumer (Calc/Effect) runs, it creates a Context that records which reactive
+  sources (Value) it reads from.
+- **Dependents**: Each reactive source maintains a list of downstream consumers
+  that depend on it. When a source invalidates, it notifies all dependents.
+- **ReactiveEnvironment**: Global singleton managing the reactive graph,
+  execution queue, and flush cycles.
+
+Key implementation details:
+
+- `Value()` is the reactive source (observable)
+- `Calc_()` is a cached computed value (recomputes only when dependencies change)
+- `Effect_()` is a side-effect that re-executes when dependencies change
+- `event()` decorator suppresses reactive dependencies for specific reads
+- The reactive graph is built automatically through the Context's dependency tracking
+- Execution uses a priority queue to ensure correct invalidation ordering
+- In tests, `reactive.flush()` forces a synchronous flush of the reactive graph
+
+## Session Hierarchy
+
+Implementation: `shiny/session/_session.py`; app entry point in `shiny/_app.py`.
+
+Sessions manage the lifetime and state of a Shiny application:
+
+- **Session (ABC)**: Base interface defining core session operations
+- **AppSession**: Concrete implementation for a single user's session
+- **SessionProxy**: Thread-safe proxy that delegates to the appropriate AppSession
+- **Inputs/Outputs**: Dynamic objects providing dict-like access to input/output values
+
+Session management:
+
+- Each WebSocket connection gets its own AppSession
+- `get_current_session()` retrieves the current session from thread-local or
+  async context
+- Sessions track input values, output invalidations, file uploads, downloads,
+  and more
+- Session context is established using the `session_context(session)` context
+  manager
+
+## Express vs Core Mode
+
+Implementation: `shiny/express/_run.py` (execution),
+`shiny/express/_node_transformers.py` (AST transformation).
+
+**Core mode** is imperative: you explicitly construct UI and define server
+logic in a function.
+
+**Express mode** transforms Python code using AST manipulation:
+
+- `@render.text` decorators are hoisted into a synthetic `server()` function
+- UI elements are collected into a synthetic `ui` object
+- Top-level code runs in a special context where UI calls are recorded
+- `RecallContextManager` enables UI elements to render themselves automatically
+- The transformation happens at import time via `_run.py` and
+  `_node_transformers.py`
+
+Critical difference: Express mode uses **execution order** (top-to-bottom) for
+UI layout, while Core mode uses explicit nesting. Debugging Express apps
+requires understanding the transformed code.
+
+## HTML Generation and Dependencies
+
+HTML is generated using the `htmltools` package:
+
+- UI functions return `Tag` or `TagList` objects
+- Tags are mutable; use `.add_class()`, `.add_style()`, `.attrs()` to modify
+- HTML dependencies are attached to tags and automatically bundled
+- `components_dependencies()` returns bslib component dependencies
+
+Asset vendoring:
+
+- SCSS source files from bslib are in `shiny/www/shared/sass/bslib/components/scss/`
+- Compiled CSS is generated for all theme presets (27 files in
+  `shiny/www/shared/sass/preset/`)
+- JavaScript bundles are in `shiny/www/shared/bslib/components/components.min.js`
+- `make upgrade-html-deps` runs `scripts/htmlDependencies.R` (requires R) to
+  update all vendored assets; versions are tracked in `shiny/_versions.py`
+- HTML dependency definitions live in `shiny/ui/_html_deps_*.py`
+
+## Input/Output Bindings
+
+Client-server communication works through bindings:
+
+**Input bindings** (client → server):
+
+- Registered via CSS class selectors in TypeScript (e.g., `.bslib-input-foo`)
+- Implement `getValue()`, `setValue()`, `subscribe()` methods
+- Send values to server using `Shiny.setInputValue(id, value)`
+- Server receives via `input.foo()` which returns a reactive Value
+
+**Output bindings** (server → client):
+
+- Server defines output using `@render.text`, `@render.plot`, etc.
+- Renderers inherit from the `Renderer` base class
+  (`shiny/render/renderer/_renderer.py`; see
+  `.claude/references/component-patterns.md` for the implementation pattern)
+- Client subscribes to output via `Shiny.bindOutput()` in TypeScript
+- Updates are sent as messages through the WebSocket
+
+**Update functions**:
+
+- Use `session.send_input_message()` to update input widgets from the server
+- Client handles via `receiveMessage()` in the input binding
+
+## Module System
+
+Implementation: `shiny/_namespaces.py` manages the namespace stack;
+`shiny/module.py` provides the decorators.
+
+Modules enable namespaced, reusable components:
+
+- `@module.ui` decorator creates a UI function with automatic ID namespacing
+- `@module.server` decorator creates a server function with namespace context
+- Inside a module, use `resolve_id()` to namespace IDs
+- `resolve_id_or_none()` for optional namespacing
+- Modules can be nested; namespaces compose with `parent-child` format
+
+## Testing Architecture
+
+**Unit tests** (`tests/pytest/`):
+
+- Use standard pytest with syrupy for snapshots (`make test-update-snapshots`
+  to regenerate)
+- Focus on Python API correctness, parameter validation, edge cases
+- Run with `make test` or `pytest`
+
+**Playwright tests** (`tests/playwright/`):
+
+- End-to-end tests using Playwright with custom controllers
+- Controllers in `shiny/playwright/controller/` provide high-level APIs for
+  interacting with inputs/outputs
+- Each input component should have a controller class
+- Test apps live alongside test files
+- Suites: `tests/playwright/shiny/` (`make playwright-shiny`),
+  `tests/playwright/examples/` (`make playwright-examples`),
+  `tests/playwright/deploys/`, `tests/playwright/ai_generated_apps/`
+- Run with `make playwright` (all browsers) or `make playwright-debug`
+  (chromium, headed)
+- Prefer `.expect_*()` controller methods, which auto-wait, over manual sleeps
+
+**Playwright controller pattern**:
+
+```python
+from shiny.playwright.controller import InputText, OutputText
+
+text_input = InputText(page, "my_input")
+text_input.set("foo")
+text_input.expect_value("foo")
+
+text_output = OutputText(page, "my_output")
+text_output.expect_value("You entered: foo")
+```
+
+## JavaScript/TypeScript Build
+
+Client-side code is in `js/`:
+
+- Entry point: `js/src/shiny/index.ts`
+- Build tool: esbuild via `js/build.ts`
+- Output: `shiny/www/shared/py-shiny/shiny.js` and minified variant
+- TypeScript definitions for Python-JS interop
+
+Development workflow:
+
+- `make js-watch` for continuous rebuilds during development (`js-watch-fast`
+  skips linting and minification)
+- Changes to `js/src/` require rebuilding to see effects in Python apps
+- Source maps are generated for debugging

--- a/.claude/references/architecture.md
+++ b/.claude/references/architecture.md
@@ -79,15 +79,8 @@ HTML is generated using the `htmltools` package:
 - HTML dependencies are attached to tags and automatically bundled
 - `components_dependencies()` returns bslib component dependencies
 
-Asset vendoring:
-
-- SCSS source files from bslib are in `shiny/www/shared/sass/bslib/components/scss/`
-- Compiled CSS is generated for all theme presets (27 files in
-  `shiny/www/shared/sass/preset/`)
-- JavaScript bundles are in `shiny/www/shared/bslib/components/components.min.js`
-- `make upgrade-html-deps` runs `scripts/htmlDependencies.R` (requires R) to
-  update all vendored assets; versions are tracked in `shiny/_versions.py`
-- HTML dependency definitions live in `shiny/ui/_html_deps_*.py`
+Asset vendoring (bslib CSS/JS, theme presets, `make upgrade-html-deps`) is
+covered in `.claude/references/assets.md`.
 
 ## Input/Output Bindings
 
@@ -165,16 +158,6 @@ text_output.expect_value("You entered: foo")
 
 ## JavaScript/TypeScript Build
 
-Client-side code is in `js/`:
-
-- Entry point: `js/src/shiny/index.ts`
-- Build tool: esbuild via `js/build.ts`
-- Output: `shiny/www/shared/py-shiny/shiny.js` and minified variant
-- TypeScript definitions for Python-JS interop
-
-Development workflow:
-
-- `make js-watch` for continuous rebuilds during development (`js-watch-fast`
-  skips linting and minification)
-- Changes to `js/src/` require rebuilding to see effects in Python apps
-- Source maps are generated for debugging
+Client-side code is in `js/` (entry point `js/src/shiny/index.ts`), bundled
+with esbuild into `shiny/www/shared/py-shiny/`. Build commands and workflow are
+covered in `.claude/references/assets.md`.

--- a/.claude/references/assets.md
+++ b/.claude/references/assets.md
@@ -1,0 +1,57 @@
+# Asset Management
+
+py-shiny ships two kinds of client-side assets:
+
+1. **Vendored assets** from upstream packages (bslib, shiny, sass, htmltools),
+   pulled in by an R script.
+2. **py-shiny's own TypeScript bundle**, built from `js/` with esbuild.
+
+## Vendored upstream assets
+
+```bash
+make upgrade-html-deps   # Requires R installed
+```
+
+This runs `scripts/htmlDependencies.R`, which vendors compiled assets from the
+upstream R packages into the repo:
+
+- SCSS source files from bslib: `shiny/www/shared/sass/bslib/components/scss/`
+- Compiled CSS for all theme presets: `shiny/www/shared/sass/preset/` (27 files)
+- bslib JavaScript bundle: `shiny/www/shared/bslib/components/components.min.js`
+- Upstream package versions are recorded in `shiny/_versions.py`
+
+Related files:
+
+- `shiny/ui/_html_deps_*.py` — `HTMLDependency` definitions that attach these
+  assets to UI components
+- `components_dependencies()` — returns the bslib component dependencies; a
+  component whose styles don't load is usually missing this
+
+**Pitfall**: after running `make upgrade-html-deps`, verify the theme preset
+files under `shiny/www/shared/sass/preset/` were actually updated — a partial
+run can leave presets stale.
+
+## py-shiny TypeScript bundle
+
+Client-side code is in `js/`:
+
+- Entry point: `js/src/shiny/index.ts`
+- Build tool: esbuild via `js/build.ts`
+- Output: `shiny/www/shared/py-shiny/shiny.js` and minified variant, with
+  source maps for debugging
+- TypeScript definitions for Python-JS interop
+
+```bash
+make js-build        # One-time build (npm install runs automatically)
+make js-watch        # Continuous rebuild on change
+make js-watch-fast   # Continuous rebuild, skipping lint and minification
+```
+
+Changes to `js/src/` are invisible to Python apps until rebuilt — the apps load
+the committed bundle from `shiny/www/shared/py-shiny/`.
+
+## When assets come from bslib
+
+New Bootstrap components are developed in the R bslib package first and ported
+here; the port vendors bslib's compiled JS/CSS rather than reimplementing it.
+See `.claude/skills/port-from-bslib/SKILL.md` for that full workflow.

--- a/.claude/references/commit-conventions.md
+++ b/.claude/references/commit-conventions.md
@@ -8,8 +8,6 @@ This project uses **conventional commits** for commit messages and PR titles.
 <type>: <description>
 
 [optional body]
-
-Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
 ```
 
 An optional scope may be added when it clarifies the affected area, e.g.
@@ -33,8 +31,7 @@ An optional scope may be added when it clarifies the affected area, e.g.
 - Use sentence case: "Add feature" not "add feature"
 - No period at the end of the subject line
 - Body is optional but useful for explaining "why" not "what"
-- Always include `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>` when
-  Claude writes the code
+- Do not add `Co-Authored-By: Claude ...` trailers
 
 ## PR Titles
 

--- a/.claude/references/commit-conventions.md
+++ b/.claude/references/commit-conventions.md
@@ -50,25 +50,33 @@ merged, so the PR title becomes the commit message on `main`):
   `--auto` merges instantly instead of waiting for CI. Watch CI to completion,
   then merge.
 
-## Handling flaky test failures
+## Handling flaky test failures in CI
 
-- If tests unrelated to the PR fail, restart the failed jobs:
+This section is about GitHub Actions jobs failing on a PR's CI run. (A test
+that fails locally on your machine is not "flaky" for this purpose — reproduce
+and fix it.)
+
+- If a CI job fails on tests unrelated to the PR's changes, restart that job:
   `gh run rerun <run-id> --failed`.
-- For each broken test that **passes within the restarted job**, submit a
-  GitHub Issue (`gh issue create`) containing a github.com URL link to the
-  broken job and the error output when possible. Search existing issues for
-  the test name first; if one exists, comment with the new occurrence instead
-  of filing a duplicate.
-- Individual tests are already retried in-job (pytest-rerunfailures); a
-  `1 rerun` note in the log means a flake was absorbed and needs no action.
-- A test that fails the **same way twice in a row** is not flaky — treat it as
-  real breakage and investigate.
-- Before chasing a failure, check whether `main` fails the same way
-  (`gh run list --workflow "Run tests" --branch main`). If it does, the
-  breakage is pre-existing — report it, don't fix it in the unrelated PR.
-- Never change tests or snapshots just to quiet an unrelated failure (e.g., do
-  not run `--snapshot-update` to silence syrupy's "unused snapshots" error —
-  a job can fail from that even when every test passed).
+- For each test that failed in the original CI job but **passes in the
+  restarted job**, submit a GitHub Issue (`gh issue create`) containing a
+  github.com URL link to the failed job and the error output when possible.
+  Search existing issues for the test name first; if one exists, comment with
+  the new occurrence instead of filing a duplicate.
+- Within a CI job, individual tests are already retried
+  (pytest-rerunfailures); a `1 rerun` note in the job log means a flake was
+  absorbed and the job passed — no action needed.
+- A CI job that fails the **same way twice in a row** (original run + restart)
+  is not flaky — treat it as real breakage and investigate, starting by
+  reproducing the failing test locally.
+- Before chasing a CI failure, check whether the same workflow also fails on
+  `main` (`gh run list --workflow "Run tests" --branch main`). If it does, the
+  breakage is pre-existing — report it (or file an issue), don't fix it in the
+  unrelated PR.
+- Never change tests or snapshots just to make an unrelated CI failure go
+  away (e.g., do not run `--snapshot-update` to silence syrupy's "unused
+  snapshots" error — that error can fail a CI job even when every test
+  passed).
 
 ## Related
 

--- a/.claude/references/commit-conventions.md
+++ b/.claude/references/commit-conventions.md
@@ -1,0 +1,51 @@
+# Git Commit and PR Conventions
+
+This project uses **conventional commits** for commit messages and PR titles.
+
+## Commit Message Format
+
+```
+<type>: <description>
+
+[optional body]
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+```
+
+An optional scope may be added when it clarifies the affected area, e.g.
+`fix(tests): Read UserInput.text in chat module test app`.
+
+## Types
+
+- **feat**: New feature (e.g., `feat: Add input_submit_textarea component`)
+- **fix**: Bug fix (e.g., `fix: Resolve session context error in modules`)
+- **docs**: Documentation changes (e.g., `docs: Update reactive programming guide`)
+- **refactor**: Code refactoring without behavior change
+- **test**: Adding or updating tests
+- **chore**: Maintenance tasks, dependency updates
+- **perf**: Performance improvements
+- **style**: Code style/formatting changes (not user-facing style)
+
+## Guidelines
+
+- Use present tense: "Add feature" not "Added feature"
+- Keep the description concise (under 72 characters for the first line)
+- Use sentence case: "Add feature" not "add feature"
+- No period at the end of the subject line
+- Body is optional but useful for explaining "why" not "what"
+- Always include `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>` when
+  Claude writes the code
+
+## PR Titles
+
+PR titles should follow the same conventional commit format (PRs are squash
+merged, so the PR title becomes the commit message on `main`):
+
+- `feat: Add Toolbar component`
+- `fix: Pin griffe to <2.0.0 for quartodoc compatibility`
+- `refactor: Simplify reactive graph invalidation logic`
+
+## Related
+
+- Update `CHANGELOG.md` for user-facing changes
+- Always run `make format` before committing

--- a/.claude/references/commit-conventions.md
+++ b/.claude/references/commit-conventions.md
@@ -63,6 +63,9 @@ and fix it.)
   github.com URL link to the failed job and the error output when possible.
   Search existing issues for the test name first; if one exists, comment with
   the new occurrence instead of filing a duplicate.
+- **Staleness rule**: when a flake issue has had no new occurrences reported
+  for **30 days** (check the last occurrence comment's date), close it with a
+  note that it can be reopened if the flake returns.
 - Within a CI job, individual tests are already retried
   (pytest-rerunfailures); a `1 rerun` note in the job log means a flake was
   absorbed and the job passed — no action needed.

--- a/.claude/references/commit-conventions.md
+++ b/.claude/references/commit-conventions.md
@@ -64,9 +64,9 @@ and fix it.)
   Search existing issues for the test name first; if one exists, comment with
   the new occurrence instead of filing a duplicate.
 - Label flake issues with **`flaky test`** (groups them for the staleness
-  sweep), **`ai-generated-issue`** (marks the body as AI-written), and
-  **`needs-triage`** (flags it for human attention):
-  `gh issue create --label "flaky test,ai-generated-issue,needs-triage" ...`
+  sweep) and **`ai-generated-issue`** (marks the body as AI-written):
+  `gh issue create --label "flaky test,ai-generated-issue" ...`
+  Do not add `needs-triage`.
 - **Staleness rule**: when a flake issue has had no new occurrences reported
   for **30 days** (check the last occurrence comment's date), close it with a
   note that it can be reopened if the flake returns. Find candidates with

--- a/.claude/references/commit-conventions.md
+++ b/.claude/references/commit-conventions.md
@@ -63,9 +63,14 @@ and fix it.)
   github.com URL link to the failed job and the error output when possible.
   Search existing issues for the test name first; if one exists, comment with
   the new occurrence instead of filing a duplicate.
+- Label flake issues with **`flaky test`** (groups them for the staleness
+  sweep), **`ai-generated-issue`** (marks the body as AI-written), and
+  **`needs-triage`** (flags it for human attention):
+  `gh issue create --label "flaky test,ai-generated-issue,needs-triage" ...`
 - **Staleness rule**: when a flake issue has had no new occurrences reported
   for **30 days** (check the last occurrence comment's date), close it with a
-  note that it can be reopened if the flake returns.
+  note that it can be reopened if the flake returns. Find candidates with
+  `gh issue list --label "flaky test"`.
 - Within a CI job, individual tests are already retried
   (pytest-rerunfailures); a `1 rerun` note in the job log means a flake was
   absorbed and the job passed — no action needed.

--- a/.claude/references/commit-conventions.md
+++ b/.claude/references/commit-conventions.md
@@ -42,6 +42,34 @@ merged, so the PR title becomes the commit message on `main`):
 - `fix: Pin griffe to <2.0.0 for quartodoc compatibility`
 - `refactor: Simplify reactive graph invalidation logic`
 
+## Merging PRs
+
+- When instructed to merge a PR, **squash merge** (`gh pr merge <number> --squash`)
+  only after the **full test suite (150+ GHA jobs) has succeeded** (`gh pr checks`).
+- **Never use `gh pr merge --auto`**: this repo has no required checks, so
+  `--auto` merges instantly instead of waiting for CI. Watch CI to completion,
+  then merge.
+
+## Handling flaky test failures
+
+- If tests unrelated to the PR fail, restart the failed jobs:
+  `gh run rerun <run-id> --failed`.
+- For each broken test that **passes within the restarted job**, submit a
+  GitHub Issue (`gh issue create`) containing a github.com URL link to the
+  broken job and the error output when possible. Search existing issues for
+  the test name first; if one exists, comment with the new occurrence instead
+  of filing a duplicate.
+- Individual tests are already retried in-job (pytest-rerunfailures); a
+  `1 rerun` note in the log means a flake was absorbed and needs no action.
+- A test that fails the **same way twice in a row** is not flaky — treat it as
+  real breakage and investigate.
+- Before chasing a failure, check whether `main` fails the same way
+  (`gh run list --workflow "Run tests" --branch main`). If it does, the
+  breakage is pre-existing — report it, don't fix it in the unrelated PR.
+- Never change tests or snapshots just to quiet an unrelated failure (e.g., do
+  not run `--snapshot-update` to silence syrupy's "unused snapshots" error —
+  a job can fail from that even when every test passed).
+
 ## Related
 
 - Update `CHANGELOG.md` for user-facing changes

--- a/.claude/references/component-patterns.md
+++ b/.claude/references/component-patterns.md
@@ -48,6 +48,19 @@ with exactly one `ui.output_*()` function (the one returned by its
 renderer. When adding an output component, add its renderer alongside it (and
 vice versa) — don't create shared or orphaned output UI functions.
 
+For example, `render.text` and `render.code` are both `Renderer[str]`, so
+`@render.text` would *technically* work inside a `ui.output_code()` container.
+The pairs are still kept strictly 1:1 — `render.text` ↔ `ui.output_text()`,
+`render.code` ↔ `ui.output_code()` — because:
+
+- **Express mode requires it**: Express renders the output UI automatically via
+  `auto_output_ui()`, so every renderer must have exactly one correct default
+  container. A code-styled output needs its own renderer (`render.code`), not a
+  "use `render.text` with a different container" recipe that only works in Core.
+- **1:1 is easier to explain**: documenting "each renderer has one output
+  function" beats documenting which of several containers *possibly* work with
+  which renderer (1:many).
+
 When creating a custom output renderer (base class:
 `shiny/render/renderer/_renderer.py`):
 

--- a/.claude/references/component-patterns.md
+++ b/.claude/references/component-patterns.md
@@ -1,0 +1,68 @@
+# Component and Renderer Implementation Patterns
+
+Recipes for adding new UI components and output renderers to py-shiny. For
+porting a component from R's bslib specifically, use the
+`.claude/skills/port-from-bslib/SKILL.md` skill instead — it covers asset
+vendoring on top of these steps.
+
+## UI component pattern
+
+When implementing a UI component (see `shiny/ui/_input_slider.py` for a
+representative example):
+
+1. Create the file as `shiny/ui/_component_name.py` with an explicit `__all__`
+   tuple listing the public names.
+2. Resolve the input's ID with `resolve_id(id)` (from `shiny.module`) so the
+   component works inside modules.
+3. For input components, support bookmarking by passing the initial value
+   through `restore_input(resolved_id, value)` (from `shiny.bookmark`).
+4. Use `shiny_input_label()` (from `shiny/ui/_utils.py`) to render the label
+   consistently with other inputs.
+5. Return a `Tag`/`TagList`. If the component depends on bslib assets, include
+   `components_dependencies()`; component-specific JS/CSS is attached as
+   `HTMLDependency` objects defined in `shiny/ui/_html_deps_*.py`.
+6. Export the function:
+   - `shiny/ui/__init__.py` (Core API)
+   - `shiny/express/ui/__init__.py` (Express API, if applicable — most UI
+     functions are re-exported there, sometimes wrapped as a
+     `RecallContextManager` for container components)
+7. Input components usually need a companion `update_*()` function that sends a
+   message via `session.send_input_message(id, ...)`; the TypeScript input
+   binding handles it in `receiveMessage()`.
+8. Add docs: docstring per `.claude/references/documentation-style.md`, an
+   example app in `shiny/api-examples/<name>/` (`app-core.py` +
+   `app-express.py`), and entries in `docs/_quartodoc-core.yml` /
+   `docs/_quartodoc-express.yml`.
+9. For input components, add a Playwright controller class in
+   `shiny/playwright/controller/` (see the `_input_*.py` files there) and
+   register it in the testing quartodoc YAML.
+10. Add unit tests in `tests/pytest/` and an end-to-end test app + test in
+    `tests/playwright/shiny/`.
+11. Update `CHANGELOG.md`.
+
+## Renderer pattern
+
+When creating a custom output renderer (base class:
+`shiny/render/renderer/_renderer.py`):
+
+1. Inherit from `Renderer[IT]`, where `IT` is the type the app author's value
+   function returns.
+2. Implement `auto_output_ui(self)` — the UI that Express mode renders
+   automatically for this output (Core mode users place the matching
+   `ui.output_*()` themselves).
+3. Implement **either**:
+   - `transform(self, value: IT)` — the simple path. It only receives
+     non-`None` values and must return something JSON-serializable; the base
+     class handles resolving the value function and early-`None` returns.
+   - `render(self)` — full control. Call the app-supplied value function via
+     `await self.fn()` (always async-wrapped) and return a JSON-serializable
+     result.
+4. The renderer auto-registers with the session's `Output` when it receives the
+   value function, so app authors don't need `@output`. Use
+   `self.output_id` / `self.__name__` for the output's name (module prefix not
+   included).
+5. Export from `shiny/render/__init__.py` and add docs entries (quartodoc
+   YAMLs, example app).
+
+> **Do not use `@output_transformer()`** (`shiny/render/transformer/`) for new
+> renderers — it is superseded by the `Renderer` class and slated for removal.

--- a/.claude/references/component-patterns.md
+++ b/.claude/references/component-patterns.md
@@ -42,6 +42,12 @@ representative example):
 
 ## Renderer pattern
 
+Output components and renderers have a **1:1 mapping**: each renderer pairs
+with exactly one `ui.output_*()` function (the one returned by its
+`auto_output_ui()`), and each output component exists to serve exactly one
+renderer. When adding an output component, add its renderer alongside it (and
+vice versa) — don't create shared or orphaned output UI functions.
+
 When creating a custom output renderer (base class:
 `shiny/render/renderer/_renderer.py`):
 

--- a/.claude/references/documentation-style.md
+++ b/.claude/references/documentation-style.md
@@ -1,0 +1,159 @@
+# Documentation Style Guide
+
+Conventions for writing docstrings and API examples in py-shiny. API docs are
+rendered by [quartodoc](https://machow.github.io/quartodoc/) (configured in
+`docs/_quartodoc-*.yml`), so docstrings must follow the conventions below to
+render correctly.
+
+## Docstring format
+
+Use **NumPy-style (numpydoc) docstrings** with dash-underlined section headers.
+(Not Google-style, and not free-form reST — though Sphinx *roles* are used for
+cross-references, see below.)
+
+- Brief one-line description first, then optional longer paragraphs.
+- Section order: `Parameters`, `Returns`, `Yields`, `Raises`, `Notes`,
+  `Examples`, `See Also`.
+- Parameter entries are the bare name (no type — types come from annotations)
+  followed by an indented description:
+
+  ```
+  Parameters
+  ----------
+  id
+      An input id.
+  label
+      An input label.
+  ```
+
+- `Returns` uses a bare `:` placeholder instead of repeating the type:
+
+  ```
+  Returns
+  -------
+  :
+      A UI element.
+  ```
+
+- `Raises` names the exception class and describes when it is raised.
+
+## Inline markup and cross-references
+
+- Inline code: use double backticks (reST style), e.g. ``` ``True`` ``` ,
+  ``` ``None`` ``` , ``` ``"400px"`` ``` . Markdown single backticks also
+  render, but match the double-backtick style of surrounding code.
+- Cross-reference other API objects with Sphinx roles, using `~` to display
+  only the final name segment:
+  - Functions: `` :func:`~shiny.ui.update_slider` ``
+  - Classes: `` :class:`~shiny.ui.AnimationOptions` ``, `` :class:`~datetime.datetime` ``
+  - Also available: `` :meth:` ` ``, `` :attr:` ` ``
+- `See Also` is a markdown bullet list of cross-reference roles:
+
+  ```
+  See Also
+  --------
+  * :func:`~shiny.ui.update_slider`
+  * :class:`~shiny.ui.AnimationOptions`
+  ```
+
+- Quarto markdown (callouts, divs) is allowed in docstrings since docs are
+  rendered with Quarto:
+
+  ```
+  ::: {.callout-note title="Server value"}
+  A number, date, or date-time (depending on the class of value).
+  :::
+  ```
+
+## Input component conventions
+
+Every `input_*()` function documents its server-side value in a
+`Notes` section using the "Server value" callout shown above. This is the
+canonical place to describe what `input.<id>()` returns on the server.
+
+## Examples via `@add_example()`
+
+Do **not** write inline `Examples` sections for public API functions. Instead,
+attach runnable example apps with the `@add_example()` decorator
+(`shiny/_docstring.py`):
+
+- Examples live in `shiny/api-examples/<function_name>/` (or
+  `shiny/experimental/api-examples/` for `shiny.experimental`).
+- Each example directory contains `app-core.py` (Core syntax) and
+  `app-express.py` (Express syntax). A single `app.py` is treated as the Core
+  variant. Provide both variants whenever the function exists in both APIs.
+- Support files (data, modules, `icons.py`, etc.) may sit alongside the app
+  files, but must not be named `app.py` or start with `app-` — those names are
+  reserved for example variants.
+- `@add_example()` looks up the directory matching the function's `__name__`.
+  When the example directory has a different name (e.g. several functions
+  share one example), pass `example_name="other_dir"`. Prefer `example_name=`
+  over the legacy `ex_dir=` relative-path parameter.
+- Use `@no_example()` (optionally `@no_example("express")` /
+  `@no_example("core")`) to intentionally skip an example for a function or
+  for one mode.
+- Examples are only injected when `SHINY_ADD_EXAMPLES=true` (set by
+  `make quartodoc`), so missing examples surface as **docs build failures**,
+  not import errors. The docs build fails on missing API examples — every new
+  public function needs an example directory or an explicit `@no_example()`.
+
+## Registering new API in the docs site
+
+Adding a docstring is not enough to publish it. New public functions/classes
+must be listed in the quartodoc config:
+
+- `docs/_quartodoc-core.yml` — Core API reference
+- `docs/_quartodoc-express.yml` — Express API reference
+- `docs/_quartodoc-testing.yml` — Testing/controller API reference
+
+Add entries in **alphabetical order within their section**. Express variants of
+UI functions generally need entries in both the core and express files.
+
+## Verifying docs changes
+
+```bash
+make docs           # Build with quartodoc (slow — run at the end; sets SHINY_ADD_EXAMPLES=true)
+make docs-preview   # Build and serve locally
+```
+
+A successful `make docs` run is the check that examples resolve, cross-reference
+roles are valid, and quartodoc YAML entries are correct.
+
+## Full template
+
+````python
+from .._docstring import add_example
+
+@add_example()
+def input_foo(id: str, label: TagChild, *, width: Optional[str] = None) -> Tag:
+    """
+    Create a foo input control.
+
+    Longer description if needed. Use ``double backticks`` for inline code and
+    :func:`~shiny.ui.update_foo` style roles for cross-references.
+
+    Parameters
+    ----------
+    id
+        An input id.
+    label
+        An input label.
+    width
+        The CSS width, e.g. ``"400px"`` or ``"100%"``.
+
+    Returns
+    -------
+    :
+        A UI element.
+
+    Notes
+    ------
+    ::: {.callout-note title="Server value"}
+    A string with the current value of the foo input.
+    :::
+
+    See Also
+    --------
+    * :func:`~shiny.ui.update_foo`
+    """
+````

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,133 +67,30 @@ make playwright-examples  # Tests in tests/playwright/examples/
 
 ## Architecture
 
-### Reactive System
+See `.claude/references/architecture.md` for the full guide. Topic summaries:
 
-The reactive system is based on a **push-pull** model with three core abstractions:
-
-- **Context**: Tracks reactive dependencies during execution. When a reactive consumer (Calc/Effect) runs, it creates a Context that records which reactive sources (Value) it reads from.
-- **Dependents**: Each reactive source maintains a list of downstream consumers that depend on it. When a source invalidates, it notifies all dependents.
-- **ReactiveEnvironment**: Global singleton managing the reactive graph, execution queue, and flush cycles.
-
-Key implementation details:
-- `Value()` is the reactive source (observable)
-- `Calc_()` is a cached computed value (recomputes only when dependencies change)
-- `Effect_()` is a side-effect that re-executes when dependencies change
-- `event()` decorator suppresses reactive dependencies for specific reads
-- The reactive graph is built automatically through the Context's dependency tracking
-- Execution uses a priority queue to ensure correct invalidation ordering
-
-### Session Hierarchy
-
-Sessions manage the lifetime and state of a Shiny application:
-
-- **Session (ABC)**: Base interface defining core session operations
-- **AppSession**: Concrete implementation for a single user's session
-- **SessionProxy**: Thread-safe proxy that delegates to the appropriate AppSession
-- **Inputs/Outputs**: Dynamic objects providing dict-like access to input/output values
-
-Session management:
-- Each WebSocket connection gets its own AppSession
-- `get_current_session()` retrieves the current session from thread-local or async context
-- Sessions track input values, output invalidations, file uploads, downloads, and more
-- Session context is established using `session_context(session)` context manager
-
-### Express vs Core Mode
-
-**Core mode** is imperative: you explicitly construct UI and define server logic in a function.
-
-**Express mode** transforms Python code using AST manipulation:
-- `@render.text` decorators are hoisted into a synthetic `server()` function
-- UI elements are collected into a synthetic `ui` object
-- Top-level code runs in a special context where UI calls are recorded
-- `RecallContextManager` enables UI elements to render themselves automatically
-- The transformation happens at import time via `_run.py` and `_node_transformers.py`
-
-Critical difference: Express mode uses **execution order** (top-to-bottom) for UI layout, while Core mode uses explicit nesting.
-
-### HTML Generation and Dependencies
-
-HTML is generated using the `htmltools` package:
-- UI functions return `Tag` or `TagList` objects
-- Tags are mutable; use `.add_class()`, `.add_style()`, `.attrs()` to modify
-- HTML dependencies are attached to tags and automatically bundled
-- `components_dependencies()` returns bslib component dependencies
-
-Asset vendoring:
-- SCSS source files from bslib are in `shiny/www/shared/sass/bslib/components/scss/`
-- Compiled CSS is generated for all theme presets (27 files in `shiny/www/shared/sass/preset/`)
-- JavaScript bundles are in `shiny/www/shared/bslib/components/components.min.js`
-- `make upgrade-html-deps` runs `scripts/htmlDependencies.R` to update all assets
-
-### Input/Output Bindings
-
-Client-server communication works through bindings:
-
-**Input bindings** (client → server):
-- Registered via CSS class selectors in TypeScript (e.g., `.bslib-input-foo`)
-- Implement `getValue()`, `setValue()`, `subscribe()` methods
-- Send values to server using `Shiny.setInputValue(id, value)`
-- Server receives via `input.foo()` which returns a reactive Value
-
-**Output bindings** (server → client):
-- Server defines output using `@render.text`, `@render.plot`, etc.
-- Renderers inherit from `Renderer` base class
-- Client subscribes to output via `Shiny.bindOutput()` in TypeScript
-- Updates are sent as messages through the WebSocket
-
-**Update functions**:
-- Use `session.send_input_message()` to update input widgets from server
-- Client handles via `receiveMessage()` in the input binding
-
-### Module System
-
-Modules enable namespaced, reusable components:
-- `@module.ui` decorator creates a UI function with automatic ID namespacing
-- `@module.server` decorator creates a server function with namespace context
-- Inside a module, use `resolve_id()` to namespace IDs
-- `resolve_id_or_none()` for optional namespacing
-- Modules can be nested; namespaces compose with `parent-child` format
-
-Implementation: `_namespaces.py` manages the namespace stack, `module.py` provides decorators.
-
-### Testing Architecture
-
-**Unit tests** (`tests/pytest/`):
-- Use standard pytest with syrupy for snapshots
-- Focus on Python API correctness, parameter validation, edge cases
-- Run with `make test` or `pytest`
-
-**Playwright tests** (`tests/playwright/`):
-- End-to-end tests using Playwright with custom controllers
-- Controllers in `shiny/playwright/controller/` provide high-level APIs for interacting with inputs/outputs
-- Each input component should have a controller class
-- Test apps live alongside test files
-- Run with `make playwright` (all browsers) or `make playwright-debug` (chromium, headed)
-
-**Playwright controller pattern**:
-```python
-from shiny.playwright.controller import InputText, OutputText
-
-text_input = InputText(page, "my_input")
-text_input.set("foo")
-text_input.expect_value("foo")
-
-text_output = OutputText(page, "my_output")
-text_output.expect_value("You entered: foo")
-```
-
-### JavaScript/TypeScript Build
-
-Client-side code is in `js/`:
-- Entry point: `js/src/shiny/index.ts`
-- Build tool: esbuild via `js/build.ts`
-- Output: `shiny/www/shared/py-shiny/shiny.js` and minified variant
-- TypeScript definitions for Python-JS interop
-
-Development workflow:
-- `make js-watch` for continuous rebuilds during development
-- Changes to `js/src/` require rebuilding to see effects in Python apps
-- Source maps are generated for debugging
+- **Reactive system** (`shiny/reactive/`): push-pull model. `Value` is the source,
+  `Calc_` a cached computed value, `Effect_` a side-effect. A per-execution `Context`
+  records dependencies automatically; the `ReactiveEnvironment` singleton manages the
+  graph and flush cycles
+- **Sessions** (`shiny/session/`): each WebSocket connection gets an `AppSession`;
+  `get_current_session()` / `session_context()` manage the active session context
+- **Express vs Core**: Core is explicit UI construction + a server function. Express
+  rewrites the app via AST transformation at import time (`shiny/express/_run.py`,
+  `_node_transformers.py`) and lays out UI in execution order
+- **HTML/assets**: UI functions return `htmltools` `Tag`/`TagList` objects with
+  attached HTML dependencies; bslib CSS/JS/SCSS is vendored under `shiny/www/shared/`
+  via `make upgrade-html-deps`
+- **Input/output bindings**: TypeScript input bindings send values via
+  `Shiny.setInputValue()`; renderers push output over the WebSocket; server-initiated
+  updates go through `session.send_input_message()`
+- **Modules** (`shiny/module.py`, `shiny/_namespaces.py`): `@module.ui` /
+  `@module.server` namespace IDs; `resolve_id()` applies the namespace stack
+- **Testing**: unit tests in `tests/pytest/` (pytest + syrupy snapshots); end-to-end
+  tests in `tests/playwright/` driven by controller classes from
+  `shiny/playwright/controller/`
+- **JS build** (`js/`): esbuild via `js/build.ts` outputs to
+  `shiny/www/shared/py-shiny/`; rebuild (`make js-build` / `js-watch`) to see changes
 
 ## Key Files
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,8 @@ See `.claude/references/component-patterns.md` for the full checklists. In short
   `shiny/express/ui/__init__.py`; add example, controller, quartodoc entries, tests
 - **Renderers**: inherit `Renderer[IT]`; implement `auto_output_ui()` plus either
   `transform()` (simple) or `render()` (full control); export from
-  `shiny/render/__init__.py`. Do not use the deprecated `@output_transformer()`
+  `shiny/render/__init__.py`. Do not use the deprecated `@output_transformer()`.
+  Output components and renderers map 1:1 — add them as a pair
 
 ### Documentation Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,18 +132,6 @@ See `.claude/references/component-patterns.md` for the full checklists. In short
   `shiny/render/__init__.py`. Do not use the deprecated `@output_transformer()`.
   Output components and renderers map 1:1 — add them as a pair
 
-### Documentation Style
-
-See `.claude/references/documentation-style.md` for the full guide. In short:
-
-- **NumPy-style (numpydoc) docstrings** with dash-underlined sections; bare
-  parameter names (no types) with indented descriptions; `Returns` uses a `:` placeholder
-- Cross-reference API objects with Sphinx roles: `` :func:`~shiny.ui.update_slider` ``
-- Input components document their server value in a `Notes` Quarto callout
-- Attach runnable examples with `@add_example()` (apps in `shiny/api-examples/<name>/`
-  as `app-core.py` + `app-express.py`), not inline `Examples` sections
-- Register new public API in `docs/_quartodoc-*.yml` (alphabetical within sections)
-
 ### Type Checking Notes
 
 - Pyright is the primary type checker (not mypy)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,24 +10,33 @@ py-shiny is a Python web framework for building reactive web applications. It ma
 
 ### Essential Commands
 ```bash
-# Install dev dependencies
+# Install dev dependencies (requires Python 3.10+)
 pip install -e ".[dev,test,doc]"
+pre-commit install       # Optional: auto-format/lint on commit
 
 # Format code (always run before committing)
 make format              # Auto-fix with black and isort
 make check-format        # Check only
+make check-lint          # Lint with flake8
 
 # Type checking
 make check-types         # Run pyright (requires typings)
 
 # Run tests
 make test                # Unit tests only (pytest)
+pytest tests/pytest/test_foo.py::test_name  # Single unit test
 make playwright          # All end-to-end tests (slow)
 make playwright-shiny SUB_FILE="inputs/test_foo.py"  # Single test
 
 # Comprehensive checks
 make check               # Format, lint, types, unit tests
 make check-fix           # Same but auto-fixes formatting
+```
+
+### Running Apps
+```bash
+shiny run app.py --reload --launch-browser  # Dev server with auto-reload
+SHINY_LOG_LEVEL=DEBUG shiny run app.py      # Verbose logging
 ```
 
 ### Asset Management
@@ -38,13 +47,6 @@ make upgrade-html-deps   # Requires R installed
 # Build JavaScript/TypeScript
 make js-build            # One-time build
 make js-watch            # Continuous rebuild
-```
-
-### Documentation
-```bash
-# Build API docs (slow, run at the end)
-make docs                # Build with quartodoc
-make docs-preview        # Build and serve locally
 ```
 
 ### Testing Shortcuts
@@ -217,10 +219,7 @@ Development workflow:
 - `.pre-commit-config.yaml` - Pre-commit hook configuration
 
 ### Documentation
-- `docs/_quartodoc-core.yml` - Core API reference config
-- `docs/_quartodoc-express.yml` - Express API reference config
-- `docs/_quartodoc-testing.yml` - Testing API reference config
-- Add new functions here to include in generated docs (alphabetical order within sections)
+- `.claude/references/documentation-style.md` - Docstring conventions, `@add_example()` workflow, quartodoc registration, docs build commands
 
 ## Important Patterns
 
@@ -245,44 +244,15 @@ When creating a custom renderer:
 
 ### Documentation Style
 
-- Use **Google-style docstrings**, not Sphinx/reStructuredText format
-- Parameter descriptions use `name` followed by description on next line, indented
-- Use markdown in docstrings: backticks for code, `**bold**` for emphasis
-- Section headers: `Parameters`, `Returns`, `Yields`, `Raises`, `Examples`, `Note`, `See Also`
-- Example format:
+See `.claude/references/documentation-style.md` for the full guide. In short:
 
-````python
-def foo(x: int, name: str) -> bool:
-    """
-    Brief one-line description.
-
-    Longer description paragraph if needed. Can use markdown formatting
-    like `code`, **bold**, and even code blocks.
-
-    Parameters
-    ----------
-    x
-        Description of x parameter.
-    name
-        Description of name parameter.
-
-    Returns
-    -------
-    :
-        Description of return value.
-
-    Examples
-    --------
-    ```python
-    result = foo(42, "test")
-    ```
-
-    See Also
-    --------
-    * `bar()` - Related function that does something similar
-    * `baz()` - Another related function
-    """
-````
+- **NumPy-style (numpydoc) docstrings** with dash-underlined sections; bare
+  parameter names (no types) with indented descriptions; `Returns` uses a `:` placeholder
+- Cross-reference API objects with Sphinx roles: `` :func:`~shiny.ui.update_slider` ``
+- Input components document their server value in a `Notes` Quarto callout
+- Attach runnable examples with `@add_example()` (apps in `shiny/api-examples/<name>/`
+  as `app-core.py` + `app-express.py`), not inline `Examples` sections
+- Register new public API in `docs/_quartodoc-*.yml` (alphabetical within sections)
 
 ### Type Checking Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,30 +69,10 @@ make playwright-examples  # Tests in tests/playwright/examples/
 
 ## Architecture
 
-See `.claude/references/architecture.md` for the full guide. Topic summaries:
-
-- **Reactive system** (`shiny/reactive/`): push-pull model. `Value` is the source,
-  `Calc_` a cached computed value, `Effect_` a side-effect. A per-execution `Context`
-  records dependencies automatically; the `ReactiveEnvironment` singleton manages the
-  graph and flush cycles
-- **Sessions** (`shiny/session/`): each WebSocket connection gets an `AppSession`;
-  `get_current_session()` / `session_context()` manage the active session context
-- **Express vs Core**: Core is explicit UI construction + a server function. Express
-  rewrites the app via AST transformation at import time (`shiny/express/_run.py`,
-  `_node_transformers.py`) and lays out UI in execution order
-- **HTML/assets**: UI functions return `htmltools` `Tag`/`TagList` objects with
-  attached HTML dependencies; bslib CSS/JS/SCSS is vendored under `shiny/www/shared/`
-  via `make upgrade-html-deps`
-- **Input/output bindings**: TypeScript input bindings send values via
-  `Shiny.setInputValue()`; renderers push output over the WebSocket; server-initiated
-  updates go through `session.send_input_message()`
-- **Modules** (`shiny/module.py`, `shiny/_namespaces.py`): `@module.ui` /
-  `@module.server` namespace IDs; `resolve_id()` applies the namespace stack
-- **Testing**: unit tests in `tests/pytest/` (pytest + syrupy snapshots); end-to-end
-  tests in `tests/playwright/` driven by controller classes from
-  `shiny/playwright/controller/`
-- **JS build** (`js/`): esbuild via `js/build.ts` outputs to
-  `shiny/www/shared/py-shiny/`; rebuild (`make js-build` / `js-watch`) to see changes
+`.claude/references/architecture.md` explains how the internals work: the reactive
+system, session hierarchy, Express vs Core mode, HTML generation and dependencies,
+input/output bindings, the module system, testing architecture, and the JS build.
+Read the relevant section before working on any of those areas.
 
 ## Key Files
 
@@ -122,15 +102,10 @@ See `.claude/references/architecture.md` for the full guide. Topic summaries:
 
 ### Component and Renderer Implementation
 
-See `.claude/references/component-patterns.md` for the full checklists. In short:
-
-- **UI components**: `shiny/ui/_component_name.py`; use `resolve_id()` (modules) and
-  `restore_input()` (bookmarking); export from `shiny/ui/__init__.py` and
-  `shiny/express/ui/__init__.py`; add example, controller, quartodoc entries, tests
-- **Renderers**: inherit `Renderer[IT]`; implement `auto_output_ui()` plus either
-  `transform()` (simple) or `render()` (full control); export from
-  `shiny/render/__init__.py`. Do not use the deprecated `@output_transformer()`.
-  Output components and renderers map 1:1 — add them as a pair
+Before implementing a UI component or output renderer, read
+`.claude/references/component-patterns.md` — it has the step-by-step checklists
+(file layout, exports, examples, controllers, tests) and the rules for pairing
+output components with renderers.
 
 ### Type Checking Notes
 
@@ -174,10 +149,9 @@ Beyond PEP 8 and standard Python conventions, the following style preferences ar
 
 ## Git Commit and PR Conventions
 
-See `.claude/references/commit-conventions.md` for the full guide. In short:
-**conventional commits** for commit messages and PR titles
-(`<type>: <Description>` — sentence case, present tense, ≤72 chars, no trailing
-period). Types: feat, fix, docs, refactor, test, chore, perf, style.
+Commit messages and PR titles use **conventional commits**. Read
+`.claude/references/commit-conventions.md` for the format, types, and guidelines
+before committing or opening a PR.
 
 ## Common Pitfalls
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,24 +223,16 @@ Development workflow:
 
 ## Important Patterns
 
-### Component Implementation Pattern
+### Component and Renderer Implementation
 
-When implementing a UI component:
-1. Create file in `shiny/ui/_component_name.py`
-2. Use `@add_example()` decorator with example from `shiny/api-examples/`
-3. Use `resolve_id()` for module support
-4. Use `restore_input()` for bookmarking support (input components)
-5. Return Tag/TagList with `components_dependencies()` for bslib deps
-6. Export from `shiny/ui/__init__.py` (and `shiny/express/ui/__init__.py` if applicable)
+See `.claude/references/component-patterns.md` for the full checklists. In short:
 
-### Renderer Implementation Pattern
-
-When creating a custom renderer:
-1. Inherit from `Renderer[T]` base class
-2. Implement `auto_output_ui()` for automatic UI generation
-3. Implement `render()` async method returning the rendered value
-4. Use `@output_transformer()` decorator for post-processing
-5. Register in `shiny/render/__init__.py`
+- **UI components**: `shiny/ui/_component_name.py`; use `resolve_id()` (modules) and
+  `restore_input()` (bookmarking); export from `shiny/ui/__init__.py` and
+  `shiny/express/ui/__init__.py`; add example, controller, quartodoc entries, tests
+- **Renderers**: inherit `Renderer[IT]`; implement `auto_output_ui()` plus either
+  `transform()` (simple) or `render()` (full control); export from
+  `shiny/render/__init__.py`. Do not use the deprecated `@output_transformer()`
 
 ### Documentation Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,8 @@ SHINY_LOG_LEVEL=DEBUG shiny run app.py      # Verbose logging
 ```
 
 ### Asset Management
+
+See `.claude/references/assets.md` for details.
 ```bash
 # Vendor assets from upstream (bslib, shiny, sass, htmltools)
 make upgrade-html-deps   # Requires R installed
@@ -105,9 +107,7 @@ See `.claude/references/architecture.md` for the full guide. Topic summaries:
 - `shiny/module.py` - Module decorators and namespacing
 
 ### Asset Management
-- `scripts/htmlDependencies.R` - Vendors assets from bslib/shiny/sass/htmltools
-- `shiny/_versions.py` - Version tracking for vendored dependencies
-- `shiny/ui/_html_deps_*.py` - HTML dependency definitions
+- `.claude/references/assets.md` - Vendored bslib/shiny assets and the py-shiny JS bundle (key files, commands, pitfalls)
 
 ### Configuration
 - `pyproject.toml` - Package config, dependencies, tool settings
@@ -193,16 +193,10 @@ period). Types: feat, fix, docs, refactor, test, chore, perf, style.
 
 ## Porting from bslib
 
-For comprehensive guidance on porting components from R's bslib package, see `.claude/skills/port-from-bslib/SKILL.md`. Key steps:
-
-1. Locate and study the bslib source (R, TypeScript, SCSS)
-2. Create Python implementation in `shiny/ui/`
-3. Run `make upgrade-html-deps` to vendor compiled assets
-4. Create API examples in `shiny/api-examples/`
-5. Create Playwright controller (if input component)
-6. Port unit tests and create end-to-end tests
-7. Update quartodoc YAML files
-8. Update `CHANGELOG.md`
+New Bootstrap components are developed in R's bslib package first, then ported here
+(vendoring bslib's compiled assets rather than reimplementing them). For the complete
+workflow — studying the bslib source, Python implementation, asset vendoring, tests,
+and docs — use the `.claude/skills/port-from-bslib/SKILL.md` skill.
 
 ## Common Pitfalls
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,8 @@ Beyond PEP 8 and standard Python conventions, the following style preferences ar
 
 Commit messages and PR titles use **conventional commits**. Read
 `.claude/references/commit-conventions.md` for the format, types, and guidelines
-before committing or opening a PR.
+before committing or opening a PR — and for the merge policy and flaky-test
+handling before merging one.
 
 ## Common Pitfalls
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,40 +185,10 @@ Beyond PEP 8 and standard Python conventions, the following style preferences ar
 
 ## Git Commit and PR Conventions
 
-This project uses **conventional commits** for commit messages and PR titles:
-
-### Commit Message Format
-```
-<type>: <description>
-
-[optional body]
-
-Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
-```
-
-### Common Types
-- **feat**: New feature (e.g., `feat: Add input_submit_textarea component`)
-- **fix**: Bug fix (e.g., `fix: Resolve session context error in modules`)
-- **docs**: Documentation changes (e.g., `docs: Update reactive programming guide`)
-- **refactor**: Code refactoring without behavior change
-- **test**: Adding or updating tests
-- **chore**: Maintenance tasks, dependency updates
-- **perf**: Performance improvements
-- **style**: Code style/formatting changes (not user-facing style)
-
-### Guidelines
-- Use present tense: "Add feature" not "Added feature"
-- Keep the description concise (under 72 characters for the first line)
-- Use sentence case: "Add feature" not "add feature"
-- No period at the end of the subject line
-- Body is optional but useful for explaining "why" not "what"
-- Always include `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>` when Claude writes the code
-
-### PR Titles
-PR titles should follow the same conventional commit format:
-- `feat: Add Toolbar component`
-- `fix: Pin griffe to <2.0.0 for quartodoc compatibility`
-- `refactor: Simplify reactive graph invalidation logic`
+See `.claude/references/commit-conventions.md` for the full guide. In short:
+**conventional commits** for commit messages and PR titles
+(`<type>: <Description>` — sentence case, present tense, ≤72 chars, no trailing
+period). Types: feat, fix, docs, refactor, test, chore, perf, style.
 
 ## Porting from bslib
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,13 +179,6 @@ See `.claude/references/commit-conventions.md` for the full guide. In short:
 (`<type>: <Description>` — sentence case, present tense, ≤72 chars, no trailing
 period). Types: feat, fix, docs, refactor, test, chore, perf, style.
 
-## Porting from bslib
-
-New Bootstrap components are developed in R's bslib package first, then ported here
-(vendoring bslib's compiled assets rather than reimplementing them). For the complete
-workflow — studying the bslib source, Python implementation, asset vendoring, tests,
-and docs — use the `.claude/skills/port-from-bslib/SKILL.md` skill.
-
 ## Common Pitfalls
 
 - **Forgetting to run `make format`**: Always format before committing


### PR DESCRIPTION
## Summary

CLAUDE.md had grown to ~356 lines of always-loaded context, much of it deep-dive material only needed for specific task types. This PR slims it to ~164 lines of commands, key files, and per-edit style rules, and relocates the detailed guidance into five new task-specific reference files under `.claude/references/`:

- `architecture.md` — reactive system, sessions, Express vs Core AST transformation, bindings, modules, testing architecture, JS build
- `assets.md` — vendored bslib/shiny assets (`make upgrade-html-deps`) and the py-shiny TypeScript bundle
- `component-patterns.md` — UI component and renderer implementation checklists, including the 1:1 output-component ↔ renderer pairing rule (with the `render.text`/`render.code` example)
- `commit-conventions.md` — conventional commit format, types, and PR title guidelines
- `documentation-style.md` — docstring conventions, `@add_example()` workflow, quartodoc registration, docs build commands

Key decisions and corrections along the way:

- CLAUDE.md sections were replaced with scope-only pointers (what each reference covers, not its conclusions) so the always-loaded file can't drift out of sync with the references.
- Corrected the docstring guidance: the codebase uses NumPy-style (numpydoc) docstrings with Sphinx cross-reference roles, not Google-style with markdown as previously claimed.
- Corrected the renderer guidance: `@output_transformer()` is deprecated in favor of the `Renderer` base class (`transform()`/`render()` + `auto_output_ui()`).
- Removed the Claude co-author trailer from the commit conventions.
- The bslib porting section was reduced to nothing new: the `port-from-bslib` skill remains the single source for that workflow.

## Verification

Docs-only change (CLAUDE.md + `.claude/references/`); no code paths affected. Review by reading CLAUDE.md top to bottom and spot-checking that each pointer resolves to a reference file covering the named topics. Factual claims in the references were verified against the source while writing (e.g. `shiny/render/renderer/_renderer.py`, `shiny/_docstring.py`, `js/package.json`, `Makefile`).