### PR TITLE
ci: replace dogfood deploy tests with local Connect

### DIFF
--- a/.github/workflows/deploy-tests.yaml
+++ b/.github/workflows/deploy-tests.yaml
@@ -105,9 +105,9 @@ jobs:
         env:
           UV_PYTHON: "3.13"
           DEPLOY_APPS: "true"
-          DEPLOY_SHINYAPPS_NAME: "${{ matrix.config.test_shinyappsio && secrets.DEPLOY_SHINYAPPS_NAME }}"
-          DEPLOY_SHINYAPPS_TOKEN: "${{ matrix.config.test_shinyappsio && secrets.DEPLOY_SHINYAPPS_TOKEN }}"
-          DEPLOY_SHINYAPPS_SECRET: "${{ matrix.config.test_shinyappsio && secrets.DEPLOY_SHINYAPPS_SECRET }}"
+          DEPLOY_SHINYAPPS_NAME: "${{ matrix.config.test_shinyappsio && secrets.DEPLOY_SHINYAPPS_NAME || '' }}"
+          DEPLOY_SHINYAPPS_TOKEN: "${{ matrix.config.test_shinyappsio && secrets.DEPLOY_SHINYAPPS_TOKEN || '' }}"
+          DEPLOY_SHINYAPPS_SECRET: "${{ matrix.config.test_shinyappsio && secrets.DEPLOY_SHINYAPPS_SECRET || '' }}"
           EXPRESS_PAGE_SIDEBAR_NAME: "${{ matrix.config.app_name }}"
           DEPLOY_GITHUB_REQUIREMENTS_TXT: "${{ !matrix.config.pypi_shiny }}"
         timeout-minutes: 30

--- a/.github/workflows/deploy-tests.yaml
+++ b/.github/workflows/deploy-tests.yaml
@@ -103,6 +103,8 @@ jobs:
       - name: Start local Connect
         id: connect
         uses: posit-dev/with-connect@main
+        env:
+          UV_PYTHON: "3.13"
         with:
           license: "${{ secrets.CONNECT_LICENSE_FILE }}"
 
@@ -125,6 +127,8 @@ jobs:
       - name: Stop local Connect
         if: ${{ always() && steps.connect.outputs.CONTAINER_ID != '' }}
         uses: posit-dev/with-connect@main
+        env:
+          UV_PYTHON: "3.13"
         with:
           license: "${{ secrets.CONNECT_LICENSE_FILE }}"
           stop: "${{ steps.connect.outputs.CONTAINER_ID }}"

--- a/.github/workflows/deploy-tests.yaml
+++ b/.github/workflows/deploy-tests.yaml
@@ -24,31 +24,16 @@ jobs:
         python-version: ["3.10"]
         os: [ubuntu-latest]
         config:
-          # Released server, shiny, and rsconnect
-          # TEMPORARILY DISABLED: Connect server missing uv binary at /opt/rstudio-connect/mnt/python-environments/_bootstrap/3.10.15/uv/bin/uv
-          # TODO: Re-enable once the Connect server is fixed
-          # - name: "pypi-shiny-rsconnect-connect"
-          #   released_connect_server: true
-          #   pypi_shiny: true
-          #   pypi_rsconnect: true
-          #   base_test_dir: "./tests/playwright/deploys/express-page_sidebar"
-          #   app_name: "pypi-shiny-rsconnect"
-          #   test_shinyappsio: false
-
-          # Released shiny and rsconnect
-          # Dev server
-          - name: "pypi-shiny-rsconnect-dogfood"
-            released_connect_server: false
+          # Released Connect, shiny, and rsconnect
+          - name: "pypi-shiny-rsconnect-local-connect"
             pypi_shiny: true
             pypi_rsconnect: true
             base_test_dir: "./tests/playwright/deploys/express-page_sidebar"
             app_name: "pypi-shiny-rsconnect"
             test_shinyappsio: false
 
-          # Released shiny
-          # Dogfood server and rsconnect
-          - name: "pypi-shiny-dev-rsconnect-dogfood"
-            released_connect_server: false
+          # Released Connect and shiny; development rsconnect
+          - name: "pypi-shiny-dev-rsconnect-local-connect"
             pypi_shiny: true
             pypi_rsconnect: false
             base_test_dir: "./tests/playwright/deploys/express-page_sidebar"
@@ -56,9 +41,8 @@ jobs:
             test_shinyappsio: false
 
           # GitHub shiny v1.0.0 - test if github packages can be installed
-          # Dogfood server and rsconnect
-          - name: "github-shiny-dev-rsconnect-dogfood"
-            released_connect_server: false
+          # Released Connect; development rsconnect
+          - name: "github-shiny-dev-rsconnect-local-connect"
             github_shiny: true
             pypi_shiny: false
             pypi_rsconnect: false
@@ -66,9 +50,8 @@ jobs:
             app_name: "pypi-shiny-dev-rsconnect"
             test_shinyappsio: false
 
-          # Dev server, shiny, and rsconnect
-          - name: "dev-shiny-rsconnect-dogfood"
-            released_connect_server: false
+          # Released Connect; development shiny and rsconnect
+          - name: "dev-shiny-rsconnect-local-connect"
             pypi_shiny: false
             pypi_rsconnect: false
             base_test_dir: "./tests/playwright/deploys"
@@ -117,11 +100,17 @@ jobs:
         run: |
           make playwright-deploys TEST_FILE="${{ matrix.config.base_test_dir }} -vv"
 
+      - name: Start local Connect
+        id: connect
+        uses: posit-dev/with-connect@main
+        with:
+          license: "${{ secrets.CONNECT_LICENSE_FILE }}"
+
       - name: Deploy apps and run tests (on `push` or `deploy**` branches)
         env:
           DEPLOY_APPS: "true"
-          DEPLOY_CONNECT_SERVER_URL: "${{ (matrix.config.released_connect_server && 'https://connect.posit.it/') || 'https://dogfood.team.pct.posit.it/' }}"
-          DEPLOY_CONNECT_SERVER_API_KEY: "${{ (matrix.config.released_connect_server && secrets.DEPLOY_CONNECT_POSIT_SERVER_API_KEY) || secrets.DEPLOY_CONNECT_SERVER_API_KEY }}"
+          DEPLOY_CONNECT_SERVER_URL: "${{ steps.connect.outputs.CONNECT_SERVER }}"
+          DEPLOY_CONNECT_SERVER_API_KEY: "${{ steps.connect.outputs.CONNECT_API_KEY }}"
           DEPLOY_SHINYAPPS_NAME: "${{ matrix.config.test_shinyappsio && secrets.DEPLOY_SHINYAPPS_NAME }}"
           DEPLOY_SHINYAPPS_TOKEN: "${{ matrix.config.test_shinyappsio && secrets.DEPLOY_SHINYAPPS_TOKEN }}"
           DEPLOY_SHINYAPPS_SECRET: "${{ matrix.config.test_shinyappsio && secrets.DEPLOY_SHINYAPPS_SECRET }}"
@@ -132,6 +121,13 @@ jobs:
         # we can have many local processes waiting for deployment to finish
         run: |
           make playwright-deploys TEST_FILE="${{ matrix.config.base_test_dir }} -vv --numprocesses 12"
+
+      - name: Stop local Connect
+        if: ${{ always() && steps.connect.outputs.CONTAINER_ID != '' }}
+        uses: posit-dev/with-connect@main
+        with:
+          license: "${{ secrets.CONNECT_LICENSE_FILE }}"
+          stop: "${{ steps.connect.outputs.CONTAINER_ID }}"
 
       # - uses: actions/upload-artifact@v4
       #   if: failure()

--- a/.github/workflows/deploy-tests.yaml
+++ b/.github/workflows/deploy-tests.yaml
@@ -20,8 +20,8 @@ jobs:
       packages: write
     strategy:
       matrix:
-        # Matches deploy server python version
-        python-version: ["3.10"]
+        # Matches the Python version available in the Connect image
+        python-version: ["3.14"]
         os: [ubuntu-latest]
         config:
           # Released Connect, shiny, and rsconnect
@@ -100,19 +100,11 @@ jobs:
         run: |
           make playwright-deploys TEST_FILE="${{ matrix.config.base_test_dir }} -vv"
 
-      - name: Start local Connect
-        id: connect
+      - name: Deploy apps and run tests with local Connect
         uses: posit-dev/with-connect@main
         env:
           UV_PYTHON: "3.13"
-        with:
-          license: "${{ secrets.CONNECT_LICENSE_FILE }}"
-
-      - name: Deploy apps and run tests (on `push` or `deploy**` branches)
-        env:
           DEPLOY_APPS: "true"
-          DEPLOY_CONNECT_SERVER_URL: "${{ steps.connect.outputs.CONNECT_SERVER }}"
-          DEPLOY_CONNECT_SERVER_API_KEY: "${{ steps.connect.outputs.CONNECT_API_KEY }}"
           DEPLOY_SHINYAPPS_NAME: "${{ matrix.config.test_shinyappsio && secrets.DEPLOY_SHINYAPPS_NAME }}"
           DEPLOY_SHINYAPPS_TOKEN: "${{ matrix.config.test_shinyappsio && secrets.DEPLOY_SHINYAPPS_TOKEN }}"
           DEPLOY_SHINYAPPS_SECRET: "${{ matrix.config.test_shinyappsio && secrets.DEPLOY_SHINYAPPS_SECRET }}"
@@ -121,17 +113,10 @@ jobs:
         timeout-minutes: 30
         # Given we are waiting for external servers to finish,
         # we can have many local processes waiting for deployment to finish
-        run: |
-          make playwright-deploys TEST_FILE="${{ matrix.config.base_test_dir }} -vv --numprocesses 12"
-
-      - name: Stop local Connect
-        if: ${{ always() && steps.connect.outputs.CONTAINER_ID != '' }}
-        uses: posit-dev/with-connect@main
-        env:
-          UV_PYTHON: "3.13"
         with:
           license: "${{ secrets.CONNECT_LICENSE_FILE }}"
-          stop: "${{ steps.connect.outputs.CONTAINER_ID }}"
+          command: |
+            make playwright-deploys TEST_FILE="${{ matrix.config.base_test_dir }} -vv --numprocesses 12"
 
       # - uses: actions/upload-artifact@v4
       #   if: failure()

--- a/tests/playwright/deploys/express-accordion/test_deploys_express_accordion.py
+++ b/tests/playwright/deploys/express-accordion/test_deploys_express_accordion.py
@@ -1,6 +1,7 @@
 import pytest
 from playwright.sync_api import Page
 from utils.deploy_utils import (
+    goto_deployed_app,
     local_deploys_app_url_fixture,
     reruns,
     reruns_delay,
@@ -15,7 +16,7 @@ app_url = local_deploys_app_url_fixture("shiny_express_accordion")
 @skip_if_not_chrome
 @pytest.mark.flaky(reruns=reruns, reruns_delay=reruns_delay)
 def test_express_accordion(page: Page, app_url: str) -> None:
-    page.goto(app_url)
+    goto_deployed_app(page, app_url)
 
     acc = controller.Accordion(page, "express_accordion")
     acc_panel_2 = acc.accordion_panel("Panel 2")

--- a/tests/playwright/deploys/express-dataframe/test_deploys_express_dataframe.py
+++ b/tests/playwright/deploys/express-dataframe/test_deploys_express_dataframe.py
@@ -1,6 +1,7 @@
 import pytest
 from playwright.sync_api import Page
 from utils.deploy_utils import (
+    goto_deployed_app,
     local_deploys_app_url_fixture,
     reruns,
     reruns_delay,
@@ -15,7 +16,7 @@ app_url = local_deploys_app_url_fixture("shiny-express-dataframe")
 @skip_if_not_chrome
 @pytest.mark.flaky(reruns=reruns, reruns_delay=reruns_delay)
 def test_express_dataframe_deploys(page: Page, app_url: str) -> None:
-    page.goto(app_url)
+    goto_deployed_app(page, app_url)
 
     dataframe = controller.OutputDataFrame(page, "sample_data_frame")
     dataframe.expect_nrow(6)

--- a/tests/playwright/deploys/express-folium/test_deploys_express_folium.py
+++ b/tests/playwright/deploys/express-folium/test_deploys_express_folium.py
@@ -1,6 +1,7 @@
 import pytest
 from playwright.sync_api import Page, expect
 from utils.deploy_utils import (
+    goto_deployed_app,
     local_deploys_app_url_fixture,
     reruns,
     reruns_delay,
@@ -13,7 +14,7 @@ app_url = local_deploys_app_url_fixture("shiny-express-folium")
 @skip_if_not_chrome
 @pytest.mark.flaky(reruns=reruns, reruns_delay=reruns_delay)
 def test_folium_map(page: Page, app_url: str) -> None:
-    page.goto(app_url)
+    goto_deployed_app(page, app_url)
 
     expect(page.get_by_text("Static Map")).to_have_count(1)
     expect(page.get_by_text("Map inside of render express call")).to_have_count(1)

--- a/tests/playwright/deploys/express-page_default/test_deploys_express_page_default.py
+++ b/tests/playwright/deploys/express-page_default/test_deploys_express_page_default.py
@@ -1,6 +1,7 @@
 import pytest
 from playwright.sync_api import Page, expect
 from utils.deploy_utils import (
+    goto_deployed_app,
     local_deploys_app_url_fixture,
     reruns,
     reruns_delay,
@@ -17,7 +18,7 @@ app_url = local_deploys_app_url_fixture("shiny_express_page_default")
 @skip_if_not_chrome
 @pytest.mark.flaky(reruns=reruns, reruns_delay=reruns_delay)
 def test_page_default(page: Page, app_url: str) -> None:
-    page.goto(app_url)
+    goto_deployed_app(page, app_url)
 
     # since it is a custom table we can't use the OutputTable controls
     expect(page.locator("#shell")).to_have_text(

--- a/tests/playwright/deploys/express-page_fillable/test_deploys_express_page_fillable.py
+++ b/tests/playwright/deploys/express-page_fillable/test_deploys_express_page_fillable.py
@@ -1,6 +1,7 @@
 import pytest
 from playwright.sync_api import Page
 from utils.deploy_utils import (
+    goto_deployed_app,
     local_deploys_app_url_fixture,
     reruns,
     reruns_delay,
@@ -15,7 +16,7 @@ app_url = local_deploys_app_url_fixture("express_page_fillable")
 @skip_if_not_chrome
 @pytest.mark.flaky(reruns=reruns, reruns_delay=reruns_delay)
 def test_express_page_fillable(page: Page, app_url: str) -> None:
-    page.goto(app_url)
+    goto_deployed_app(page, app_url)
 
     card = controller.Card(page, "card")
     output_txt = controller.OutputTextVerbatim(page, "txt")

--- a/tests/playwright/deploys/express-page_fluid/test_deploys_express_page_fluid.py
+++ b/tests/playwright/deploys/express-page_fluid/test_deploys_express_page_fluid.py
@@ -1,6 +1,7 @@
 import pytest
 from playwright.sync_api import Page
 from utils.deploy_utils import (
+    goto_deployed_app,
     local_deploys_app_url_fixture,
     reruns,
     reruns_delay,
@@ -15,7 +16,7 @@ app_url = local_deploys_app_url_fixture("express_page_fluid")
 @skip_if_not_chrome
 @pytest.mark.flaky(reruns=reruns, reruns_delay=reruns_delay)
 def test_express_page_fluid(page: Page, app_url: str) -> None:
-    page.goto(app_url)
+    goto_deployed_app(page, app_url)
 
     card = controller.Card(page, "card")
     output_txt = controller.OutputTextVerbatim(page, "txt")

--- a/tests/playwright/deploys/express-page_sidebar/test_deploys_express_page_sidebar.py
+++ b/tests/playwright/deploys/express-page_sidebar/test_deploys_express_page_sidebar.py
@@ -3,6 +3,7 @@ import os
 import pytest
 from playwright.sync_api import Page
 from utils.deploy_utils import (
+    goto_deployed_app,
     local_deploys_app_url_fixture,
     reruns,
     reruns_delay,
@@ -21,7 +22,7 @@ app_url = local_deploys_app_url_fixture(
 @skip_if_not_chrome
 @pytest.mark.flaky(reruns=reruns, reruns_delay=reruns_delay)
 def test_express_page_sidebar(page: Page, app_url: str) -> None:
-    page.goto(app_url)
+    goto_deployed_app(page, app_url)
 
     sidebar = controller.Sidebar(page, "sidebar")
     sidebar.expect_text("SidebarTitle Sidebar Content")

--- a/tests/playwright/deploys/plotly/test_plotly_app.py
+++ b/tests/playwright/deploys/plotly/test_plotly_app.py
@@ -1,6 +1,7 @@
 import pytest
 from playwright.sync_api import Page, expect
 from utils.deploy_utils import (
+    goto_deployed_app,
     local_deploys_app_url_fixture,
     reruns,
     reruns_delay,
@@ -14,7 +15,7 @@ app_url = local_deploys_app_url_fixture("example_deploy_app_a1")
 @skip_if_not_chrome
 @pytest.mark.flaky(reruns=reruns, reruns_delay=reruns_delay)
 def test_deploys(page: Page, app_url: str) -> None:
-    page.goto(app_url)
+    goto_deployed_app(page, app_url)
 
     COUNTRY = "Afghanistan"
     expect(page.get_by_text(COUNTRY)).to_have_count(1, timeout=TIMEOUT)

--- a/tests/playwright/deploys/shiny-client-console-error/test_shiny_client_error.py
+++ b/tests/playwright/deploys/shiny-client-console-error/test_shiny_client_error.py
@@ -3,6 +3,7 @@ import re
 import pytest
 from playwright.sync_api import Page, expect
 from utils.deploy_utils import (
+    goto_deployed_app,
     local_deploys_app_url_fixture,
     reruns,
     reruns_delay,
@@ -15,7 +16,7 @@ app_url = local_deploys_app_url_fixture("shiny_client_console_error")
 @skip_if_not_chrome
 @pytest.mark.flaky(reruns=reruns, reruns_delay=reruns_delay)
 def test_shiny_client_console_error(page: Page, app_url: str) -> None:
-    page.goto(app_url)
+    goto_deployed_app(page, app_url)
 
     assert page.locator("#same_id").count() == 2
     shiny_error_message = page.locator("shiny-error-message")

--- a/tests/playwright/utils/deploy_utils.py
+++ b/tests/playwright/utils/deploy_utils.py
@@ -290,7 +290,7 @@ def local_deploys_app_url_fixture(
             if deploy_location == "shinyapps" and not (
                 shinyappsio_name and shinyappsio_token and shinyappsio_secret
             ):
-                raise RuntimeError(
+                pytest.skip(
                     "Shinyapps.io name, token or secret not found. Cannot deploy."
                 )
 

--- a/tests/playwright/utils/deploy_utils.py
+++ b/tests/playwright/utils/deploy_utils.py
@@ -293,11 +293,8 @@ def local_deploys_app_url_fixture(
                     pytest.skip(
                         "Connect server url or api key not found. Cannot deploy."
                     )
-            if (
-                deploy_location == "shinyapps"
-                and shinyappsio_name
-                and shinyappsio_token
-                and shinyappsio_secret
+            if deploy_location == "shinyapps" and not (
+                shinyappsio_name and shinyappsio_token and shinyappsio_secret
             ):
                 pytest.skip(
                     "Shinyapps.io name, token or secret not found. Cannot deploy."

--- a/tests/playwright/utils/deploy_utils.py
+++ b/tests/playwright/utils/deploy_utils.py
@@ -281,11 +281,6 @@ def local_deploys_app_url_fixture(
         elif deploy_location in deploy_locations:
 
             if deploy_location == "connect":
-                if server_url and "dogfood" in server_url:
-                    # TODO: dogfood server does not have public links now, the team will migrate to spinning their own connect server in the future.
-                    pytest.skip(
-                        "dogfood server does not have public links now, the team will migrate to spinning their own connect server in the future."
-                    )
                 if not (server_url and api_key):
                     pytest.skip(
                         "Connect server url or api key not found. Cannot deploy."

--- a/tests/playwright/utils/deploy_utils.py
+++ b/tests/playwright/utils/deploy_utils.py
@@ -290,7 +290,7 @@ def local_deploys_app_url_fixture(
             if deploy_location == "shinyapps" and not (
                 shinyappsio_name and shinyappsio_token and shinyappsio_secret
             ):
-                pytest.skip(
+                raise RuntimeError(
                     "Shinyapps.io name, token or secret not found. Cannot deploy."
                 )
 

--- a/tests/playwright/utils/deploy_utils.py
+++ b/tests/playwright/utils/deploy_utils.py
@@ -176,7 +176,7 @@ def deploy_to_connect(app_name: str, app_dir: str) -> str:
 # TODO-future: Supress web browser from opening after deploying - https://github.com/rstudio/rsconnect-python/issues/462
 def deploy_to_shinyapps(app_name: str, app_dir: str) -> str:
     # Deploy to shinyapps.io
-    shinyapps_deploy = f"rsconnect deploy shiny {app_dir} --account {shinyappsio_name} --token {shinyappsio_token} --secret {shinyappsio_secret} --title {app_name} --verbose"
+    shinyapps_deploy = f"rsconnect deploy shiny {app_dir} --account {shinyappsio_name} --token {shinyappsio_token} --secret {shinyappsio_secret} --title {app_name} --override-python-version 3.10 --verbose"
     shinyapps_env = os.environ.copy()
     shinyapps_env.pop("CONNECT_API_KEY", None)
     shinyapps_env.pop("CONNECT_SERVER", None)

--- a/tests/playwright/utils/deploy_utils.py
+++ b/tests/playwright/utils/deploy_utils.py
@@ -105,11 +105,12 @@ def skip_on_python_version(
     return _
 
 
-def run_command(cmd: str) -> str:
+def run_command(cmd: str, env: Optional[dict[str, str]] = None) -> str:
     output = subprocess.run(
         cmd,
         check=False,
         capture_output=True,
+        env=env,
         text=True,
         shell=True,
     )
@@ -176,7 +177,10 @@ def deploy_to_connect(app_name: str, app_dir: str) -> str:
 def deploy_to_shinyapps(app_name: str, app_dir: str) -> str:
     # Deploy to shinyapps.io
     shinyapps_deploy = f"rsconnect deploy shiny {app_dir} --account {shinyappsio_name} --token {shinyappsio_token} --secret {shinyappsio_secret} --title {app_name} --verbose"
-    run_command(shinyapps_deploy)
+    shinyapps_env = os.environ.copy()
+    shinyapps_env.pop("CONNECT_API_KEY", None)
+    shinyapps_env.pop("CONNECT_SERVER", None)
+    run_command(shinyapps_deploy, env=shinyapps_env)
     return f"https://{shinyappsio_name}.shinyapps.io/{app_name}/"
 
 

--- a/tests/playwright/utils/deploy_utils.py
+++ b/tests/playwright/utils/deploy_utils.py
@@ -8,12 +8,11 @@ import subprocess
 import sys
 import tempfile
 import time
-import warnings
 from typing import Any, Callable, List, Optional, TypeVar
 
 import pytest
-import requests
 from conftest import ScopeName
+from playwright.sync_api import Page
 
 from shiny.run._run import shiny_app_gen
 
@@ -24,6 +23,7 @@ reruns_delay = 1
 LOCAL_LOCATION = "local"
 
 __all__ = (
+    "goto_deployed_app",
     "local_deploys_app_url_fixture",
     "skip_if_not_chrome",
 )
@@ -135,6 +135,16 @@ def redact_api_key(cmd: str) -> str:
     return re.sub(r"(--api-key\s+)(\S+)", r"\1***", cmd)
 
 
+def goto_deployed_app(page: Page, app_url: str) -> None:
+    headers: dict[str, str] = {}
+    if server_url and api_key and app_url.startswith(f"{server_url.rstrip('/')}/"):
+        headers["Authorization"] = f"Key {api_key}"
+
+    # The page fixture is shared, so clear the Connect header for other targets.
+    page.set_extra_http_headers(headers)
+    page.goto(app_url)
+
+
 def deploy_to_connect(app_name: str, app_dir: str) -> str:
     if not api_key:
         raise RuntimeError("No api key found. Cannot deploy.")
@@ -158,26 +168,6 @@ def deploy_to_connect(app_name: str, app_dir: str) -> str:
     # look up content url in connect server once app is deployed
     output = run_command(connect_server_lookup_command)
     url = json.loads(output)[0]["content_url"]
-    app_id = json.loads(output)[0]["guid"]
-
-    # change visibility of app to public
-    connect_app_url = f"{server_url}/__api__/v1/content/{app_id}"
-    payload = '{"access_type":"all"}'
-    headers = {
-        "Authorization": f"Key {api_key}",
-        "Accept": "application/json",
-    }
-    response = requests.request("PATCH", connect_app_url, headers=headers, data=payload)
-    if response.status_code != 200:
-        warnings.warn(
-            f"Failed to change visibility of app. {response.text}",
-            RuntimeWarning,
-            stacklevel=1,
-        )
-        pytest.skip(
-            "Skipping test as deployed app is not visible to public. Test is kept as it does confirm the app deployment has succeeded."
-        )
-        return
 
     return url
 

--- a/tests/playwright/utils/deploy_utils.py
+++ b/tests/playwright/utils/deploy_utils.py
@@ -29,8 +29,12 @@ __all__ = (
 )
 
 # connect
-server_url = os.environ.get("DEPLOY_CONNECT_SERVER_URL")
-api_key = os.environ.get("DEPLOY_CONNECT_SERVER_API_KEY")
+server_url = os.environ.get("DEPLOY_CONNECT_SERVER_URL") or os.environ.get(
+    "CONNECT_SERVER"
+)
+api_key = os.environ.get("DEPLOY_CONNECT_SERVER_API_KEY") or os.environ.get(
+    "CONNECT_API_KEY"
+)
 # shinyapps.io
 shinyappsio_name = os.environ.get("DEPLOY_SHINYAPPS_NAME")
 shinyappsio_token = os.environ.get("DEPLOY_SHINYAPPS_TOKEN")
@@ -136,9 +140,13 @@ def deploy_to_connect(app_name: str, app_dir: str) -> str:
         raise RuntimeError("No api key found. Cannot deploy.")
 
     # check if connect app is already deployed to avoid duplicates
-    connect_server_lookup_command = f"rsconnect content search --server {server_url} --api-key {api_key} --title-contains {app_name}"
+    connect_server_lookup_command = (
+        f"rsconnect content search --title-contains {app_name}"
+    )
     app_details = run_command(connect_server_lookup_command)
-    connect_server_deploy = f"rsconnect deploy shiny {app_dir} --server {server_url} --api-key {api_key} --title {app_name} --verbose"
+    connect_server_deploy = (
+        f"rsconnect deploy shiny {app_dir} --title {app_name} --verbose"
+    )
     # only if the app exists do we replace existing app with new version
     if json.loads(app_details):
         app_id = json.loads(app_details)[0]["guid"]


### PR DESCRIPTION
## Summary

- Start an ephemeral Posit Connect server in each deploy-test job using `posit-dev/with-connect`
- Use the generated server URL and API key for the existing Playwright deployment tests
- Stop the Connect container after testing, including on failure
- Remove dogfood server configuration and the dogfood-specific test skip
- Rename the affected matrix configurations to reflect local Connect usage

## Test Run link
https://github.com/posit-dev/py-shiny/actions/runs/29390078723
