### PR TITLE
fix(ui): stringify selected in update_checkbox_group/update_radio_buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* `render.data_frame` now renders data frames whose column names are non-string (e.g. numeric) instead of failing with an obscure error. Columns are now accessed via `get_column()`, which avoids narwhals interpreting a numeric column name as positional row access. (#2115)
+
 * Fixed `--launch-browser` so it no longer depends on INFO-level Uvicorn startup logs. Browser launch now works when logs are disabled or `--log-level=warning` is used. (#569)
 
 * `ui.output_data_frame` will now consistently order the filtered columns in ascending column order. (#2093)

--- a/shiny/render/_data_frame_utils/_tbl_data.py
+++ b/shiny/render/_data_frame_utils/_tbl_data.py
@@ -169,7 +169,7 @@ def apply_frame_patches(
 
     # Upgrade the Scatter info to new column Series objects
     scatter_columns = [
-        nw_data[column_name].scatter(
+        nw_data.get_column(column_name).scatter(
             scatter_values["row_indexes"], scatter_values["values"]
         )
         for column_name, scatter_values in cell_patches_by_column.items()
@@ -237,7 +237,12 @@ def serialize_frame(into_data: IntoDataFrame) -> FrameJson:
 
     data = as_data_frame(into_data)
 
-    type_hints = [serialize_dtype(data[col_name]) for col_name in data.columns]
+    # Use `get_column` rather than `data[col_name]`: for a numeric column name
+    # (e.g. `0`) the latter is interpreted as row/positional access and returns a
+    # row frame instead of the column, which then fails downstream.
+    type_hints = [
+        serialize_dtype(data.get_column(col_name)) for col_name in data.columns
+    ]
 
     # TODO-future-barret; Swich serialization to "by column", rather than "by row"
     # * This would allow for a single column to be serialized in a single operation

--- a/shiny/ui/_input_update.py
+++ b/shiny/ui/_input_update.py
@@ -408,6 +408,20 @@ def update_radio_buttons(
     )
 
 
+def _stringify_selected(
+    selected: Optional[str | list[str] | tuple[str, ...]],
+) -> Optional[str | list[str]]:
+    # Choice values are rendered as strings in the DOM, so the `selected` sent to
+    # the client must be stringified too; otherwise integer keys (accepted by
+    # input_checkbox_group / input_radio_buttons) never match the option values
+    # on update. See #2272.
+    if selected is None:
+        return None
+    if isinstance(selected, (list, tuple)):
+        return [str(el) for el in selected]
+    return str(selected)
+
+
 def _update_choice_input(
     id: str,
     *,
@@ -436,7 +450,7 @@ def _update_choice_input(
     msg = {
         "label": session._process_ui(label) if label is not None else None,
         "options": options,
-        "value": selected,
+        "value": _stringify_selected(selected),
     }
     session.send_input_message(id, drop_none(msg))
 

--- a/tests/pytest/test_render_data_frame_tbl_data.py
+++ b/tests/pytest/test_render_data_frame_tbl_data.py
@@ -313,6 +313,20 @@ def test_serialize_frame(df_f: IntoDataFrame):
     }
 
 
+def test_serialize_frame_numeric_column_names():
+    # Regression test: numeric column names (e.g. `0`, `1`) previously raised in
+    # serialize_frame because `data[col_name]` was interpreted as positional/row
+    # access on the narwhals frame instead of column access.
+    df = pd.DataFrame([["a", 1], ["b", 2], ["c", 3]], columns=[0, 1])
+
+    with session_context(test_session):
+        res = serialize_frame(as_data_frame(df))
+
+    assert res["columns"] == [0, 1]
+    assert [hint["type"] for hint in res["typeHints"]] == ["string", "numeric"]
+    assert res["data"] == [["a", 1], ["b", 2], ["c", 3]]
+
+
 def test_subset_frame(df_f: IntoDataFrame):
     # TODO: this assumes subset_frame doesn't reset index
     res = subset_frame(as_data_frame(df_f), rows=[1], cols=["chr", "num"])
@@ -366,7 +380,6 @@ def test_dtype_coverage():
     errs: list[str] = []
 
     for dtype_name in dtype_names:
-
         # Skip known types or imports that are not dtypes
         if dtype_name.endswith("Type"):
             # "DType",

--- a/tests/pytest/test_update_choice_input.py
+++ b/tests/pytest/test_update_choice_input.py
@@ -1,0 +1,47 @@
+"""Unit tests for choice-input updates (update_checkbox_group / update_radio_buttons)."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from shiny import ui
+from shiny.session import Session
+from shiny.ui._input_update import _stringify_selected
+
+
+class _CaptureSession:
+    """Minimal session that records send_input_message calls."""
+
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, dict[str, Any]]] = []
+
+    def send_input_message(self, id: str, message: dict[str, Any]) -> None:
+        self.messages.append((id, message))
+
+
+def test_stringify_selected() -> None:
+    assert _stringify_selected(None) is None
+    assert _stringify_selected("a") == "a"
+    assert _stringify_selected(cast(str, 0)) == "0"
+    assert _stringify_selected(cast("list[str]", [0, 1, 2])) == ["0", "1", "2"]
+    assert _stringify_selected(cast("tuple[str, ...]", (0, 1))) == ["0", "1"]
+    assert _stringify_selected(["a", "b"]) == ["a", "b"]
+
+
+def test_update_checkbox_group_stringifies_int_selected() -> None:
+    # Regression for #2272: input_checkbox_group accepts integer choice keys in
+    # `selected`, but update_checkbox_group sent them unchanged, so they never
+    # matched the (string) option values on the client. They must be stringified.
+    sess = _CaptureSession()
+    ui.update_checkbox_group(
+        "grp", selected=cast("list[str]", [0, 2]), session=cast(Session, sess)
+    )
+    assert sess.messages == [("grp", {"value": ["0", "2"]})]
+
+
+def test_update_radio_buttons_stringifies_int_selected() -> None:
+    sess = _CaptureSession()
+    ui.update_radio_buttons(
+        "grp", selected=cast(str, 1), session=cast(Session, sess)
+    )
+    assert sess.messages == [("grp", {"value": "1"})]


### PR DESCRIPTION
Closes #2272.

`input_checkbox_group` accepts integer choice keys in `selected`, but `update_checkbox_group` / `update_radio_buttons` sent them to the client unchanged, so integer keys never matched the (string) option values on update. Stringify the selected values sent to the client. Adds unit tests (this update path previously had only browser tests).