### PR TITLE
fix(ci): Warn instead of fail on unused syrupy snapshots in playwright runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,8 +230,13 @@ install-rsconnect: FORCE
 # All end-to-end tests with playwright
 # `--timeout` bounds each test so a hang fails fast with a thread-stack dump
 # instead of consuming the whole job.
+# `--snapshot-warn-unused` because CI runs each browser and pytest-shard shard
+# as a separate partial job; syrupy (>=5.5.0, under xdist) would otherwise fail
+# the job for snapshots that belong to the tests running in the *other* jobs.
+# Stale snapshots can still be cleaned up with an all-browser, unsharded run
+# using `--snapshot-update`.
 playwright: install-playwright ## All end-to-end tests with playwright; (TEST_FILE="" from root of repo)
-	pytest $(PLAYWRIGHT_VERBOSE) --timeout=$(PLAYWRIGHT_TEST_TIMEOUT) --timeout-method=$(PLAYWRIGHT_TEST_TIMEOUT_METHOD) -o faulthandler_timeout=$(PLAYWRIGHT_FAULTHANDLER_TIMEOUT) $(TEST_FILE) $(PYTEST_BROWSERS)
+	pytest $(PLAYWRIGHT_VERBOSE) --snapshot-warn-unused --timeout=$(PLAYWRIGHT_TEST_TIMEOUT) --timeout-method=$(PLAYWRIGHT_TEST_TIMEOUT_METHOD) -o faulthandler_timeout=$(PLAYWRIGHT_FAULTHANDLER_TIMEOUT) $(TEST_FILE) $(PYTEST_BROWSERS)
 
 playwright-debug: install-playwright ## All end-to-end tests, chrome only, headed; (TEST_FILE="" from root of repo)
 	pytest -c tests/playwright/playwright-pytest.ini $(TEST_FILE)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ test = [
     "pytest-rerunfailures",
     "pytest-cov",
     "coverage",
-    "syrupy>=4.7.1",
+    "syrupy>=5.5.1",
     "psutil",
     "astropy",
     "suntime",


### PR DESCRIPTION
Closes #2333

## Summary

`playwright-shiny` CI shards started failing with syrupy's "snapshots unused" error even though every test passed. This PR downgrades the unused-snapshot check to a warning for playwright runs (`--snapshot-warn-unused` in the Makefile `playwright` target) and raises the minimum syrupy version to `>=5.5.1` so local runs and CI share the same snapshot behavior.

## Root cause

Three things combine to produce the failure:

1. **syrupy 5.5.0 (released 2026-07-06, hours before the first failure) added unused-snapshot detection under pytest-xdist** ([syrupy#1132](https://github.com/syrupy-project/syrupy/pull/1132)). Older versions silently skipped the check whenever `--numprocesses` was used, which is every CI playwright run. `pyproject.toml` had `syrupy>=4.7.1` unpinned, so CI picked up the new behavior with no repo change — that's why the failure appeared "out of nowhere" on docs-only PRs and on `main`.

2. **Every CI playwright job is a partial run.** Jobs split by browser (chromium/firefox/webkit) and by pytest-shard shard. `tests/playwright/shiny/components/data_frame/example/__snapshots__/test_data_frame.ambr` holds 12 snapshots (2 tests x 2 assertions x 3 browsers). A chromium shard that runs `test_multi_selection[chromium]` legitimately uses only 2 of them; the other 10 belong to tests running in *other* jobs. syrupy's snapshot-name matching strips the `[param]` suffix (`PyTestLocation.matches_snapshot_name`), so it cannot tell that `test_multi_selection[firefox]` belongs to a different job — hence "2 snapshots passed. 10 snapshots unused."

3. **The failure only fires when xdist worker gw0 dies mid-run.** syrupy 5.5.x has each worker publish its report to the controller, but only worker gw0 publishes the full collected-item set. This repo intentionally uses pytest-timeout's `thread` method, which kills the worker process on a hung test (then pytest-rerunfailures reruns it — the failing CI shard shows `[gw0] RERUN test_busy_indicators`). When gw0 dies, its report is lost, syrupy falls back to a state where `selected_all_collected_items` is true, and it takes the aggressive "everything discovered but unused is an error" branch. When all workers survive, the collected set (335 items, pre-shard) differs from the selected set (74) and syrupy's provided-path filtering suppresses the false positives. This is why the failure looked deterministic on CI (that test reruns frequently there) but would not reproduce locally with identical package versions and the identical command; I confirmed both paths locally by instrumenting syrupy's session state.

## Fix

- `Makefile`: add `--snapshot-warn-unused` to the `playwright` target. Unused-snapshot detection is fundamentally unreliable for these suites: partial runs by browser and shard mean no single job ever uses all snapshots, and param-stripped name matching can't distinguish cross-job snapshots from stale ones. The summary still prints the unused count as a warning. Unit tests (`make test`) keep the strict check, and stale playwright snapshots can still be cleaned with an unsharded all-browser `--snapshot-update` run.
- `pyproject.toml`: `syrupy>=4.7.1` -> `syrupy>=5.5.1` so everyone gets the same xdist-aware behavior (5.5.1 also fixes an "unknown hook" error from 5.5.0 when pytest-xdist is not installed).

## Verification

Reproduced the CI conditions locally (`pytest tests/playwright/shiny/. --numprocesses 3 --num-shards 4 --shard-id 0 --browser chromium`, same package versions as the failing CI job): 74 passed with "2 snapshots passed" and confirmed via instrumentation that the same 10 cross-job snapshots are computed as discovered-but-unused, gated only by whether gw0's report survives. With `--snapshot-warn-unused` the run reports unused snapshots as a warning and exits 0. `make -n playwright` shows the flag is included in the pytest invocation.