### PR TITLE
ci: Add "PR checks" gate job to enable auto-merge

### DIFF
--- a/.claude/references/commit-conventions.md
+++ b/.claude/references/commit-conventions.md
@@ -44,11 +44,15 @@ merged, so the PR title becomes the commit message on `main`):
 
 ## Merging PRs
 
-- When instructed to merge a PR, **squash merge** (`gh pr merge <number> --squash`)
-  only after the **full test suite (150+ GHA jobs) has succeeded** (`gh pr checks`).
-- **Never use `gh pr merge --auto`**: this repo has no required checks, so
-  `--auto` merges instantly instead of waiting for CI. Watch CI to completion,
-  then merge.
+- When instructed to merge a PR, **squash merge with auto-merge**
+  (`gh pr merge <number> --squash --auto`). Branch protection requires the
+  **"PR checks"** status check — the `pr-gate` job in
+  `.github/workflows/pytest.yaml` that fans in every PR job — so `--auto`
+  waits for the full test suite before merging.
+- The gate skips on draft PRs (drafts run a reduced test matrix and cannot be
+  merged anyway); mark the PR ready for review to trigger the full matrix.
+- When adding a job to `pytest.yaml`, add it to the `pr-gate` job's `needs:`
+  list, or its failures will not block merging.
 
 ## Handling flaky test failures in CI
 

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -20,10 +20,8 @@ on:
 jobs:
   build-docs:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.13"]
-      fail-fast: false
+    env:
+      PYTHON_VERSION: "3.13"
 
     steps:
       - uses: actions/checkout@v6
@@ -33,7 +31,7 @@ jobs:
       - name: Setup py-shiny
         uses: ./.github/py-shiny/setup
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ env.PYTHON_VERSION }}
 
       # =====================================================
       # API docs

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -326,3 +326,33 @@ jobs:
         uses: ./.github/py-shiny/narwhals-test
         with:
           shiny-dir: "."
+
+  # Single stable check for branch protection / auto-merge. Jobs above may be
+  # renamed or re-matrixed freely, but every PR job MUST be listed in `needs`
+  # below or its failure will not block merging.
+  pr-gate:
+    name: "PR checks"
+    # `always()` is required: without it, an upstream failure would make this
+    # job skip, and GitHub treats a skipped required check as satisfied.
+    # Skipping on draft PRs is safe for the same reason in reverse: drafts
+    # cannot be merged (or auto-merged) regardless, and skipping avoids
+    # failure emails from the reduced draft test matrix. Marking the PR
+    # ready for review re-triggers the workflow with the full matrix.
+    if: always() && github.event_name == 'pull_request' && !github.event.pull_request.draft
+    needs:
+      - check
+      - playwright-shiny
+      - playwright-examples
+      - playwright-ai
+      - playwright-deploys-precheck
+      - test-narwhals-integration
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify that all PR jobs succeeded
+        env:
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: |
+          echo "Job results: $RESULTS"
+          if echo "$RESULTS" | grep -qE 'failure|cancelled|skipped'; then
+            exit 1
+          fi

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -327,6 +327,14 @@ jobs:
         with:
           shiny-dir: "."
 
+  # DEMO ONLY (will be reverted): intentionally failing upstream job to prove
+  # that without `always()` the gate skips and satisfies branch protection.
+  demo-fail:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 1
+
   # Single stable check for branch protection / auto-merge. Jobs above may be
   # renamed or re-matrixed freely, but every PR job MUST be listed in `needs`
   # below or its failure will not block merging.
@@ -338,8 +346,9 @@ jobs:
     # cannot be merged (or auto-merged) regardless, and skipping avoids
     # failure emails from the reduced draft test matrix. Marking the PR
     # ready for review re-triggers the workflow with the full matrix.
-    if: always() && github.event_name == 'pull_request' && !github.event.pull_request.draft
+    if: github.event_name == 'pull_request' && !github.event.pull_request.draft
     needs:
+      - demo-fail
       - check
       - playwright-shiny
       - playwright-examples

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -327,14 +327,6 @@ jobs:
         with:
           shiny-dir: "."
 
-  # DEMO ONLY (will be reverted): intentionally failing upstream job to prove
-  # that without `always()` the gate skips and satisfies branch protection.
-  demo-fail:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - run: exit 1
-
   # Single stable check for branch protection / auto-merge. Jobs above may be
   # renamed or re-matrixed freely, but every PR job MUST be listed in `needs`
   # below or its failure will not block merging.
@@ -346,9 +338,8 @@ jobs:
     # cannot be merged (or auto-merged) regardless, and skipping avoids
     # failure emails from the reduced draft test matrix. Marking the PR
     # ready for review re-triggers the workflow with the full matrix.
-    if: github.event_name == 'pull_request' && !github.event.pull_request.draft
+    if: always() && github.event_name == 'pull_request' && !github.event.pull_request.draft
     needs:
-      - demo-fail
       - check
       - playwright-shiny
       - playwright-examples


### PR DESCRIPTION
## Summary
Adds a `pr-gate` job (check name **"PR checks"**) to `pytest.yaml` that `needs:` every PR job (`check`, `playwright-shiny`, `playwright-examples`, `playwright-ai`, `playwright-deploys-precheck`, `test-narwhals-integration`). Branch protection can require this one stable name, so jobs inside the workflow can be renamed or re-matrixed freely without touching the protection rule.

Key behaviors:
- `if: always()` so an upstream failure cannot cause the gate to skip — GitHub treats a skipped required check as satisfied.
- Skips on draft PRs: drafts run a reduced test matrix and cannot be merged anyway, and skipping avoids failure-notification emails on every draft push. Marking the PR ready for review re-triggers the workflow with the full matrix.
- Fails if any needed job reports `failure`, `cancelled`, or `skipped`.
- New PR jobs in `pytest.yaml` must be added to the gate's `needs:` list (documented in a comment at the job and in the merge-policy reference).

Also updates the merge policy in `.claude/references/commit-conventions.md` from "never use `gh pr merge --auto`" to "merge with `gh pr merge --squash --auto`", since the required check makes `--auto` wait for CI.

Follow-up after this merges: enable "Allow auto-merge" in repo settings and add **"PR checks"** as a required status check on `main`.

## Verification
On this PR's own CI run: the "PR checks" job is skipped while the PR is a draft, then runs and succeeds once the PR is marked ready for review and all fanned-in jobs pass. Its failure behavior can be seen by cancelling any needed job on a test branch — the gate then exits non-zero.