### PR TITLE
feat(otel): Include opentelemetry-distro[otlp] in the otel extra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
+* `shiny[otel]` now includes `opentelemetry-distro[otlp]`, enabling standard zero-code auto-instrumentation: `opentelemetry-instrument shiny run app.py` works out of the box, with OTLP as the default exporter. (#2348)
+
 * `@add_example()` (internal docs decorator) gained an `example_name=` parameter that looks up the example in the nearest `api-examples/` directory, and all `ex_dir=` call sites that pointed inside an `api-examples/` tree were migrated to it. `ex_dir=` remains only for examples outside the nearest `api-examples/` tree. This also fixed nine call sites that passed the example name positionally (where it was silently treated as `app_file=`), so their examples were missing from the generated docs. (#2328)
 
 * Playwright's `OutputDataFrame.set_filter()` controller now supports multi-column filters (#2093)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,13 @@ dependencies = [
 
 [project.optional-dependencies]
 theme = ["libsass>=0.23.0", "brand_yml>=0.2.0"]
-otel = ["opentelemetry-sdk>=1.24.0"]
+otel = [
+    "opentelemetry-sdk>=1.24.0",
+    # Provides `opentelemetry-instrument` for zero-code auto-instrumentation;
+    # the [otlp] extra supplies its default (OTLP) exporter. 0.45b0 is the
+    # instrumentation release paired with SDK 1.24.0.
+    "opentelemetry-distro[otlp]>=0.45b0",
+]
 test = [
     "pytest>=6.2.4",
     "pytest-asyncio>=0.17.2",


### PR DESCRIPTION
Fixes #2274.

## What

Adds `opentelemetry-distro[otlp]>=0.45b0` to the `shiny[otel]` extra, so the standard OpenTelemetry zero-code auto-instrumentation workflow works out of the box:

```bash
pip install "shiny[otel]"
opentelemetry-instrument shiny run app.py
```

- `opentelemetry-distro` provides the `opentelemetry-instrument` wrapper and the distro configuration logic that initializes the SDK before app code runs.
- The `[otlp]` extra supplies the default (OTLP) exporter, and also makes it easy to switch between gRPC and HTTP transports.
- `0.45b0` is the instrumentation release paired with `opentelemetry-sdk` 1.24.0 (the existing floor), so the lowest-supported-versions CI job resolves cleanly (verified with `uv pip compile --python-version 3.10 --resolution lowest-direct --extra theme --extra otel`).

## Verification

Fresh venv with only this checkout's `shiny[otel]` installed:

- `opentelemetry-instrument --version` works, `opentelemetry.distro` and the OTLP gRPC span exporter import cleanly.
- `OTEL_SERVICE_NAME=smoke-test opentelemetry-instrument --traces_exporter console shiny run app.py`, then connecting a session, exports `session_start`, `reactive_update`, and `session_end` spans to the console with `service.name: smoke-test` — no code changes in the app.

## Companion

posit-dev/py-shiny-site#380 documents this workflow in the OpenTelemetry Quick Start; it targets the site's `rc-shiny-v1.7.0` staging branch, which merges to `main` when this change is released.
