### PR TITLE
feat: Ship a bookmarking Agent Skill in the shiny package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * The shiny package now ships [Agent Skills](https://agentskills.io) under `shiny/.agents/skills/` (the [library-skills](https://library-skills.io) convention), starting with a `debugging` skill that teaches coding agents to inspect running apps via test mode, `shiny.testmode.export_test_values()`, and the test snapshot endpoint. (#2339)
 
-* Added a `bookmarking` Agent Skill (under `shiny/.agents/skills/`) that teaches coding agents to save and restore app state with `bookmark_store=`, the `session.bookmark` lifecycle hooks, custom bookmark values, and server-side bookmark storage. (#2342)
+* Added a `bookmarking` Agent Skill (under `shiny/.agents/skills/`) that teaches coding agents to save and restore app state with `bookmark_store=`, the `session.bookmark` lifecycle hooks, custom bookmark values, and server-side bookmark storage. (#2345)
 
 * Added `offcanvas()` for creating sliding Bootstrap Offcanvas panels that appear from a viewport edge. Panels can be triggered by a UI element, revealed programmatically with `show_offcanvas()`, or controlled by id with `hide_offcanvas()` and `toggle_offcanvas()`. (#2279)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * The shiny package now ships [Agent Skills](https://agentskills.io) under `shiny/.agents/skills/` (the [library-skills](https://library-skills.io) convention), starting with a `debugging` skill that teaches coding agents to inspect running apps via test mode, `shiny.testmode.export_test_values()`, and the test snapshot endpoint. (#2339)
 
+* Added a `bookmarking` Agent Skill (under `shiny/.agents/skills/`) that teaches coding agents to save and restore app state with `bookmark_store=`, the `session.bookmark` lifecycle hooks, custom bookmark values, and server-side bookmark storage. (#2342)
+
 * Added `offcanvas()` for creating sliding Bootstrap Offcanvas panels that appear from a viewport edge. Panels can be triggered by a UI element, revealed programmatically with `show_offcanvas()`, or controlled by id with `hide_offcanvas()` and `toggle_offcanvas()`. (#2279)
 
 ### Improvements

--- a/shiny/.agents/skills/bookmarking/SKILL.md
+++ b/shiny/.agents/skills/bookmarking/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: bookmarking
+description: Use when a Shiny for Python (py-shiny) app needs to save and restore its state - shareable URLs that reproduce the current inputs, restoring state after a page refresh, persisting session state to the server, excluding inputs from saved state, or when tempted to hand-roll query-string parsing or a custom persistence layer to remember input values.
+---
+
+# Bookmarking Shiny for Python apps
+
+## Overview
+
+Bookmarking snapshots an app's `input` values (plus optional custom values) and
+restores them later from a URL. Use it instead of manually encoding state into
+query strings or building a custom persistence layer. Two stores: `"url"`
+(state encoded in the query string — shareable, keep under ~65k characters) and
+`"server"` (state saved to disk, URL carries only an id). Prefer `"url"` when
+the state fits.
+
+## Enable bookmarking
+
+**Express mode** — call `app_opts` at the top of the app file:
+
+```python
+from shiny.express import app_opts, session, ui
+
+app_opts(bookmark_store="url")
+
+ui.input_radio_buttons("letter", "Choose a letter", choices=["A", "B", "C"])
+ui.input_bookmark_button()
+
+
+@session.bookmark.on_bookmarked
+async def _(url: str):
+    await session.bookmark.update_query_string(url)
+```
+
+**Core mode** — the UI **must be a function** taking a `starlette.Request`
+(a static UI object cannot receive restored values), and `App` needs
+`bookmark_store=`:
+
+```python
+from starlette.requests import Request
+from shiny import App, Inputs, Outputs, Session, ui
+
+def app_ui(request: Request):
+    return ui.page_fluid(
+        ui.input_radio_buttons("letter", "Choose a letter", choices=["A", "B", "C"]),
+        ui.input_bookmark_button(),
+    )
+
+def server(input: Inputs, output: Outputs, session: Session):
+    @session.bookmark.on_bookmarked
+    async def _(url: str):
+        await session.bookmark.update_query_string(url)
+
+app = App(app_ui, server, bookmark_store="url")
+```
+
+With this in place, all inputs are saved on bookmark and restored on page load
+automatically — no per-input code needed.
+
+## Trigger a bookmark
+
+- **UI button:** `ui.input_bookmark_button()` — clicking it calls
+  `session.bookmark()` for you.
+- **Programmatic** (e.g. bookmark on every change):
+
+```python
+@reactive.effect
+@reactive.event(input.letter, ignore_init=True)
+async def _():
+    await session.bookmark()
+```
+
+After the state is saved, `on_bookmarked` callbacks receive the bookmark URL.
+If none are registered, a modal dialog shows the URL; registering the
+`update_query_string(url)` callback (as above) writes it to the browser's
+address bar instead.
+
+## Save and restore custom (non-input) values
+
+Reactive values, computed state, etc. go in `state.values` — do NOT create
+hidden inputs to smuggle them into the bookmark:
+
+```python
+from shiny.bookmark import BookmarkState, RestoreState
+
+@session.bookmark.on_bookmark
+def _(state: BookmarkState):
+    state.values["page"] = current_page()
+
+@session.bookmark.on_restore
+def _(state: RestoreState):
+    if "page" in state.values:
+        ui.update_radio_buttons("page", selected=state.values["page"])
+```
+
+Unlike inputs, `state.values` are never applied to the UI automatically — apply
+them yourself in `on_restore` (runs before reactive expressions) or, for slow
+late-rendering components, `on_restored` (runs after). `state.input` is also
+readable in these callbacks, but input restoration has already happened via the
+UI.
+
+## Exclude inputs
+
+```python
+session.bookmark.exclude.append("transient_input")
+```
+
+Passwords are excluded automatically; file inputs are unserializable under
+`"url"` storage. For custom exclusion logic, register a serializer:
+`session.input.set_serializer(id, fn)` where `fn` returns a JSON-serializable
+value or `shiny.bookmark.Unserializable()`.
+
+## Server-side storage location
+
+For `bookmark_store="server"` in hosted environments, control where state is
+written (set these **before** creating the `App`):
+
+```python
+from pathlib import Path
+from shiny.bookmark import set_global_restore_dir_fn, set_global_save_dir_fn
+
+bookmark_dir = Path(__file__).parent / "bookmarks"
+
+def save_dir(id: str) -> Path:
+    d = bookmark_dir / id
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+set_global_save_dir_fn(save_dir)
+set_global_restore_dir_fn(lambda id: bookmark_dir / id)
+```
+
+## Quick reference
+
+| Need | API |
+|---|---|
+| Enable (Express / Core) | `app_opts(bookmark_store="url")` / `App(..., bookmark_store="url")` |
+| Bookmark now | `await session.bookmark()` |
+| Put bookmark URL in address bar | `session.bookmark.update_query_string(url)` inside `on_bookmarked` |
+| Get URL without side-band UI | `await session.bookmark.get_bookmark_url()` |
+| Lifecycle hooks | `session.bookmark.on_bookmark` / `on_bookmarked` / `on_restore` / `on_restored` |
+| Skip an input | `session.bookmark.exclude.append(id)` |
+| Custom input component restores itself | `shiny.bookmark.restore_input(resolved_id, default)` when building its HTML |
+
+## Common mistakes
+
+- Core-mode UI defined as a plain object → nothing restores. The UI must be a
+  function accepting a `Request`.
+- `bookmark_store` left unset (default `"disable"`) → `session.bookmark()`
+  warns and does nothing.
+- Expecting `state.values` to restore into the UI automatically → they are
+  server-only; call `ui.update_*()` in `on_restore`.
+- `ui.input_bookmark_button()` inside a module (or two buttons in one app) →
+  the default id only auto-bookmarks at the top level. Give each button a
+  unique `id=`, exclude that id, and wire your own
+  `@reactive.event(input.<id>)` effect that calls `await session.bookmark()`.
+- Mutating `state.input` in `on_bookmark` to drop values → ignored on save;
+  use `session.bookmark.exclude` instead.
+- Module inputs missing from `state.values` checks → names are prefixed with
+  the module namespace, like inputs and outputs.

--- a/shiny/.agents/skills/bookmarking/SKILL.md
+++ b/shiny/.agents/skills/bookmarking/SKILL.md
@@ -9,10 +9,19 @@ description: Use when a Shiny for Python (py-shiny) app needs to save and restor
 
 Bookmarking snapshots an app's `input` values (plus optional custom values) and
 restores them later from a URL. Use it instead of manually encoding state into
-query strings or building a custom persistence layer. Two stores: `"url"`
-(state encoded in the query string — shareable, keep under ~65k characters) and
-`"server"` (state saved to disk, URL carries only an id). Prefer `"url"` when
-the state fits.
+query strings or building a custom persistence layer.
+
+## Store values
+
+`bookmark_store` (on `App(...)` or `app_opts(...)`) accepts three values:
+
+| Value | Where state lives | Trade-offs |
+|---|---|---|
+| `"url"` | Entirely in the URL query string | Shareable anywhere with zero server setup. Keep the serialized state under ~65k characters; file inputs cannot be serialized. |
+| `"server"` | On disk; the URL carries only a state id | Handles large state and file inputs (files are copied into the state directory). URLs only restore on a deployment that still has that directory — the hosting environment must persist it (see "Server-side storage location"). |
+| `"disable"` | Nowhere (the default) | Bookmarking is off: `session.bookmark()` warns and does nothing. |
+
+Prefer `"url"` whenever the state fits — it needs no storage management.
 
 ## Enable bookmarking
 


### PR DESCRIPTION
## Summary

Adds a second bundled Agent Skill, `bookmarking`, under `shiny/.agents/skills/` (following the layout and conventions in `.claude/references/agent-skills.md`, same shape as the `debugging` skill from #2341). The skill teaches coding agents to save and restore app state using the public bookmarking API instead of hand-rolling query-string parsing or a custom persistence layer.

It covers: enabling bookmarking in Express (`app_opts(bookmark_store=)`) and Core mode (UI as a `Request`-taking function + `App(..., bookmark_store=)`), triggering bookmarks (`ui.input_bookmark_button()` / `await session.bookmark()`), the `on_bookmark`/`on_bookmarked`/`on_restore`/`on_restored` lifecycle hooks, custom values via `state.values`, excluding inputs and custom serializers, server-side storage via `set_global_save_dir_fn`/`set_global_restore_dir_fn`, plus a quick-reference table and common mistakes (static Core UI, unset `bookmark_store`, bookmark buttons inside modules, module-namespaced value keys).

Every API claim was verified against the source (e.g. automatic password exclusion in `shiny/input_handler.py`, the default URL-modal fallback in `shiny/bookmark/_bookmark.py`, module-button guidance from `shiny/bookmark/_button.py`).

## Verification

- `pytest tests/pytest/test_packaging.py` passes (frontmatter contract + wheel package-data globs).
- Spec validator: `uvx --from skills-ref agentskills validate shiny/.agents/skills/bookmarking` → `Valid skill`.
- Before/after check per `.claude/references/agent-skills.md`: a fresh agent asked to make a Core-mode app survive refresh with a shareable URL was given the skill description; it chose to load the skill and its answer picked up py-shiny-specific facts from the body (UI-must-be-a-function requirement, `on_bookmarked` → `update_query_string(url)` pattern, the `"disable"` default warning, automatic password exclusion). The baseline (no-skill) agent knew the concept but produced rougher API details.