### PR TITLE
ci: Skip pyright type check on Windows runners

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -44,9 +44,10 @@ jobs:
         run: |
           make check-tests
 
-      - name: Type check
-        if: steps.install.outcome == 'success' && (success() || failure())
+      - name: Type check (not Windows)
+        if: steps.install.outcome == 'success' && (success() || failure()) && matrix.os != 'windows-latest'
         run: |
+          # `pythonPlatform: All` covers platform-specific stubs
           make check-types
 
       - name: Lint code

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -17,6 +17,7 @@
     "tests/inspect-ai/scripts/evaluation.py"
   ],
   "typeCheckingMode": "strict",
+  "pythonPlatform": "All",
   "reportImportCycles": "none",
   "reportUnusedFunction": "none",
   "reportPrivateUsage": "none",


### PR DESCRIPTION
## Summary

Windows runners are the slowest jobs in the test matrix, and pyright is a static check whose results don't depend on the host OS — the codebase has no `sys.platform` branching, so the Windows type check duplicated the ubuntu/mac runs. The "Type check" step in `pytest.yaml` now skips `windows-latest`, using the same condition pattern as the existing mypy step. To keep coverage of platform-conditional stdlib symbols (e.g. Windows-only `os`/`asyncio` members), `pyrightconfig.json` now sets `pythonPlatform: "All"`, which makes pyright check all platforms' stubs from any host. Unit tests, lint, and format checks still run on Windows.

## Verification

`make check-types` passes locally with the new `pythonPlatform: "All"` setting (0 errors). On this PR's CI run, the "Type check (not Windows)" step should show as skipped on `windows-latest` jobs and pass on ubuntu/mac.