### PR TITLE
fix(tests): De-race chat update_user_input test by numbering responses

### DIFF
--- a/tests/playwright/shiny/components/chat/update_user_input/app.py
+++ b/tests/playwright/shiny/components/chat/update_user_input/app.py
@@ -1,3 +1,5 @@
+from itertools import count
+
 from shiny import reactive
 from shiny.express import input, ui
 
@@ -49,6 +51,13 @@ def do_submit_and_focus():
     )
 
 
+# Number each response so the test can tell consecutive submissions of the
+# same message apart (otherwise an assertion on the latest message can be
+# satisfied by the previous, identical response while the new one is still in
+# flight).
+submit_counter = count(1)
+
+
 @chat.on_user_submit
 async def on_user_submit(message: str):
-    await chat.append_message(f"You said: {message}")
+    await chat.append_message(f"You said ({next(submit_counter)}): {message}")

--- a/tests/playwright/shiny/components/chat/update_user_input/test_chat_update_user_input.py
+++ b/tests/playwright/shiny/components/chat/update_user_input/test_chat_update_user_input.py
@@ -40,7 +40,9 @@ def test_validate_chat_update_user_input(page: Page, local_app: ShinyAppProc) ->
     submit.loc.focus()
     submit.click()
     chat.expect_user_input(set_msg)  # User doesn't lose what they had written
-    chat.expect_latest_message("You said: This chat was sent on behalf of the user.")
+    chat.expect_latest_message(
+        "You said (1): This chat was sent on behalf of the user."
+    )
     expect(chat.loc_input_button).to_be_enabled()
     expect(chat.loc_input).not_to_be_focused()
 
@@ -54,7 +56,14 @@ def test_validate_chat_update_user_input(page: Page, local_app: ShinyAppProc) ->
     submit.loc.focus()
     submit.click()
     chat.expect_user_input("")
-    chat.expect_latest_message("You said: This chat was sent on behalf of the user.")
+    # The "(2)" suffix distinguishes this response from the identical message
+    # submitted above. Waiting on it guarantees this submission's round trip
+    # has finished (and the chat input is re-enabled) before the next click;
+    # otherwise the next submit would be silently dropped while the input is
+    # disabled awaiting this response (#2337).
+    chat.expect_latest_message(
+        "You said (2): This chat was sent on behalf of the user."
+    )
     expect(chat.loc_input_button).to_be_disabled()
     expect(chat.loc_input).not_to_be_focused()
 
@@ -63,7 +72,7 @@ def test_validate_chat_update_user_input(page: Page, local_app: ShinyAppProc) ->
     submit_and_focus.click()
     chat.expect_user_input("")
     chat.expect_latest_message(
-        "You said: This chat was sent on behalf of the user. Input will still be focused."
+        "You said (3): This chat was sent on behalf of the user. Input will still be focused."
     )
     expect(chat.loc_input_button).to_be_disabled()
     expect(chat.loc_input).to_be_focused()


### PR DESCRIPTION
Closes #2337

## Summary

`test_validate_chat_update_user_input` submitted the exact same message twice ("This chat was sent on behalf of the user."). The assertion that waits for the second submission's response could therefore be satisfied by the *first* submission's identical response already in the DOM. When that happened, the test clicked `submit_and_focus` while the second submission was still in flight — and shinychat's client silently drops `update_user_input(submit=True)` while the input is disabled awaiting a response (`submitValue()` in `ChatInput.tsx` returns `false` when `disabled`). The third message never appeared and the final assertion timed out, matching the CI log exactly: two polls on the second submission's empty placeholder, then twelve polls on its echo.

The fix numbers each response in the test app (`You said (1): ...`, `You said (2): ...`, ...), so every `expect_latest_message` assertion can only be satisfied by its own submission's round trip. Since the message action and re-enabling of the input arrive in the same client state update, the next click is guaranteed to happen with the input enabled.

The race was reproduced deterministically by dispatching the `submit` and `submit_and_focus` clicks in a single JS task (both `update_input` actions then reach the client back-to-back before the first response), which produced the identical failure signature from the issue.

Note: the underlying silent drop of `update_user_input(submit=True)` while awaiting a response is arguably a shinychat bug worth an upstream issue; this PR only de-races the py-shiny test.

## Verification

`pytest tests/playwright/shiny/components/chat/update_user_input/ -p no:rerunfailures --browser chromium` — passes 4/4 consecutive runs locally.