### PR TITLE
fix(tests): Extend first-assertion timeout in flaky table test

### DIFF
--- a/tests/playwright/shiny/components/table/test_table.py
+++ b/tests/playwright/shiny/components/table/test_table.py
@@ -9,7 +9,9 @@ from shiny.run import ShinyAppProc
 def test_table_data_support(page: Page, local_app: ShinyAppProc) -> None:
     page.goto(local_app.url)
 
-    controller.OutputTable(page, "nw_table").expect_nrow(2)
+    # The first expectation after page load absorbs the initial render flush,
+    # which can exceed the default 5s timeout on a loaded CI runner.
+    controller.OutputTable(page, "nw_table").expect_nrow(2, timeout=30 * 1000)
     controller.OutputCode(page, "nw_df_type").expect_value(re.compile("narwhals"))
 
     controller.OutputTable(page, "pd_table").expect_nrow(2)


### PR DESCRIPTION
Fixes #2352

`test_table_data_support[chromium]` flaked on CI ([failed job](https://github.com/posit-dev/py-shiny/actions/runs/29024300268/job/86139648841)) with `nw_table` reporting 0 rows.

**Root cause:** the failing assertion is the *first* expectation after `page.goto()`, so it waits for the app's initial render flush. The app log from the failure shows a clean startup (uvicorn up, websocket accepted, no Python errors) — the output simply hadn't rendered within the default 5s expect timeout on a loaded runner (3 xdist workers each driving Chromium, running alongside heavy data_frame tests). The playwright-shiny suite has no in-job reruns, so one slow render fails the job.

**Fix:** give the first post-load assertion a 30s timeout, matching the pattern already used in e.g. `test_chat_message_stream_context.py` and `test_chat_update_user_input.py`. Subsequent assertions keep the default since everything arrives in the same render flush.

Verified locally: `pytest tests/playwright/shiny/components/table/test_table.py --browser chromium` passes.