### PR TITLE
fix: render data frames with non-string column names (#2115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* `render.data_frame` now renders data frames whose column names are non-string (e.g. numeric) instead of failing with an obscure error. Columns are now accessed via `get_column()`, which avoids narwhals interpreting a numeric column name as positional row access. (#2115)
+
 * Fixed `--launch-browser` so it no longer depends on INFO-level Uvicorn startup logs. Browser launch now works when logs are disabled or `--log-level=warning` is used. (#569)
 
 * `ui.output_data_frame` will now consistently order the filtered columns in ascending column order. (#2093)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `@render.data_frame` now renders (and patches edits into) data frames whose column names are not strings, e.g. the integer labels pandas assigns by default. Previously a numeric column name was interpreted as a positional row lookup, and rendering failed with `AttributeError: 'DataFrame' object has no attribute 'dtype'`. (#2115)
 
+* `render.CellValue` now includes the non-string JSON scalars (`int`, `float`, `bool`, `None`) in addition to HTML-like content. A `@<data_frame>.set_patch_fn` that coerces the browser's string to its column's type — as the `data_frame_data_view` example does with `int()` and `float()` — was correct at runtime but reported as a type error. (#2115)
+
 * `value_box()`'s `id` docstring now documents `input.<id>_full_screen()` for observing the value box's full screen state, matching `card()`. It previously documented the wrong reactive-value syntax, `input.<id>()["full_screen"]`. (#2324)
 
 ### Other changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `ui.output_data_frame()` now consistently orders the filtered columns in ascending column order (#2093), and resetting a numeric range filter resets both values (#2093).
 
+* `@render.data_frame` now renders (and patches edits into) data frames whose column names are not strings, e.g. the integer labels pandas assigns by default. Previously a numeric column name was interpreted as a positional row lookup, and rendering failed with `AttributeError: 'DataFrame' object has no attribute 'dtype'`. (#2115)
+
 * `value_box()`'s `id` docstring now documents `input.<id>_full_screen()` for observing the value box's full screen state, matching `card()`. It previously documented the wrong reactive-value syntax, `input.<id>()["full_screen"]`. (#2324)
 
 ### Other changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `ui.output_data_frame()` now consistently orders the filtered columns in ascending column order (#2093), and resetting a numeric range filter resets both values (#2093).
 
-* `@render.data_frame` now renders (and patches edits into) data frames whose column names are not strings, e.g. the integer labels pandas assigns by default. Previously a numeric column name was interpreted as a positional row lookup, and rendering failed with `AttributeError: 'DataFrame' object has no attribute 'dtype'`. (#2115)
+* `@render.data_frame` now renders (and patches edits into) data frames whose column names are not strings, e.g. the integer labels pandas assigns by default. Previously a numeric column name was interpreted as a positional row lookup, and rendering failed with `AttributeError: 'DataFrame' object has no attribute 'dtype'`. (Thanks, @eeshsaxena!) (#2115)
 
 * `render.CellValue` now includes the non-string JSON scalars (`int`, `float`, `bool`, `None`) in addition to HTML-like content. A `@<data_frame>.set_patch_fn` that coerces the browser's string to its column's type — as the `data_frame_data_view` example does with `int()` and `float()` — was correct at runtime but reported as a type error. (#2115)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `@render.data_frame` now renders (and patches edits into) data frames whose column names are not strings, e.g. the integer labels pandas assigns by default. Previously a numeric column name was interpreted as a positional row lookup, and rendering failed with `AttributeError: 'DataFrame' object has no attribute 'dtype'`. (Thanks, @eeshsaxena!) (#2115)
 
-* `render.CellValue` now includes the non-string JSON scalars (`int`, `float`, `bool`, `None`) in addition to HTML-like content. A `@<data_frame>.set_patch_fn` that coerces the browser's string to its column's type — as the `data_frame_data_view` example does with `int()` and `float()` — was correct at runtime but reported as a type error. (#2115)
+* `render.CellValue` now includes the non-string JSON scalars (`int`, `float`, `bool`, `None`) in addition to HTML-like content. A `@<data_frame>.set_patch_fn` that coerces the browser's string to its column's type — as the `data_frame_data_view` example does with `int()` and `float()` — was correct at runtime but reported as a type error. (Thanks, @eeshsaxena!) (#2115)
 
 * `value_box()`'s `id` docstring now documents `input.<id>_full_screen()` for observing the value box's full screen state, matching `card()`. It previously documented the wrong reactive-value syntax, `input.<id>()["full_screen"]`. (#2324)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,3 +185,4 @@ CI then rejects.
 - **Playwright timing**: Use `.expect_*()` methods which auto-wait; avoid manual `sleep()`
 - **Asset updates**: After running `make upgrade-html-deps`, verify theme preset files were updated
 - **Stale bundled skills**: When changing a public API, grep `shiny/.agents/skills/` for it — bundled Agent Skills document public APIs and must be updated in the same PR
+- **Narwhals column access**: Never subscript a narwhals frame with a column *name* — use `.get_column(name)`. Subscripts are positional, and pandas allows non-string column names, so `data[0]` returns row `0`, not the column named `0`. Keep `[...]` for genuinely positional access (`data[rows, :]`, `data[:, col_indexes]`), resolving names to positions first

--- a/shiny/render/_data_frame_utils/_html.py
+++ b/shiny/render/_data_frame_utils/_html.py
@@ -19,9 +19,6 @@ def as_cell_html(processed_ui: RenderedDeps) -> CellHtml:
 JsonifiableScalarT = TypeVar("JsonifiableScalarT", bound=JsonifiableScalar)
 
 
-# Scalars are never HTML-like, so they are returned unchanged (`str` included, which is
-# why this overload must precede the `TagNode` one). The type var keeps "unchanged"
-# precise: a `str` in yields a `str` out, not the whole scalar union.
 @overload
 def maybe_as_cell_html(  # pyright: ignore[reportOverlappingOverload]
     x: JsonifiableScalarT, *, session: Session

--- a/shiny/render/_data_frame_utils/_html.py
+++ b/shiny/render/_data_frame_utils/_html.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, cast, overload
+from typing import TYPE_CHECKING, Literal, overload
 
 from htmltools import TagNode
 
 from ..._typing_extensions import TypeIs
-from ...types import Jsonifiable
-from ._types import CellHtml, JsonifiableScalar, Series
+from ._types import CellHtml, CellValue, JsonifiableScalar, Series
 
 if TYPE_CHECKING:
     from ...session import Session
@@ -27,14 +26,12 @@ def maybe_as_cell_html(  # pyright: ignore[reportOverlappingOverload]
 def maybe_as_cell_html(  # pyright: ignore[reportOverlappingOverload]
     x: TagNode, *, session: Session
 ) -> CellHtml: ...
-@overload
-def maybe_as_cell_html(x: Jsonifiable, *, session: Session) -> Jsonifiable: ...
 def maybe_as_cell_html(
-    x: Jsonifiable | TagNode, *, session: Session
-) -> Jsonifiable | CellHtml:
+    x: CellValue, *, session: Session
+) -> JsonifiableScalar | CellHtml:
     if ui_must_be_processed(x):
         return as_cell_html(session._process_ui(x))
-    return cast(Jsonifiable, x)
+    return x
 
 
 def series_contains_htmltoolslike(ser: Series) -> bool:

--- a/shiny/render/_data_frame_utils/_html.py
+++ b/shiny/render/_data_frame_utils/_html.py
@@ -6,7 +6,7 @@ from htmltools import TagNode
 
 from ..._typing_extensions import TypeIs
 from ...types import Jsonifiable
-from ._types import CellHtml, Series
+from ._types import CellHtml, JsonifiableScalar, Series
 
 if TYPE_CHECKING:
     from ...session import Session
@@ -17,10 +17,12 @@ def as_cell_html(processed_ui: RenderedDeps) -> CellHtml:
     return {"isShinyHtml": True, "obj": processed_ui}
 
 
+# Scalars are never HTML-like, so they are returned unchanged (`str` included, which is
+# why this overload must precede the `TagNode` one).
 @overload
 def maybe_as_cell_html(  # pyright: ignore[reportOverlappingOverload]
-    x: str, *, session: Session
-) -> Jsonifiable: ...
+    x: JsonifiableScalar, *, session: Session
+) -> JsonifiableScalar: ...
 @overload
 def maybe_as_cell_html(  # pyright: ignore[reportOverlappingOverload]
     x: TagNode, *, session: Session

--- a/shiny/render/_data_frame_utils/_html.py
+++ b/shiny/render/_data_frame_utils/_html.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, overload
+from typing import TYPE_CHECKING, Literal, TypeVar, overload
 
 from htmltools import TagNode
 
@@ -16,12 +16,16 @@ def as_cell_html(processed_ui: RenderedDeps) -> CellHtml:
     return {"isShinyHtml": True, "obj": processed_ui}
 
 
+JsonifiableScalarT = TypeVar("JsonifiableScalarT", bound=JsonifiableScalar)
+
+
 # Scalars are never HTML-like, so they are returned unchanged (`str` included, which is
-# why this overload must precede the `TagNode` one).
+# why this overload must precede the `TagNode` one). The type var keeps "unchanged"
+# precise: a `str` in yields a `str` out, not the whole scalar union.
 @overload
 def maybe_as_cell_html(  # pyright: ignore[reportOverlappingOverload]
-    x: JsonifiableScalar, *, session: Session
-) -> JsonifiableScalar: ...
+    x: JsonifiableScalarT, *, session: Session
+) -> JsonifiableScalarT: ...
 @overload
 def maybe_as_cell_html(  # pyright: ignore[reportOverlappingOverload]
     x: TagNode, *, session: Session

--- a/shiny/render/_data_frame_utils/_tbl_data.py
+++ b/shiny/render/_data_frame_utils/_tbl_data.py
@@ -169,7 +169,7 @@ def apply_frame_patches(
 
     # Upgrade the Scatter info to new column Series objects
     scatter_columns = [
-        nw_data[column_name].scatter(
+        nw_data.get_column(column_name).scatter(
             scatter_values["row_indexes"], scatter_values["values"]
         )
         for column_name, scatter_values in cell_patches_by_column.items()
@@ -237,7 +237,12 @@ def serialize_frame(into_data: IntoDataFrame) -> FrameJson:
 
     data = as_data_frame(into_data)
 
-    type_hints = [serialize_dtype(data[col_name]) for col_name in data.columns]
+    # Use `get_column` rather than `data[col_name]`: for a numeric column name
+    # (e.g. `0`) the latter is interpreted as row/positional access and returns a
+    # row frame instead of the column, which then fails downstream.
+    type_hints = [
+        serialize_dtype(data.get_column(col_name)) for col_name in data.columns
+    ]
 
     # TODO-future-barret; Swich serialization to "by column", rather than "by row"
     # * This would allow for a single column to be serialized in a single operation

--- a/shiny/render/_data_frame_utils/_tbl_data.py
+++ b/shiny/render/_data_frame_utils/_tbl_data.py
@@ -150,9 +150,11 @@ def apply_frame_patches(
     # This allows for a single column to be updated in a single operation (rather than multiple updates to the same column)
     #
     # In; patches: List[Dict[row_index: int, column_index: int, value: Any]]
-    # Out; cell_patches_by_column: Dict[column_name: str, List[Dict[row_index: int, value: Any]]]
+    # Out; cell_patches_by_column: Dict[column_name: Any, List[Dict[row_index: int, value: Any]]]
     #
-    cell_patches_by_column: dict[str, ScatterValues] = {}
+    # Column names are not necessarily strings (e.g. pandas' default integer labels),
+    # so the keys are typed as `Any`.
+    cell_patches_by_column: dict[Any, ScatterValues] = {}
     for cell_patch in patches:
         column_name = nw_data.columns[cell_patch["column_index"]]
         if column_name not in cell_patches_by_column:

--- a/shiny/render/_data_frame_utils/_tbl_data.py
+++ b/shiny/render/_data_frame_utils/_tbl_data.py
@@ -152,8 +152,11 @@ def apply_frame_patches(
     # In; patches: List[Dict[row_index: int, column_index: int, value: Any]]
     # Out; cell_patches_by_column: Dict[column_name: Any, List[Dict[row_index: int, value: Any]]]
     #
-    # Column names are not necessarily strings (e.g. pandas' default integer labels),
-    # so the keys are typed as `Any`.
+    # Narwhals types `get_column(name)`'s `name` as `str`, but its docs note that pandas
+    # does allow non-string column names and that they work when passed to it, as there
+    # is no ambiguity:
+    # https://narwhals-dev.github.io/narwhals/api-reference/dataframe/#narwhals.dataframe.DataFrame.get_column
+    # This dict is not exported, so its key type is relaxed to match.
     cell_patches_by_column: dict[Any, ScatterValues] = {}
     for cell_patch in patches:
         column_name = nw_data.columns[cell_patch["column_index"]]
@@ -239,9 +242,6 @@ def serialize_frame(into_data: IntoDataFrame) -> FrameJson:
 
     data = as_data_frame(into_data)
 
-    # Use `get_column` rather than `data[col_name]`: for a numeric column name
-    # (e.g. `0`) the latter is interpreted as row/positional access and returns a
-    # row frame instead of the column, which then fails downstream.
     type_hints = [
         serialize_dtype(data.get_column(col_name)) for col_name in data.columns
     ]
@@ -331,17 +331,23 @@ def subset_frame(
             return data[rows, :]  # pyrefly: ignore[bad-return]
     else:
         # `cols` is not None
-        col_names = [data.columns[col] if isinstance(col, int) else col for col in cols]
+        # Resolve each column to its position rather than its name. Narwhals reads a
+        # list of ints in the column slot as positions, so a non-string column name
+        # (e.g. pandas' integer labels) would be taken as a position instead: selecting
+        # the wrong columns, or raising `IndexError` when it is out of bounds.
+        col_indexes = [
+            col if isinstance(col, int) else data.columns.index(col) for col in cols
+        ]
 
         # Return a DataFrame with no rows or columns
         # If there are no columns, there are no Series objects to support any rows
-        if len(col_names) == 0:
+        if len(col_indexes) == 0:
             return data[[], []]  # pyrefly: ignore[bad-return]
 
         if rows is None:
-            return data[:, col_names]  # pyrefly: ignore[bad-return]
+            return data[:, col_indexes]  # pyrefly: ignore[bad-return]
         else:
-            return data[rows, col_names]  # pyrefly: ignore[bad-return]
+            return data[rows, col_indexes]  # pyrefly: ignore[bad-return]
 
 
 class ScatterValues(TypedDict):

--- a/shiny/render/_data_frame_utils/_types.py
+++ b/shiny/render/_data_frame_utils/_types.py
@@ -246,7 +246,17 @@ BrowserStyleInfo = BrowserStyleInfoBody
 # Cell patches ----------------------------------------------------------
 
 # CellValue = str | TagList | Tag | HTML
-CellValue = TagNode
+#
+# A cell's value is either HTML-like content (`TagNode`, which includes `str`) or a
+# non-string scalar. The scalars are limited to the JSON-native types, as patch values
+# are sent back to the browser with `json.dumps()`; e.g. a `datetime` would serialize
+# the data frame fine but raise when the patch is sent to the client.
+#
+# Non-string scalars matter when patching a non-string column: the browser always sends
+# the edited value as a `str`, and writing that `str` into (say) a numeric column can
+# fail (pandas raises `LossySetitemError`), so `@<data_frame>.set_patch_fn` is expected
+# to coerce the value to the column's type before it is applied.
+CellValue = Union[TagNode, int, float, bool, None]
 
 
 class CellPatch(TypedDict):
@@ -258,7 +268,9 @@ class CellPatch(TypedDict):
 class CellPatchProcessed(TypedDict):
     row_index: int
     column_index: int
-    value: str | CellHtml
+    # HTML-like values are upgraded to `CellHtml`; everything else (including non-string
+    # scalars) is passed through as-is to be sent to the client.
+    value: Jsonifiable | CellHtml
     # prev_value: CellValue
 
 

--- a/shiny/render/_data_frame_utils/_types.py
+++ b/shiny/render/_data_frame_utils/_types.py
@@ -256,7 +256,11 @@ BrowserStyleInfo = BrowserStyleInfoBody
 # the edited value as a `str`, and writing that `str` into (say) a numeric column can
 # fail (pandas raises `LossySetitemError`), so `@<data_frame>.set_patch_fn` is expected
 # to coerce the value to the column's type before it is applied.
-CellValue = Union[TagNode, int, float, bool, None]
+#
+# `Jsonifiable`'s containers (list, tuple, dict) are deliberately excluded: a cell holds
+# a single value, not a collection.
+JsonifiableScalar = Union[str, int, float, bool, None]
+CellValue = Union[TagNode, JsonifiableScalar]
 
 
 class CellPatch(TypedDict):
@@ -268,9 +272,9 @@ class CellPatch(TypedDict):
 class CellPatchProcessed(TypedDict):
     row_index: int
     column_index: int
-    # HTML-like values are upgraded to `CellHtml`; everything else (including non-string
-    # scalars) is passed through as-is to be sent to the client.
-    value: Jsonifiable | CellHtml
+    # HTML-like values are upgraded to `CellHtml`; the scalars in `CellValue` are passed
+    # through as-is to be sent to the client.
+    value: JsonifiableScalar | CellHtml
     # prev_value: CellValue
 
 

--- a/tests/pytest/test_render_data_frame_tbl_data.py
+++ b/tests/pytest/test_render_data_frame_tbl_data.py
@@ -313,6 +313,20 @@ def test_serialize_frame(df_f: IntoDataFrame):
     }
 
 
+def test_serialize_frame_numeric_column_names():
+    # Regression test: numeric column names (e.g. `0`, `1`) previously raised in
+    # serialize_frame because `data[col_name]` was interpreted as positional/row
+    # access on the narwhals frame instead of column access.
+    df = pd.DataFrame([["a", 1], ["b", 2], ["c", 3]], columns=[0, 1])
+
+    with session_context(test_session):
+        res = serialize_frame(as_data_frame(df))
+
+    assert res["columns"] == [0, 1]
+    assert [hint["type"] for hint in res["typeHints"]] == ["string", "numeric"]
+    assert res["data"] == [["a", 1], ["b", 2], ["c", 3]]
+
+
 def test_subset_frame(df_f: IntoDataFrame):
     # TODO: this assumes subset_frame doesn't reset index
     res = subset_frame(as_data_frame(df_f), rows=[1], cols=["chr", "num"])
@@ -366,7 +380,6 @@ def test_dtype_coverage():
     errs: list[str] = []
 
     for dtype_name in dtype_names:
-
         # Skip known types or imports that are not dtypes
         if dtype_name.endswith("Type"):
             # "DType",

--- a/tests/pytest/test_render_data_frame_tbl_data.py
+++ b/tests/pytest/test_render_data_frame_tbl_data.py
@@ -391,6 +391,23 @@ def test_subset_frame(df_f: IntoDataFrame):
     assert_frame_equal2(res, dst)
 
 
+def test_subset_frame_numeric_column_names():
+    # `cols` entries are positions when `int`, so they must not be handed to narwhals as
+    # column names: with non-string column names narwhals reads the name as a position,
+    # selecting the wrong column or raising `IndexError` when it is out of bounds.
+    df = as_data_frame(pd.DataFrame([["a", 1], ["b", 2]], columns=[10, 20]))
+
+    res = subset_frame(df, cols=[0])
+
+    assert res.columns == [10]
+    assert res.rows(named=False) == [("a",), ("b",)]
+
+    res = subset_frame(df, rows=[1], cols=[1])
+
+    assert res.columns == [20]
+    assert res.rows(named=False) == [(2,)]
+
+
 def test_subset_frame_rows_single(small_df_f: IntoDataFrame):
     res = subset_frame(as_data_frame(small_df_f), rows=[1])
 

--- a/tests/pytest/test_render_data_frame_tbl_data.py
+++ b/tests/pytest/test_render_data_frame_tbl_data.py
@@ -15,6 +15,7 @@ import pytest
 
 from shiny._namespaces import Root
 from shiny.module import ResolvedId
+from shiny.render._data_frame_utils._html import maybe_as_cell_html
 from shiny.render._data_frame_utils._tbl_data import (
     apply_frame_patches,
     as_data_frame,
@@ -367,6 +368,19 @@ def test_apply_frame_patches_non_string_values():
     res = apply_frame_patches(df, patches)
 
     assert res.rows(named=False) == [(30, 1.5, False), (2, 3.5, False)]
+
+
+def test_maybe_as_cell_html_passes_scalars_through():
+    # `CellPatchProcessed["value"]` is `JsonifiableScalar | CellHtml`, so every
+    # `CellValue` must land in one of those two shapes: scalars unchanged (`str`
+    # included), HTML-like content upgraded to a `CellHtml` dict.
+    for scalar in ("a", 1, 1.5, True, None):
+        assert maybe_as_cell_html(scalar, session=test_session) is scalar
+
+    res = maybe_as_cell_html(HTML("<b>bold</b>"), session=test_session)
+
+    assert res["isShinyHtml"] is True
+    assert res["obj"]["html"] == "<b>bold</b>"
 
 
 def test_subset_frame(df_f: IntoDataFrame):

--- a/tests/pytest/test_render_data_frame_tbl_data.py
+++ b/tests/pytest/test_render_data_frame_tbl_data.py
@@ -16,12 +16,13 @@ import pytest
 from shiny._namespaces import Root
 from shiny.module import ResolvedId
 from shiny.render._data_frame_utils._tbl_data import (
+    apply_frame_patches,
     as_data_frame,
     serialize_dtype,
     serialize_frame,
     subset_frame,
 )
-from shiny.render._data_frame_utils._types import IntoDataFrame
+from shiny.render._data_frame_utils._types import CellPatch, IntoDataFrame
 from shiny.session import Session, session_context
 from shiny.session._session import RenderedDeps
 from shiny.ui import HTML, TagChild, TagList, h1, span
@@ -327,6 +328,28 @@ def test_serialize_frame_numeric_column_names():
     assert res["data"] == [["a", 1], ["b", 2], ["c", 3]]
 
 
+def test_apply_frame_patches_numeric_column_names():
+    # Regression test: patching a cell of a frame with numeric column names previously
+    # raised in apply_frame_patches because `nw_data[column_name]` was interpreted as
+    # positional/row access, returning a frame (which has no `.scatter()` method).
+    df = as_data_frame(
+        pd.DataFrame([["a", "x"], ["b", "y"], ["c", "z"]], columns=[0, 1])
+    )
+
+    # Patch two different columns so the patches are grouped by column name
+    patches: list[CellPatch] = [
+        {"row_index": 0, "column_index": 0, "value": "A"},
+        {"row_index": 2, "column_index": 1, "value": "Z"},
+    ]
+
+    res = apply_frame_patches(df, patches)
+
+    assert res.columns == [0, 1]
+    assert res.rows(named=False) == [("A", "x"), ("b", "y"), ("c", "Z")]
+    # The original frame is cloned, not patched in place
+    assert df.rows(named=False) == [("a", "x"), ("b", "y"), ("c", "z")]
+
+
 def test_subset_frame(df_f: IntoDataFrame):
     # TODO: this assumes subset_frame doesn't reset index
     res = subset_frame(as_data_frame(df_f), rows=[1], cols=["chr", "num"])
@@ -380,6 +403,7 @@ def test_dtype_coverage():
     errs: list[str] = []
 
     for dtype_name in dtype_names:
+
         # Skip known types or imports that are not dtypes
         if dtype_name.endswith("Type"):
             # "DType",

--- a/tests/pytest/test_render_data_frame_tbl_data.py
+++ b/tests/pytest/test_render_data_frame_tbl_data.py
@@ -350,6 +350,25 @@ def test_apply_frame_patches_numeric_column_names():
     assert df.rows(named=False) == [("a", "x"), ("b", "y"), ("c", "z")]
 
 
+def test_apply_frame_patches_non_string_values():
+    # `CellValue` allows non-string scalars so that `@<data_frame>.set_patch_fn` can
+    # coerce the browser's string to the column's type. Writing a `str` into these
+    # columns raises `pandas.errors.LossySetitemError`, so the scalar types must work.
+    df = as_data_frame(
+        pd.DataFrame({"num": [1, 2], "dbl": [1.5, 2.5], "bool": [True, False]})
+    )
+
+    patches: list[CellPatch] = [
+        {"row_index": 0, "column_index": 0, "value": 30},
+        {"row_index": 1, "column_index": 1, "value": 3.5},
+        {"row_index": 0, "column_index": 2, "value": False},
+    ]
+
+    res = apply_frame_patches(df, patches)
+
+    assert res.rows(named=False) == [(30, 1.5, False), (2, 3.5, False)]
+
+
 def test_subset_frame(df_f: IntoDataFrame):
     # TODO: this assumes subset_frame doesn't reset index
     res = subset_frame(as_data_frame(df_f), rows=[1], cols=["chr", "num"])


### PR DESCRIPTION
Fixes #2115.

## Problem

Rendering a `render.DataGrid` / `render.data_frame` from a `DataFrame` whose column names are non-string (e.g. numeric) fails with an obscure `AttributeError`:

```python
from shiny.express import render
import pandas as pd

@render.data_frame
def table():
    df = pd.DataFrame([["a", 1], ["b", 2], ["c", 3], ["d", 4]], columns=[0, 1])
    return render.DataGrid(df)
# AttributeError: 'DataFrame' object has no attribute 'dtype'
```

## Cause

In `shiny/render/_data_frame_utils/_tbl_data.py`, columns were accessed with `data[col_name]` on the narwhals frame:

```python
type_hints = [serialize_dtype(data[col_name]) for col_name in data.columns]
```

For a numeric column name, narwhals interprets `data[0]` as positional/row access and returns a **row frame** rather than the column, so `serialize_dtype` receives a `DataFrame` instead of a `Series`. Thanks to @… (the issue reporter) for the precise diagnosis.

The same ambiguous access exists in the cell-patch scatter path (`apply_frame_patches`), where the column name comes from `nw_data.columns[...]` and can likewise be numeric:

```python
nw_data[column_name].scatter(...)
```

## Fix

Use `data.get_column(col_name)` / `nw_data.get_column(column_name)` in both places, which unambiguously accesses a column by name.

```python
>>> serialize_frame(as_data_frame(pd.DataFrame([["a", 1], ["b", 2]], columns=[0, 1])))
# now returns columns=[0, 1], typeHints=["string", "numeric"], data=[["a", 1], ["b", 2]]
```

## Testing

- Added `test_serialize_frame_numeric_column_names` in `tests/pytest/test_render_data_frame_tbl_data.py`. It fails on `main` with the `AttributeError` and passes with this change.
- Full `test_render_data_frame_tbl_data.py` passes (42 tests); ruff check + format clean.
- Added a CHANGELOG entry under Bug fixes.

An AI assistant helped implement this fix (following the root-cause and suggested approach from the issue); I reviewed the change and ran the tests locally.
