### PR TITLE
docs: Add api-examples for test mode (`export_test_values`, `snapshot_preprocess_input`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `@add_example()` (internal docs decorator) gained an `example_name=` parameter that looks up the example in the nearest `api-examples/` directory, and all `ex_dir=` call sites that pointed inside an `api-examples/` tree were migrated to it. `ex_dir=` remains only for examples outside the nearest `api-examples/` tree. This also fixed nine call sites that passed the example name positionally (where it was silently treated as `app_file=`), so their examples were missing from the generated docs. (#2328)
 
-* Added api-examples for `shiny.testmode.export_test_values()` and `shiny.testmode.snapshot_preprocess_input()`, demonstrating how to surface reactive values in the test-mode snapshot and how to scrub sensitive input values from it. (#2284)
+* Added api-examples for `shiny.testmode.export_test_values()`, `shiny.testmode.snapshot_preprocess_input()`, and `Renderer.snapshot_preprocess()`, demonstrating how to surface reactive values in the test-mode snapshot and how to scrub sensitive or nondeterministic input/output values from it. (#2284)
 
 * Playwright's `OutputDataFrame.set_filter()` controller now supports multi-column filters (#2093)
 * Add api-example for `ui.output_code` (#2093)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `@add_example()` (internal docs decorator) gained an `example_name=` parameter that looks up the example in the nearest `api-examples/` directory, and all `ex_dir=` call sites that pointed inside an `api-examples/` tree were migrated to it. `ex_dir=` remains only for examples outside the nearest `api-examples/` tree. This also fixed nine call sites that passed the example name positionally (where it was silently treated as `app_file=`), so their examples were missing from the generated docs. (#2328)
 
+* Added api-examples for `shiny.testmode.export_test_values()` and `shiny.testmode.snapshot_preprocess_input()`, demonstrating how to surface reactive values in the test-mode snapshot and how to scrub sensitive input values from it. (#2284)
+
 * Playwright's `OutputDataFrame.set_filter()` controller now supports multi-column filters (#2093)
 * Add api-example for `ui.output_code` (#2093)
 * Update controllers for `DownloadLink` and `DownloadButton` (#2093)

--- a/shiny/api-examples/export_test_values/app-core.py
+++ b/shiny/api-examples/export_test_values/app-core.py
@@ -21,10 +21,15 @@ def server(input: Inputs, output: Outputs, session: Session):
     # (`App(test_mode=True)` or `SHINY_TESTMODE=1`), so the call can be left in
     # production code. The `shiny.pytest` app fixtures enable test mode by
     # default, so an end-to-end test can assert on it with the
-    # `shiny.playwright.controller.AppTestValues` controller:
+    # `shiny.playwright.controller.AppTestValues` controller. The expected
+    # value may be an exact value or a function of the actual value:
+    #
+    #     def is_even(value):
+    #         return value % 2 == 0
     #
     #     app_values = controller.AppTestValues(page)
     #     app_values.expect_export("doubled", 40)
+    #     app_values.expect_export("doubled", is_even)
     export_test_values(doubled=doubled)
 
 

--- a/shiny/api-examples/export_test_values/app-core.py
+++ b/shiny/api-examples/export_test_values/app-core.py
@@ -1,0 +1,31 @@
+from shiny import App, Inputs, Outputs, Session, reactive, render, ui
+from shiny.testmode import export_test_values
+
+app_ui = ui.page_fluid(
+    ui.input_slider("n", "N", min=0, max=100, value=20),
+    ui.output_text_verbatim("txt"),
+)
+
+
+def server(input: Inputs, output: Outputs, session: Session):
+    @reactive.calc
+    def doubled() -> int:
+        return input.n() * 2
+
+    @render.text
+    def txt() -> str:
+        return f"n * 2 = {doubled()}"
+
+    # Surface the internal reactive value in the test-mode snapshot, under the
+    # snapshot's `export` block. Has no effect unless test mode is enabled
+    # (`App(test_mode=True)` or `SHINY_TESTMODE=1`), so the call can be left in
+    # production code. The `shiny.pytest` app fixtures enable test mode by
+    # default, so an end-to-end test can assert on it with the
+    # `shiny.playwright.controller.AppTestValues` controller:
+    #
+    #     app_values = controller.AppTestValues(page)
+    #     app_values.expect_export("doubled", 40)
+    export_test_values(doubled=doubled)
+
+
+app = App(app_ui, server)

--- a/shiny/api-examples/export_test_values/app-express.py
+++ b/shiny/api-examples/export_test_values/app-express.py
@@ -1,0 +1,27 @@
+from shiny import reactive, render
+from shiny.express import input, ui
+from shiny.testmode import export_test_values
+
+ui.input_slider("n", "N", min=0, max=100, value=20)
+
+
+@reactive.calc
+def doubled() -> int:
+    return input.n() * 2
+
+
+@render.text
+def txt() -> str:
+    return f"n * 2 = {doubled()}"
+
+
+# Surface the internal reactive value in the test-mode snapshot, under the
+# snapshot's `export` block. Has no effect unless test mode is enabled
+# (`SHINY_TESTMODE=1`), so the call can be left in production code. The
+# `shiny.pytest` app fixtures enable test mode by default, so an end-to-end
+# test can assert on it with the `shiny.playwright.controller.AppTestValues`
+# controller:
+#
+#     app_values = controller.AppTestValues(page)
+#     app_values.expect_export("doubled", 40)
+export_test_values(doubled=doubled)

--- a/shiny/api-examples/export_test_values/app-express.py
+++ b/shiny/api-examples/export_test_values/app-express.py
@@ -20,8 +20,13 @@ def txt() -> str:
 # (`SHINY_TESTMODE=1`), so the call can be left in production code. The
 # `shiny.pytest` app fixtures enable test mode by default, so an end-to-end
 # test can assert on it with the `shiny.playwright.controller.AppTestValues`
-# controller:
+# controller. The expected value may be an exact value or a function of the
+# actual value:
+#
+#     def is_even(value):
+#         return value % 2 == 0
 #
 #     app_values = controller.AppTestValues(page)
 #     app_values.expect_export("doubled", 40)
+#     app_values.expect_export("doubled", is_even)
 export_test_values(doubled=doubled)

--- a/shiny/api-examples/snapshot_preprocess/app-core.py
+++ b/shiny/api-examples/snapshot_preprocess/app-core.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+
+from shiny import App, Inputs, Outputs, Session, render, ui
+
+app_ui = ui.page_fluid(
+    ui.input_text("name", "Name", value="Shiny"),
+    ui.output_text_verbatim("greeting"),
+)
+
+
+def server(input: Inputs, output: Outputs, session: Session):
+    @render.text
+    def greeting() -> str:
+        return f"Hello, {input.name()}! It is {datetime.now().isoformat()}."
+
+    # Scrub the nondeterministic timestamp from test-mode snapshots so they
+    # diff cleanly; the value sent to the client is untouched. Has no effect
+    # unless test mode is enabled (`App(test_mode=True)` or
+    # `SHINY_TESTMODE=1`), so the call can be left in production code.
+    greeting.snapshot_preprocess(lambda value: value.split(" It is ")[0])
+
+
+app = App(app_ui, server)

--- a/shiny/api-examples/snapshot_preprocess/app-express.py
+++ b/shiny/api-examples/snapshot_preprocess/app-express.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+
+from shiny import render
+from shiny.express import input, ui
+
+ui.input_text("name", "Name", value="Shiny")
+
+
+@render.text
+def greeting() -> str:
+    return f"Hello, {input.name()}! It is {datetime.now().isoformat()}."
+
+
+# Scrub the nondeterministic timestamp from test-mode snapshots so they diff
+# cleanly; the value sent to the client is untouched. Has no effect unless
+# test mode is enabled (`SHINY_TESTMODE=1`), so the call can be left in
+# production code.
+greeting.snapshot_preprocess(lambda value: value.split(" It is ")[0])

--- a/shiny/api-examples/snapshot_preprocess_input/app-core.py
+++ b/shiny/api-examples/snapshot_preprocess_input/app-core.py
@@ -1,0 +1,22 @@
+from shiny import App, Inputs, Outputs, Session, render, ui
+from shiny.testmode import snapshot_preprocess_input
+
+app_ui = ui.page_fluid(
+    ui.input_text("secret", "Secret", value="hunter2"),
+    ui.output_text_verbatim("shout"),
+)
+
+
+def server(input: Inputs, output: Outputs, session: Session):
+    # Scrub the sensitive value from test-mode snapshots; the live input value
+    # is untouched. Has no effect unless test mode is enabled
+    # (`App(test_mode=True)` or `SHINY_TESTMODE=1`), so the call can be left in
+    # production code.
+    snapshot_preprocess_input("secret", lambda value: "<redacted>")
+
+    @render.text
+    def shout() -> str:
+        return str(input.secret()).upper()
+
+
+app = App(app_ui, server)

--- a/shiny/api-examples/snapshot_preprocess_input/app-express.py
+++ b/shiny/api-examples/snapshot_preprocess_input/app-express.py
@@ -1,0 +1,15 @@
+from shiny import render
+from shiny.express import input, ui
+from shiny.testmode import snapshot_preprocess_input
+
+ui.input_text("secret", "Secret", value="hunter2")
+
+# Scrub the sensitive value from test-mode snapshots; the live input value is
+# untouched. Has no effect unless test mode is enabled (`SHINY_TESTMODE=1`),
+# so the call can be left in production code.
+snapshot_preprocess_input("secret", lambda value: "<redacted>")
+
+
+@render.text
+def shout() -> str:
+    return str(input.secret()).upper()

--- a/shiny/playwright/controller/_app_test_values.py
+++ b/shiny/playwright/controller/_app_test_values.py
@@ -38,6 +38,12 @@ class AppTestValues:
     app_values.expect_export("upper", "ABC")
     snapshot = app_values.get()  # {"input": {...}, "output": {...}, "export": {...}}
     ```
+
+    See Also
+    --------
+    * :func:`~shiny.testmode.export_test_values`
+    * :func:`~shiny.testmode.snapshot_preprocess_input`
+    * :meth:`~shiny.render.renderer.Renderer.snapshot_preprocess`
     """
 
     page: Page

--- a/shiny/render/renderer/_renderer.py
+++ b/shiny/render/renderer/_renderer.py
@@ -229,6 +229,8 @@ class Renderer(Generic[IT]):
         See Also
         --------
         * :func:`~shiny.testmode.snapshot_preprocess_input`
+        * :func:`~shiny.testmode.export_test_values`
+        * :class:`~shiny.playwright.controller.AppTestValues`
         """
         self._snapshot_preprocess_fn = wrap_async(fn)
 

--- a/shiny/render/renderer/_renderer.py
+++ b/shiny/render/renderer/_renderer.py
@@ -202,6 +202,7 @@ class Renderer(Generic[IT]):
         """
         self.output_id = output_id
 
+    @add_example()
     def snapshot_preprocess(
         self,
         fn: Callable[[Any], Any] | Callable[[Any], Awaitable[Any]],
@@ -224,6 +225,10 @@ class Renderer(Generic[IT]):
         fn
             A function that takes the output value and returns the value to
             write to the test snapshot.
+
+        See Also
+        --------
+        * :func:`~shiny.testmode.snapshot_preprocess_input`
         """
         self._snapshot_preprocess_fn = wrap_async(fn)
 

--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -2107,6 +2107,13 @@ class Inputs:
         fn
             A function that takes the input value and returns the value to
             write to the test snapshot.
+
+        See Also
+        --------
+        * :func:`~shiny.testmode.snapshot_preprocess_input`
+        * :meth:`~shiny.render.renderer.Renderer.snapshot_preprocess`
+        * :func:`~shiny.testmode.export_test_values`
+        * :class:`~shiny.playwright.controller.AppTestValues`
         """
         self._snapshot_preprocessors[self._ns(id)] = wrap_async(fn)
 

--- a/shiny/testmode.py
+++ b/shiny/testmode.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Awaitable, Callable, cast
 
+from ._docstring import add_example
+
 # Import from `shiny.session._utils` directly (not the `shiny.session` package
 # __init__): `shiny.session._session` imports from this module, so importing the
 # package here would be circular.
@@ -16,6 +18,7 @@ __all__ = (
 )
 
 
+@add_example()
 def export_test_values(**kwargs: Callable[[], Any]) -> None:
     """
     Register named values to include in the test-mode snapshot.
@@ -49,30 +52,15 @@ def export_test_values(**kwargs: Callable[[], Any]) -> None:
     RuntimeError
         If there is no active session.
 
-    Examples
+    See Also
     --------
-    ```python
-    from shiny import App, Inputs, Outputs, Session, reactive, ui
-    from shiny.testmode import export_test_values
-
-    app_ui = ui.page_fluid(ui.input_slider("n", "n", 0, 100, 20))
-
-    def server(input: Inputs, output: Outputs, session: Session):
-        @reactive.calc
-        def doubled():
-            return input.n() * 2
-
-        # Surface an internal reactive value in the test-mode snapshot.
-        # No effect unless `SHINY_TESTMODE=1` is set.
-        export_test_values(doubled=doubled)
-
-    app = App(app_ui, server)
-    ```
+    * :func:`~shiny.testmode.snapshot_preprocess_input`
     """
     session = require_active_session(None)
     session._export_test_values(**kwargs)
 
 
+@add_example()
 def snapshot_preprocess_input(
     id: str,
     fn: Callable[[Any], Any] | Callable[[Any], Awaitable[Any]],
@@ -98,25 +86,10 @@ def snapshot_preprocess_input(
     RuntimeError
         If there is no active session.
 
-    Examples
-    --------
-    ```python
-    from shiny import App, Inputs, Outputs, Session, ui
-    from shiny.testmode import snapshot_preprocess_input
-
-    app_ui = ui.page_fluid(ui.input_text("secret", "Secret", value="hunter2"))
-
-    def server(input: Inputs, output: Outputs, session: Session):
-        # Scrub the value shown in test-mode snapshots; the live input value
-        # is untouched. No effect unless `SHINY_TESTMODE=1` is set.
-        snapshot_preprocess_input("secret", lambda value: "<redacted>")
-
-    app = App(app_ui, server)
-    ```
-
     See Also
     --------
-    * `shiny.render.renderer.Renderer.snapshot_preprocess`
+    * :meth:`~shiny.render.renderer.Renderer.snapshot_preprocess`
+    * :func:`~shiny.testmode.export_test_values`
     """
     session = require_active_session(None)
     session.input.set_snapshot_preprocess(id, fn)

--- a/shiny/testmode.py
+++ b/shiny/testmode.py
@@ -55,6 +55,8 @@ def export_test_values(**kwargs: Callable[[], Any]) -> None:
     See Also
     --------
     * :func:`~shiny.testmode.snapshot_preprocess_input`
+    * :meth:`~shiny.render.renderer.Renderer.snapshot_preprocess`
+    * :class:`~shiny.playwright.controller.AppTestValues`
     """
     session = require_active_session(None)
     session._export_test_values(**kwargs)
@@ -90,6 +92,7 @@ def snapshot_preprocess_input(
     --------
     * :meth:`~shiny.render.renderer.Renderer.snapshot_preprocess`
     * :func:`~shiny.testmode.export_test_values`
+    * :class:`~shiny.playwright.controller.AppTestValues`
     """
     session = require_active_session(None)
     session.input.set_snapshot_preprocess(id, fn)


### PR DESCRIPTION
Closes #2284

Follow-up to #2270 / #2282. Companion site-article issue: posit-dev/py-shiny-site#379.

## Summary

Test mode's public functions previously had only inline docstring `Examples` blocks, which is against the repo's documentation style (public API functions should use `@add_example()` with runnable example apps). This PR:

* Adds `shiny/api-examples/export_test_values/` (core + express variants): a small app that surfaces an internal `reactive.calc` in the test-mode snapshot's `export` block, with a comment showing how an end-to-end test reads it via `shiny.playwright.controller.AppTestValues` (`app_values.expect_export("doubled", 40)`).
* Adds `shiny/api-examples/snapshot_preprocess_input/` (core + express variants): scrubbing a sensitive input value from the snapshot while the live input value is untouched.
* Wires both onto `shiny/testmode.py` with `@add_example()`, replacing the inline `Examples` blocks with `See Also` cross-references (including `Renderer.snapshot_preprocess` for output-side preprocessing).
* Adds a CHANGELOG entry.

The full end-to-end test demonstration already exists at `tests/playwright/shiny/test_mode/`; the how-to article half of #2284 is tracked in posit-dev/py-shiny-site#379.

## Verification

* All four example apps load and serve: core variants imported as modules, express variants served with `shiny run` and returned HTTP 200.
* `SHINY_ADD_EXAMPLES=true` docstring injection verified for both functions (the mechanism `make quartodoc` uses).
* `pytest tests/pytest/test_test_mode.py tests/pytest/test_app_test_values.py` — 49 passed.
* black, isort, flake8, and pyright clean on the touched files.