### PR TITLE
feat: Accept predicate callables in AppTestValues expect methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added the `shiny.playwright.controller.AppTestValues` Playwright controller for reading a session's test-mode snapshot (`input`/`output`/`export`) in end-to-end tests. (#2269)
 
+* `AppTestValues` expect methods now accept predicates: pass any callable (e.g. `app_values.expect_input("n", is_integer)`) in place of an expected value, and the expectation retries until the predicate returns a truthy value. (#2357)
+
 * The test-mode snapshot endpoint honors query params `input`/`output`/`export` to select specific blocks (`=1` for a whole block, or a comma-separated list of keys). Unlike R, requesting no blocks returns all three rather than a `400`. (#2269)
 
 * Test-mode snapshot values can now be preprocessed before they are written to the snapshot, e.g. to scrub timestamps or temp paths: `input.set_snapshot_preprocess(id, fn)` (or `shiny.testmode.snapshot_preprocess_input()`) for inputs and `my_output.snapshot_preprocess(fn)` for outputs. Handlers may be synchronous or asynchronous. File inputs automatically scrub each file's `datapath` to its basename, matching Shiny for R. `export_test_values()` moved from `shiny.session` to the new `shiny.testmode` module. (#2282)

--- a/shiny/.agents/skills/debugging/SKILL.md
+++ b/shiny/.agents/skills/debugging/SKILL.md
@@ -94,6 +94,9 @@ app_values.expect_export("doubled", 40)
 snapshot = app_values.get()  # full {"input", "output", "export"} dict
 ```
 
+Expected values may also be predicates: any callable taking the actual value,
+retried until it returns truthy (e.g. `app_values.expect_input("n", is_integer)`).
+
 Requires the app loaded in the page and test mode on (a `RuntimeError` with a
 fix hint is raised otherwise).
 

--- a/shiny/.agents/skills/testing/SKILL.md
+++ b/shiny/.agents/skills/testing/SKILL.md
@@ -132,7 +132,12 @@ asserting server state:
 app_values = controller.AppTestValues(page)
 app_values.expect_input("n", 50)          # server-side: int, not "50"
 app_values.expect_export("doubled", 100)  # internal reactive, no DOM
+app_values.expect_input("n", is_integer)  # predicate: any callable(actual) -> bool
 ```
+
+Expected values may be predicates (callables taking the actual value, retried
+until truthy). Use named functions, not lambdas — the function's name appears
+in failure messages.
 
 See the `debugging` skill for the full test-mode snapshot API.
 

--- a/shiny/playwright/controller/_app_test_values.py
+++ b/shiny/playwright/controller/_app_test_values.py
@@ -12,6 +12,21 @@ __all__ = ("AppTestValues",)
 _DEFAULT_TIMEOUT_SECS = 30
 
 
+def _matches(actual: Any, expected: Any) -> bool:
+    # Snapshot values are JSON-decoded, so they can never be callables; a callable
+    # `expected` is unambiguously a predicate to apply to the actual value.
+    if callable(expected):
+        return bool(expected(actual))
+    return actual == expected
+
+
+def _mismatch_message(block: str, key: str, actual: Any, expected: Any) -> str:
+    if callable(expected):
+        name = getattr(expected, "__name__", repr(expected))
+        return f"{block}[{key!r}] == {actual!r}, which does not satisfy {name}"
+    return f"{block}[{key!r}] == {actual!r}, expected {expected!r}"
+
+
 class AppTestValues:
     """
     Read a Shiny session's test-mode snapshot of `input`, `output`, and `export`
@@ -37,6 +52,15 @@ class AppTestValues:
     app_values.expect_output("greeting", "Hello abc")
     app_values.expect_export("upper", "ABC")
     snapshot = app_values.get()  # {"input": {...}, "output": {...}, "export": {...}}
+
+
+    # Expected values may also be predicates (any callable taking the actual
+    # value); prefer named functions over lambdas for readable failure messages.
+    def is_integer(value):
+        return isinstance(value, int)
+
+
+    app_values.expect_input("n", is_integer)
     ```
     """
 
@@ -109,9 +133,9 @@ class AppTestValues:
                     f"Present keys: {sorted(section)}"
                 )
             actual = section[key]
-            if actual != value:
+            if not _matches(actual, value):
                 raise AssertionError(
-                    f"{block}[{key!r}] == {actual!r}, expected {value!r}"
+                    _mismatch_message(block, key, actual=actual, expected=value)
                 )
 
         _()
@@ -122,6 +146,11 @@ class AppTestValues:
         """
         Expect the input `key` to equal `value` (JSON-decoded), retrying until it
         matches or `timeout` seconds elapse.
+
+        `value` may instead be a predicate (a callable taking the actual value):
+        the expectation retries until it returns a truthy value. A predicate may
+        also raise `AssertionError` itself to provide a richer failure message;
+        any other exception it raises propagates immediately without retrying.
         """
         self._expect_value("input", key, value, timeout)
 
@@ -131,6 +160,8 @@ class AppTestValues:
         """
         Expect the output `key` to equal `value` (JSON-decoded), retrying until it
         matches or `timeout` seconds elapse.
+
+        `value` may instead be a predicate; see `expect_input` for the semantics.
         """
         self._expect_value("output", key, value, timeout)
 
@@ -140,6 +171,8 @@ class AppTestValues:
         """
         Expect the exported value `key` to equal `value` (JSON-decoded), retrying
         until it matches or `timeout` seconds elapse.
+
+        `value` may instead be a predicate; see `expect_input` for the semantics.
         """
         self._expect_value("export", key, value, timeout)
 
@@ -165,7 +198,9 @@ class AppTestValues:
             # This applies to BOTH modes: "exact" must verify values too, not
             # just that the key sets are equal.
             mismatched = sorted(
-                key for key in values if key in section and section[key] != values[key]
+                key
+                for key in values
+                if key in section and not _matches(section[key], values[key])
             )
 
             if not (missing or extra or mismatched):
@@ -177,7 +212,7 @@ class AppTestValues:
             if extra:
                 problems.append(f"unexpected keys {extra}")
             problems += [
-                f"{block}[{key!r}] == {section[key]!r}, expected {values[key]!r}"
+                _mismatch_message(block, key, actual=section[key], expected=values[key])
                 for key in mismatched
             ]
             raise AssertionError(f"{block} (match={match!r}): " + "; ".join(problems))
@@ -198,7 +233,9 @@ class AppTestValues:
         Parameters
         ----------
         values
-            A mapping of (namespaced) input ids to their expected values.
+            A mapping of (namespaced) input ids to their expected values. Any
+            expected value may instead be a predicate (a callable taking the
+            actual value); see `expect_input` for the semantics.
         match
             `"subset"` (the default) requires every key in `values` to be present
             and equal, ignoring any additional keys in the snapshot. `"exact"`
@@ -222,7 +259,9 @@ class AppTestValues:
         Parameters
         ----------
         values
-            A mapping of (namespaced) output ids to their expected values.
+            A mapping of (namespaced) output ids to their expected values. Any
+            expected value may instead be a predicate (a callable taking the
+            actual value); see `expect_input` for the semantics.
         match
             `"subset"` (the default) requires every key in `values` to be present
             and equal, ignoring any additional keys in the snapshot. `"exact"`
@@ -247,6 +286,8 @@ class AppTestValues:
         ----------
         values
             A mapping of (namespaced) exported names to their expected values.
+            Any expected value may instead be a predicate (a callable taking the
+            actual value); see `expect_input` for the semantics.
         match
             `"subset"` (the default) requires every key in `values` to be present
             and equal, ignoring any additional keys in the snapshot. `"exact"`

--- a/tests/playwright/shiny/test_mode/test_app_test_values.py
+++ b/tests/playwright/shiny/test_mode/test_app_test_values.py
@@ -37,6 +37,16 @@ def test_app_test_values(page: Page, local_app: ShinyAppProc) -> None:
     app_values.expect_output("double_txt", "doubled = 60")
     app_values.expect_export("doubled", 60)
 
+    # Predicates: any callable stands in for an expected value and is retried
+    # until it returns truthy; a failing predicate raises with its name.
+    def is_integer(value: object) -> bool:
+        return isinstance(value, int)
+
+    app_values.expect_export("doubled", is_integer)
+    app_values.expect_inputs({"n": is_integer, "name": "xyz"})
+    with pytest.raises(AssertionError, match="does not satisfy is_integer"):
+        app_values.expect_input("name", is_integer, timeout=1)
+
     # Whole-block expectations: subset (default) checks only the given keys,
     # ignoring other keys present in the block.
     app_values.expect_inputs({"name": "xyz"})

--- a/tests/pytest/test_app_test_values.py
+++ b/tests/pytest/test_app_test_values.py
@@ -24,7 +24,12 @@ def test_expect_values_rejects_invalid_match() -> None:
         av.expect_exports({"a": 1}, match=cast(Any, "SUBSET"))
 
 
-def _fake_page(*, ok: bool = True, json_error: bool = False) -> MagicMock:
+def _fake_page(
+    *,
+    ok: bool = True,
+    json_error: bool = False,
+    snapshot: dict[str, Any] | None = None,
+) -> MagicMock:
     page = MagicMock()
     # `wait_for_function` returns a JSHandle whose `.json_value()` is the URL.
     page.wait_for_function.return_value.json_value.return_value = (
@@ -36,9 +41,86 @@ def _fake_page(*, ok: bool = True, json_error: bool = False) -> MagicMock:
     if json_error:
         response.json.side_effect = ValueError("not json")
     else:
-        response.json.return_value = {"input": {}, "output": {}, "export": {}}
+        response.json.return_value = (
+            snapshot
+            if snapshot is not None
+            else {"input": {}, "output": {}, "export": {}}
+        )
     page.request.get.return_value = response
     return page
+
+
+_SNAPSHOT = {
+    "input": {"n": 42, "name": "abc"},
+    "output": {"greeting": "Hello abc"},
+    "export": {"upper": "ABC"},
+}
+
+
+def _is_integer(value: Any) -> bool:
+    return isinstance(value, int)
+
+
+def test_expect_value_accepts_passing_callable() -> None:
+    av = AppTestValues(_fake_page(snapshot=_SNAPSHOT))
+    av.expect_input("n", _is_integer)
+
+
+def test_expect_value_failing_callable_reports_name_and_actual() -> None:
+    av = AppTestValues(_fake_page(snapshot=_SNAPSHOT))
+    with pytest.raises(
+        AssertionError, match=r"'name'.*'abc'.*does not satisfy _is_integer"
+    ):
+        av.expect_input("name", _is_integer, timeout=0)
+
+
+def test_expect_value_callable_error_propagates_without_retry() -> None:
+    # A buggy predicate (raising a non-AssertionError) must fail fast, not be
+    # retried until the timeout.
+    calls = 0
+
+    def boom(value: Any) -> bool:
+        nonlocal calls
+        calls += 1
+        raise TypeError("bad predicate")
+
+    av = AppTestValues(_fake_page(snapshot=_SNAPSHOT))
+    with pytest.raises(TypeError, match="bad predicate"):
+        av.expect_input("n", boom, timeout=5)
+    assert calls == 1
+
+
+def test_expect_values_mixes_callables_and_literals() -> None:
+    av = AppTestValues(_fake_page(snapshot=_SNAPSHOT))
+    av.expect_inputs({"n": _is_integer, "name": "abc"})
+
+    with pytest.raises(
+        AssertionError, match=r"'name'.*'abc'.*does not satisfy _is_integer"
+    ):
+        av.expect_inputs({"n": 42, "name": _is_integer}, timeout=0)
+
+
+@pytest.mark.parametrize(
+    "method,method_many,key",
+    [
+        ("expect_input", "expect_inputs", "name"),
+        ("expect_output", "expect_outputs", "greeting"),
+        ("expect_export", "expect_exports", "upper"),
+    ],
+)
+def test_callables_supported_in_every_block(
+    method: str, method_many: str, key: str
+) -> None:
+    # All expect methods share the same matching helper; this guards against any
+    # one block's methods diverging from predicate support.
+    def is_string(value: Any) -> bool:
+        return isinstance(value, str)
+
+    av = AppTestValues(_fake_page(snapshot=_SNAPSHOT))
+    getattr(av, method)(key, is_string)
+    getattr(av, method_many)({key: is_string})
+    with pytest.raises(AssertionError, match="does not satisfy _is_integer"):
+        getattr(av, method)(key, _is_integer, timeout=0)
 
 
 def test_get_raises_when_response_not_ok() -> None:


### PR DESCRIPTION
Follow-up to #2269.

## Summary

`AppTestValues` expect methods now accept predicates: any callable passed as an expected value to `expect_input`/`expect_output`/`expect_export` (or inside the dicts for `expect_inputs`/`expect_outputs`/`expect_exports`) is applied to the actual snapshot value, and the expectation retries until the predicate returns a truthy value. Snapshot values are JSON-decoded, so a callable can never be a legitimate expected value — there is no ambiguity in treating callables as matchers. This also fixes a silent footgun: previously, passing a function compared the snapshot value against the function object itself and spun for the full timeout before failing with `expected <function ... at 0x...>`.

Key behaviors, each pinned by a unit test:

- Failure messages report the predicate's `__name__`: `input['name'] == 'abc', which does not satisfy is_integer` (named functions are recommended over lambdas for this reason).
- A predicate may raise `AssertionError` itself for a richer failure message; those retry normally (the existing `retry_with_timeout` only catches `AssertionError`).
- Any other exception from a predicate (i.e. a buggy predicate) propagates immediately without retrying — verified with a call counter.
- A parametrized test guards all three blocks (input/output/export) and both the singular and dict-based methods against future divergence, since all six methods share the same `_matches`/`_mismatch_message` helpers.

The bundled `testing` and `debugging` Agent Skills document this API, so they are updated in the same PR per CLAUDE.md.

## Verification

The live-app Playwright test exercises passing, failing, and dict-mixed predicates against a real browser session:

```python
def is_integer(value: object) -> bool:
    return isinstance(value, int)

app_values = controller.AppTestValues(page)
app_values.expect_export("doubled", is_integer)
app_values.expect_inputs({"n": is_integer, "name": "xyz"})
with pytest.raises(AssertionError, match="does not satisfy is_integer"):
    app_values.expect_input("name", is_integer, timeout=1)
```

Run locally:

```bash
pytest tests/pytest/test_app_test_values.py
pytest tests/playwright/shiny/test_mode/test_app_test_values.py
```