### PR TITLE
feat: Add render.download_button and render.download_link

### DIFF
--- a/.claude/skills/py-shiny-release/SKILL.md
+++ b/.claude/skills/py-shiny-release/SKILL.md
@@ -35,6 +35,9 @@ this verification checklist with the user**:
    - CI status (link to the passing run)
    - Changelog entry (show the relevant section)
    - Dependency check result (any git-based deps found?)
+   - **`TODO: release` markers** — run `grep -rn "TODO: release" . | grep -v '\.git/'` and
+     list every marker with its holding PR and whether it acts before/after publish (see
+     "Release-blocking `TODO: release` markers" above). None may be left unaddressed.
    - For py-shiny: shinylive example test results
 2. **Ask for explicit confirmation**:
    > "Ready to release **{package} v{version}**? This will tag the commit and publish
@@ -47,8 +50,43 @@ this verification checklist with the user**:
 1. Ask the user which version of py-shiny is being released (e.g., `1.3.0`)
 2. Ask if py-htmltools also needs a release (and what version)
 3. Ask if any Shiny HTML Dependencies were updated (triggers shinyswatch prerequisite)
-4. Create a TodoWrite checklist of all 13 phases
-5. Begin with Phase 1
+4. **Scan for release-blocking `TODO: release` markers** (see below) and fold each into
+   the TodoWrite checklist
+5. Create a TodoWrite checklist of all 13 phases plus any `TODO: release` items
+6. Begin with Phase 1
+
+## Release-blocking `TODO: release` markers
+
+Some changes cannot land on their own and must be actioned during a release — e.g. a
+temporary CI pin to an unmerged "holding" PR in a downstream repo, a dependency that
+can only be un-pinned once an upstream package is on PyPI, or a docs version bump. These
+are marked in-code with a greppable comment of the form:
+
+```
+TODO: release - <what to do, and when (before/after PyPI publish), plus the holding PR link>
+```
+
+**At the start of every release, and again at the pre-release gate, scan the py-shiny
+repo for these markers and resolve each one:**
+
+```bash
+grep -rn "TODO: release" . ':!*.lock' 2>/dev/null | grep -v '\.git/'
+```
+
+For each marker:
+1. Read it — it says what to do and whether it happens **before** or **after** the PyPI
+   publish, and links the holding PR it depends on.
+2. Add it to the TodoWrite checklist at the correct point in the phase order.
+3. Do NOT complete the release while any `TODO: release` marker is unresolved: either the
+   action has been performed and the marker removed, or the user has explicitly deferred it.
+
+**Known holding item (as of py-shiny #2364 — `render.download` deprecation):**
+`.github/workflows/pytest.yaml` temporarily pins the `py-shiny-templates` checkout to the
+branch of [posit-dev/py-shiny-templates#55](https://github.com/posit-dev/py-shiny-templates/pull/55)
+(which migrates the templates to `render.download_button`/`render.download_link`). During
+Phase 3 (py-shiny), **after** this py-shiny version is published to PyPI: merge
+py-shiny-templates#55, then open a follow-up py-shiny PR removing the `ref:` pin so CI
+tracks the templates' default branch again. Remove the `TODO: release` comment in that PR.
 
 ## Phase Overview
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -271,6 +271,12 @@ jobs:
         with:
           repository: posit-dev/py-shiny-templates
           path: py-shiny-templates
+          # TODO: release - Temporarily pinned to the branch of
+          # posit-dev/py-shiny-templates#55, which migrates the templates to
+          # render.download_button/link (deprecating render.download, py-shiny#2364).
+          # Before release: merge py-shiny-templates#55 after this py-shiny version is
+          # on PyPI, then remove this `ref:` so CI tracks the default branch again.
+          ref: migrate-render-download-button
 
       - name: Install py-shiny-templates dependencies
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added `offcanvas()` for creating sliding Bootstrap Offcanvas panels that appear from a viewport edge. Panels can be triggered by a UI element, revealed programmatically with `show_offcanvas()`, or controlled by id with `hide_offcanvas()` and `toggle_offcanvas()`. (#2279)
 
-* Added `@render.download_button` and `@render.download_link`, which pair 1:1 with `ui.download_button()` and `ui.download_link()`. (#<PR>)
+* Added `@render.download_button` and `@render.download_link`, which pair 1:1 with `ui.download_button()` and `ui.download_link()`. (#2364)
 
 ### Improvements
 
@@ -49,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecations
 
-* Deprecated `@render.download`; use `@render.download_button` (or `@render.download_link`) instead. (#<PR>)
+* Deprecated `@render.download`; use `@render.download_button` (or `@render.download_link`) instead. (#2364)
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added `offcanvas()` for creating sliding Bootstrap Offcanvas panels that appear from a viewport edge. Panels can be triggered by a UI element, revealed programmatically with `show_offcanvas()`, or controlled by id with `hide_offcanvas()` and `toggle_offcanvas()`. (#2279)
 
+* Added `@render.download_button` and `@render.download_link`, which pair 1:1 with `ui.download_button()` and `ui.download_link()`. (#<PR>)
+
 ### Improvements
 
 * The `shiny[otel]` optional dependency group now includes `opentelemetry-distro[otlp]`, so OpenTelemetry zero-code auto-instrumentation works out of the box: `opentelemetry-instrument shiny run app.py`. This is now the documented standard way to enable OpenTelemetry — the docs and the `examples/open-telemetry/` example no longer configure providers inside the app (in-code `set_tracer_provider()` setup is silently ignored when a provider is already installed, e.g. under `opentelemetry-instrument`). The OTLP exporters are also included, making it easy to switch between gRPC and HTTP export via standard `OTEL_*` environment variables. Note that `opentelemetry-distro` pins `opentelemetry-sdk` to a matching minor version, so if you combine `shiny[otel]` with other packages that pin the OpenTelemetry SDK (e.g. `logfire`), the resolver may need matching versions. (#2349)
@@ -44,6 +46,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Playwright's `OutputDataFrame.set_filter()` controller now supports multi-column filters (#2093)
 * Add api-example for `ui.output_code` (#2093)
 * Update controllers for `DownloadLink` and `DownloadButton` (#2093)
+
+### Deprecations
+
+* Deprecated `@render.download`; use `@render.download_button` (or `@render.download_link`) instead. (#<PR>)
 
 ### Bug fixes
 

--- a/docs/_quartodoc-core.yml
+++ b/docs/_quartodoc-core.yml
@@ -217,6 +217,8 @@ quartodoc:
         - render.ui
         - render.express
         - render.download
+        - render.download_button
+        - render.download_link
         - render.data_frame
         - render.DataGrid
         - render.DataTable

--- a/docs/_quartodoc-express.yml
+++ b/docs/_quartodoc-express.yml
@@ -52,6 +52,8 @@ quartodoc:
         - express.render.text
         - express.render.ui
         - express.render.download
+        - express.render.download_button
+        - express.render.download_link
         - express.render.image
         - express.render.express
     - title: Layouts and other UI tools
@@ -188,6 +190,8 @@ quartodoc:
       contents:
         - express.ui.input_file
         - express.render.download
+        - express.render.download_button
+        - express.render.download_link
     - title: Dynamic UI
       desc: Dynamically show/hide UI elements.
       contents:

--- a/examples/annotation-export/app.py
+++ b/examples/annotation-export/app.py
@@ -109,7 +109,7 @@ def server(input: Inputs, output: Outputs, session: Session):
         df = df.loc[df["annotation"] != ""]
         return df
 
-    @render.download(filename="data.csv")
+    @render.download_button(filename="data.csv")
     def download():
         yield annotated_data().to_csv()
 

--- a/shiny/.agents/skills/shiny-for-python/SKILL.md
+++ b/shiny/.agents/skills/shiny-for-python/SKILL.md
@@ -41,7 +41,7 @@ reference file before writing code** for that area.
 |---|---|---|
 | Plots & images | Rendering matplotlib/seaborn/plotnine figures or images; plot click/hover/brush interactions | `references/plots.md` |
 | Data frames | Interactive tables via `@render.data_frame` (DataGrid/DataTable) — sort, filter, select, edit | `references/data-frames.md` |
-| Files | File uploads (`ui.input_file`) and generated-file downloads (`@render.download`) | `references/files.md` |
+| Files | File uploads (`ui.input_file`) and generated-file downloads (`@render.download_button`/`@render.download_link`) | `references/files.md` |
 
 ## Feedback & interactivity
 

--- a/shiny/.agents/skills/shiny-for-python/references/files.md
+++ b/shiny/.agents/skills/shiny-for-python/references/files.md
@@ -4,9 +4,9 @@
 
 Shiny handles the browser plumbing for you. For uploads, `ui.input_file`
 receives the file, stores it in a temp file, and hands the server a
-`list[FileInfo]` describing each upload. For downloads, `@render.download`
-registers a handler that streams bytes to the browser when a paired
-`ui.download_button`/`ui.download_link` is clicked.
+`list[FileInfo]` describing each upload. For downloads, `@render.download_button`
+(or `@render.download_link`) registers a handler that streams bytes to the
+browser when the paired `ui.download_button`/`ui.download_link` is clicked.
 
 Do NOT build a raw `<input type="file">`, parse multipart bodies yourself, or
 add a custom Starlette route to serve a file — Shiny already exposes both
@@ -50,12 +50,16 @@ file picker: extensions (`".csv"`), MIME types (`"text/plain"`), or wildcards
 (`"image/*"`). It only filters the picker; it is not enforced server-side, so
 still validate the uploaded file's type/name yourself.
 
-## Download a generated file: `@render.download`
+## Download a generated file: `@render.download_button` / `@render.download_link`
 
-Pair a handler with a `ui.download_button` (or `ui.download_link`) whose id
-matches the function name. The handler either **returns a path** to an existing
-file on disk, or **yields** strings/bytes for content generated on the fly.
-When yielding, pass `filename=` so the browser knows what to name it.
+Pair `@render.download_button` with a `ui.download_button` (or
+`@render.download_link` with a `ui.download_link`) whose id matches the function
+name. The handler either **returns a path** to an existing file on disk, or
+**yields** strings/bytes for content generated on the fly. When yielding, pass
+`filename=` so the browser knows what to name it.
+
+(`@render.download` is the older, now-deprecated name — it still works but emits
+a deprecation warning; use `@render.download_button` or `@render.download_link`.)
 
 ```python
 import io
@@ -68,7 +72,7 @@ app_ui = ui.page_fluid(
 )
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @render.download(filename=lambda: f"data-{date.today().isoformat()}.csv")
+    @render.download_button(filename=lambda: f"data-{date.today().isoformat()}.csv")
     def download_csv():
         df = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
         with io.StringIO() as buf:
@@ -84,8 +88,9 @@ file that already exists on disk — for temp files you create, `yield` the
 bytes instead so Shiny does not leave the temp file behind. The handler may be
 sync or async.
 
-In Express mode, `@render.download` renders its own button — pass
-`label=` and skip the separate `ui.download_button` (see `references/express.md`).
+In Express mode, `@render.download_button` renders its own button (and
+`@render.download_link` its own link) — pass `label=` and skip the separate
+`ui.download_button`/`ui.download_link` (see `references/express.md`).
 
 ## Quick reference
 
@@ -96,8 +101,8 @@ In Express mode, `@render.download` renders its own button — pass
 | Open uploaded data | `open(fileinfo["datapath"])` / `pd.read_csv(fileinfo["datapath"])` |
 | Guard empty upload | `req(input.id())` before reading |
 | Download button / link | `ui.download_button("id", "Label")` / `ui.download_link(...)` |
-| Download handler | `@render.download(filename=...)` returning a path or yielding bytes/str |
-| Dynamic filename | `@render.download(filename=lambda: ...)` |
+| Download handler | `@render.download_button(filename=...)` (or `@render.download_link`) returning a path or yielding bytes/str |
+| Dynamic filename | `@render.download_button(filename=lambda: ...)` |
 
 ## Common mistakes
 
@@ -114,4 +119,5 @@ In Express mode, `@render.download` renders its own button — pass
 - Download button never fires -> the function name must match the button id,
   and the button must be registered in the UI.
 - Building a raw `<input type="file">` or a custom download route -> use
-  `ui.input_file` and `@render.download`; Shiny wires the transport for you.
+  `ui.input_file` and `@render.download_button`/`@render.download_link`; Shiny
+  wires the transport for you.

--- a/shiny/api-examples/busy_indicators/app-core.py
+++ b/shiny/api-examples/busy_indicators/app-core.py
@@ -46,7 +46,7 @@ def server(input):
             pulse="pulse" in input.indicator_types(),
         )
 
-    @render.download
+    @render.download_button
     def download():
         time.sleep(3)
         path = os.path.join(os.path.dirname(__file__), "app-core.py")

--- a/shiny/api-examples/busy_indicators/app-express.py
+++ b/shiny/api-examples/busy_indicators/app-express.py
@@ -17,7 +17,7 @@ with ui.sidebar():
         selected=["spinners", "pulse"],
     )
 
-    @render.download
+    @render.download_button
     def download():
         time.sleep(3)
         path = os.path.join(os.path.dirname(__file__), "app-express.py")

--- a/shiny/api-examples/download/app-core.py
+++ b/shiny/api-examples/download/app-core.py
@@ -77,7 +77,8 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @render.download()
+    # Uses @render.download_button (replaces the deprecated download renderer).
+    @render.download_button()
     def download1():
         """
         This is the simplest case. The implementation simply returns the name of a file.
@@ -88,12 +89,12 @@ def server(input: Inputs, output: Outputs, session: Session):
         path = os.path.join(os.path.dirname(__file__), "mtcars.csv")
         return path
 
-    @render.download(filename="image.png")
+    @render.download_button(filename="image.png")
     def download2():
         """
         Another way to implement a file download is by yielding bytes; either all at
         once, like in this case, or by yielding multiple times. When using this
-        approach, you should pass a filename argument to @render.download, which
+        approach, you should pass a filename argument to @render.download_button, which
         determines what the browser will name the downloaded file.
         """
 
@@ -107,7 +108,7 @@ def server(input: Inputs, output: Outputs, session: Session):
             plt.savefig(buf, format="png")
             yield buf.getvalue()
 
-    @render.download(
+    @render.download_button(
         filename=lambda: f"新型-{date.today().isoformat()}-{np.random.randint(100, 999)}.csv"
     )
     async def download3():
@@ -117,7 +118,7 @@ def server(input: Inputs, output: Outputs, session: Session):
         yield "型,4,5\n"
 
     @output(id="download4")
-    @render.download(filename="failuretest.txt")
+    @render.download_button(filename="failuretest.txt")
     async def _():
         yield "hello"
         raise Exception("This error was caused intentionally")

--- a/shiny/api-examples/download/app-express.py
+++ b/shiny/api-examples/download/app-express.py
@@ -14,7 +14,8 @@ with ui.accordion(open=True):
     with ui.accordion_panel("Simple case"):
         ui.markdown("Downloads a pre-existing file, using its existing name on disk.")
 
-        @render.download(label="Download CSV")
+        # Uses @render.download_button (replaces the deprecated download renderer).
+        @render.download_button(label="Download CSV")
         def download1():
             """
             This is the simplest case. The implementation simply returns the name of a file.
@@ -31,13 +32,13 @@ with ui.accordion(open=True):
         ui.input_text("title", "Plot title", "Random scatter plot")
         ui.input_slider("num_points", "Number of data points", min=1, max=100, value=50)
 
-        @render.download(label="Download plot", filename="image.png")
+        @render.download_button(label="Download plot", filename="image.png")
         def download2():
             """
             Another way to implement a file download is by yielding bytes; either all at
             once, like in this case, or by yielding multiple times. When using this
-            approach, you should pass a filename argument to @render.download, which
-            determines what the browser will name the downloaded file.
+            approach, you should pass a filename argument to @render.download_button,
+            which determines what the browser will name the downloaded file.
             """
 
             print(input.num_points())
@@ -55,7 +56,7 @@ with ui.accordion(open=True):
             "Demonstrates that filenames can be generated on the fly (and use Unicode characters!)."
         )
 
-        @render.download(
+        @render.download_button(
             label="Download filename",
             filename=lambda: f"新型-{date.today().isoformat()}-{np.random.randint(100, 999)}.csv",
         )
@@ -70,7 +71,7 @@ with ui.accordion(open=True):
             "Throws an error in the download handler, download should not succeed."
         )
 
-        @render.download(label="Download", filename="failuretest.txt")
+        @render.download_button(label="Download", filename="failuretest.txt")
         async def download4():
             yield "hello"
             raise Exception("This error was caused intentionally")

--- a/shiny/api-examples/download_button/app-core.py
+++ b/shiny/api-examples/download_button/app-core.py
@@ -10,7 +10,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @render.download(
+    @render.download_button(
         filename=lambda: f"新型-{date.today().isoformat()}-{random.randint(100, 999)}.csv"
     )
     async def downloadData():

--- a/shiny/api-examples/download_button/app-express.py
+++ b/shiny/api-examples/download_button/app-express.py
@@ -5,7 +5,7 @@ from datetime import date
 from shiny.express import render
 
 
-@render.download(
+@render.download_button(
     filename=lambda: f"新型-{date.today().isoformat()}-{random.randint(100, 999)}.csv"
 )
 async def downloadData():

--- a/shiny/api-examples/download_link/app-core.py
+++ b/shiny/api-examples/download_link/app-core.py
@@ -10,7 +10,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    @render.download(
+    @render.download_link(
         filename=lambda: f"新型-{date.today().isoformat()}-{random.randint(100, 999)}.csv"
     )
     async def downloadData():

--- a/shiny/api-examples/download_link/app-express.py
+++ b/shiny/api-examples/download_link/app-express.py
@@ -2,20 +2,14 @@ import asyncio
 import random
 from datetime import date
 
-from shiny.express import render, ui
-from shiny.ui import download_link
+from shiny.express import render
 
-download_link("downloadData", "Download")
 
-# In Express mode, `@render.download` automatically renders a download button. Wrap it
-# in `ui.hold()` to suppress the button so the `download_link()` above is used instead.
-with ui.hold():
-
-    @render.download(
-        filename=lambda: f"data-{date.today().isoformat()}-{random.randint(100, 999)}.csv"
-    )
-    async def downloadData():
-        await asyncio.sleep(0.25)
-        yield "one,two,three\n"
-        yield "a,1,2\n"
-        yield "b,4,5\n"
+@render.download_link(
+    filename=lambda: f"data-{date.today().isoformat()}-{random.randint(100, 999)}.csv"
+)
+async def downloadData():
+    await asyncio.sleep(0.25)
+    yield "one,two,three\n"
+    yield "a,1,2\n"
+    yield "b,4,5\n"

--- a/shiny/express/ui/__init__.py
+++ b/shiny/express/ui/__init__.py
@@ -346,7 +346,7 @@ __all__ = (
 
 
 # This is used for unit tests to verify that shiny.ui and shiny.express.ui stay in sync.
-_known_missing = {
+_known_missing_express_ui = {
     # Items from shiny.ui that don't have a counterpart in shiny.express.ui
     "shiny.ui": (
         "column",  # Deprecated in favor of layout_columns

--- a/shiny/render/__init__.py
+++ b/shiny/render/__init__.py
@@ -25,6 +25,7 @@ from ._express import (
 )
 from ._render import (
     code,
+    download,
     download_button,
     download_link,
     image,

--- a/shiny/render/__init__.py
+++ b/shiny/render/__init__.py
@@ -25,7 +25,8 @@ from ._express import (
 )
 from ._render import (
     code,
-    download,
+    download_button,
+    download_link,
     image,
     plot,
     table,
@@ -44,6 +45,8 @@ __all__ = (
     "table",
     "ui",
     "download",
+    "download_button",
+    "download_link",
     "DataGrid",
     "DataTable",
     "CellPatch",

--- a/shiny/render/_render.py
+++ b/shiny/render/_render.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Union, cast
 
 from htmltools import Tag, TagAttrValue, TagChild
 
-from ._data_frame import data_frame as _data_frame
 from ._data_frame_utils._tbl_data import as_data_frame
 from ._data_frame_utils._types import IntoDataFrame
 
@@ -826,35 +825,3 @@ class download(download_button):
         )
         if fn is not None:
             self(fn)
-
-
-# --------------------------------------------------------------------------------------
-# Render ↔ UI 1:1 mapping (verified by tests/pytest/test_express_ui.py)
-# --------------------------------------------------------------------------------------
-
-# Maps each output render decorator to the UI component it pairs 1:1 with.
-_renderer_output_ui_pairs: dict[type[Renderer[Any]], Callable[..., Tag]] = {
-    text: _ui.output_text,
-    code: _ui.output_code,
-    plot: _ui.output_plot,
-    image: _ui.output_image,
-    table: _ui.output_table,
-    ui: _ui.output_ui,
-    _data_frame: _ui.output_data_frame,
-    download_button: _ui.download_button,
-    download_link: _ui.download_link,
-}
-
-# Deliberate exceptions to the render↔ui 1:1 mapping.
-_known_missing_renderer: dict[str, tuple[str, ...]] = {
-    # Renderers (in shiny.render.__all__) with no 1:1 output UI component.
-    "shiny.render": (
-        "express",  # meta-renderer (Renderer[None]); no paired UI component
-        "download",  # deprecated alias of download_button
-    ),
-    # Output UI components (in shiny.ui.__all__) with no 1:1 renderer.
-    "shiny.ui": (
-        "output_text_verbatim",  # legacy alias of output_code
-        "output_markdown_stream",  # class-based (ui.MarkdownStream)
-    ),
-}

--- a/shiny/render/_render.py
+++ b/shiny/render/_render.py
@@ -634,7 +634,7 @@ class _DownloadBase(Renderer[str]):
     ) -> Self:
         from .._utils import validate_no_params
 
-        validate_no_params(fn, "render.download", stacklevel=4)
+        validate_no_params(fn, f"render.{type(self).__name__}", stacklevel=4)
 
         # For downloads, the value function (which is passed to `__call__()`) is
         # different than for other renderers. For normal renderers, the user supplies

--- a/shiny/render/_render.py
+++ b/shiny/render/_render.py
@@ -43,7 +43,9 @@ __all__ = (
     "image",
     "table",
     "ui",
-    "download",
+    # "download" is re-added in Task 2 when the deprecated `download` class returns.
+    "download_button",
+    "download_link",
 )
 # ======================================================================================
 # RenderText
@@ -595,55 +597,15 @@ class ui(Renderer[TagChild]):
 # ======================================================================================
 # RenderDownload
 # ======================================================================================
-@add_example(example_name="download")
-class download(Renderer[str]):
+class _DownloadBase(Renderer[str]):
     """
-    Decorator to register a function to handle a download.
+    Shared implementation for the download renderers.
 
-    This decorator is used to register a function that will be called when the user
-    clicks a download link or button. The decorated function may be sync or async, and
-    should do one of the following:
-
-    * Return a string. This will be assumed to be a filename; Shiny will return this
-      file to the browser, and the downloaded file will have the same filename as the
-      original, with an inferred mime type. This is the most convenient IF the file
-      already exists on disk. But if the function must create a temporary file, then
-      this method should not be used, because the temporary file will not be deleted by
-      Shiny. Use the `yield` method instead.
-    * `yield` one or more strings or bytestrings (`b"..."` or
-      `io.BytesIO().getvalue()`). If strings are yielded, they'll be encoded in UTF-8.
-      (This is better for temp files as after you're done yielding you can delete the
-      temp file, or use a tempfile.TemporaryFile context manager) With this method, it's
-      important that the `@render.download` decorator have a `filename` argument, as the
-      decorated function won't help with that.
-
-    Parameters
-    ----------
-    filename
-        The filename of the download.
-    media_type
-        The media type of the download.
-    encoding
-        The encoding of the download.
-    label
-        (Express only) A label for the button. Defaults to "Download".
-
-    Returns
-    -------
-    :
-        The decorated function.
-
-    See Also
-    --------
-    * :func:`~shiny.ui.download_button`
-    * :func:`~shiny.ui.download_link`
+    The download control is itself an output whose rendered value is a URL. When the
+    user clicks it, the browser initiates a download from that URL, and the server
+    provides the file via ``session._downloads``. Subclasses differ only in which UI
+    control (`download_button` vs `download_link`) they auto-place in Express.
     """
-
-    def auto_output_ui(self) -> Tag:
-        return _ui.download_button(
-            self.output_id,
-            label=self.label,
-        )
 
     def __init__(
         self,
@@ -653,6 +615,7 @@ class download(Renderer[str]):
         media_type: None | str | Callable[[], str] = None,
         encoding: str = "utf-8",
         label: TagChild = "Download",
+        width: str | None = None,
     ) -> None:
         super().__init__()
 
@@ -660,6 +623,7 @@ class download(Renderer[str]):
         self.media_type = media_type
         self.encoding = encoding
         self.label = label
+        self.width = width
 
         if fn is not None:
             self(fn)
@@ -677,12 +641,12 @@ class download(Renderer[str]):
         # the value function. This function returns a value which is transformed,
         # serialized to JSON, and then sent to the browser.
         #
-        # For downloads, the download button itself is actually an output. The value
-        # that it renders is a URL; when the user clicks the button, the browser
+        # For downloads, the download control itself is actually an output. The value
+        # that it renders is a URL; when the user clicks the control, the browser
         # initiates a download from that URL, and the server provides the file via
         # `session._downloads`.
         #
-        # The `url()` function here is the value function for the download button. It
+        # The `url()` function here is the value function for the download control. It
         # returns the URL for downloading the file.
         def url() -> str:
             from urllib.parse import quote
@@ -702,8 +666,7 @@ class download(Renderer[str]):
 
         # Register the download handler for the session. The reason we check for session
         # not being None or a stub session is because in Express, when the UI is
-        # rendered, this function `render.download()()`  called once before any sessions
-        # have been started.
+        # rendered, this function is called once before any sessions have been started.
         session = get_current_session()
         if session is not None and not session.is_stub_session():
             # All download objects are stored in the root session.
@@ -719,3 +682,99 @@ class download(Renderer[str]):
 
     async def transform(self, value: str) -> Jsonifiable:
         return value
+
+
+@add_example(example_name="download_button")
+class download_button(_DownloadBase):
+    """
+    Reactively render a download button.
+
+    Register a function that generates a download, and (in Express) auto-place a
+    download button. The decorated function may be sync or async, and should either
+    return a filename (str) to send an existing file, or ``yield`` one or more strings
+    or bytestrings for a generated file (in which case pass a ``filename`` argument).
+
+    Parameters
+    ----------
+    filename
+        The filename of the download.
+    media_type
+        The media type of the download.
+    encoding
+        The encoding of the download.
+    label
+        (Express only) A label for the button. Defaults to "Download".
+    width
+        (Express only) The width of the button.
+
+    Returns
+    -------
+    :
+        The decorated function.
+
+    Tip
+    ----
+    In Shiny Core, pair this with :func:`~shiny.ui.download_button` in the UI (the
+    decorated function's name should match the ``id``).
+
+    See Also
+    --------
+    * :class:`~shiny.render.download_link`
+    * :func:`~shiny.ui.download_button`
+    """
+
+    def auto_output_ui(
+        self,
+        *,
+        width: str | None | MISSING_TYPE = MISSING,
+    ) -> Tag:
+        kwargs: dict[str, Any] = {}
+        set_kwargs_value(kwargs, "width", width, self.width)
+        return _ui.download_button(self.output_id, label=self.label, **kwargs)
+
+
+@add_example(example_name="download_link")
+class download_link(_DownloadBase):
+    """
+    Reactively render a download link.
+
+    Identical to :class:`~shiny.render.download_button` except that in Express it
+    auto-places a download *link* instead of a button.
+
+    Parameters
+    ----------
+    filename
+        The filename of the download.
+    media_type
+        The media type of the download.
+    encoding
+        The encoding of the download.
+    label
+        (Express only) A label for the link. Defaults to "Download".
+    width
+        (Express only) The width of the link.
+
+    Returns
+    -------
+    :
+        The decorated function.
+
+    Tip
+    ----
+    In Shiny Core, pair this with :func:`~shiny.ui.download_link` in the UI (the
+    decorated function's name should match the ``id``).
+
+    See Also
+    --------
+    * :class:`~shiny.render.download_button`
+    * :func:`~shiny.ui.download_link`
+    """
+
+    def auto_output_ui(
+        self,
+        *,
+        width: str | None | MISSING_TYPE = MISSING,
+    ) -> Tag:
+        kwargs: dict[str, Any] = {}
+        set_kwargs_value(kwargs, "width", width, self.width)
+        return _ui.download_link(self.output_id, label=self.label, **kwargs)

--- a/shiny/render/_render.py
+++ b/shiny/render/_render.py
@@ -727,7 +727,7 @@ class download_button(_DownloadBase):
     def auto_output_ui(
         self,
         *,
-        width: str | None | MISSING_TYPE = MISSING,
+        width: str | MISSING_TYPE = MISSING,
     ) -> Tag:
         kwargs: dict[str, Any] = {}
         set_kwargs_value(kwargs, "width", width, self.width)
@@ -774,7 +774,7 @@ class download_link(_DownloadBase):
     def auto_output_ui(
         self,
         *,
-        width: str | None | MISSING_TYPE = MISSING,
+        width: str | MISSING_TYPE = MISSING,
     ) -> Tag:
         kwargs: dict[str, Any] = {}
         set_kwargs_value(kwargs, "width", width, self.width)

--- a/shiny/render/_render.py
+++ b/shiny/render/_render.py
@@ -43,7 +43,7 @@ __all__ = (
     "image",
     "table",
     "ui",
-    # "download" is re-added in Task 2 when the deprecated `download` class returns.
+    "download",
     "download_button",
     "download_link",
 )
@@ -778,3 +778,50 @@ class download_link(_DownloadBase):
         kwargs: dict[str, Any] = {}
         set_kwargs_value(kwargs, "width", width, self.width)
         return _ui.download_link(self.output_id, label=self.label, **kwargs)
+
+
+@add_example(example_name="download")
+class download(download_button):
+    """
+    Deprecated. Use :class:`~shiny.render.download_button` (or
+    :class:`~shiny.render.download_link`) instead.
+
+    See Also
+    --------
+    * :class:`~shiny.render.download_button`
+    * :class:`~shiny.render.download_link`
+    """
+
+    def __init__(
+        self,
+        fn: Optional[DownloadHandler] = None,
+        *,
+        filename: Optional[str | Callable[[], str]] = None,
+        media_type: None | str | Callable[[], str] = None,
+        encoding: str = "utf-8",
+        label: TagChild = "Download",
+        width: str | None = None,
+    ) -> None:
+        # Local import to avoid a circular import: shiny/_deprecated.py imports
+        # `shiny.render`, which imports this module.
+        from .._deprecated import warn_deprecated
+
+        warn_deprecated(
+            "render.download is deprecated. Use render.download_button "
+            "(or render.download_link) instead.",
+            stacklevel=3,
+        )
+        # Call `super().__init__()` without `fn` (and invoke `self(fn)` ourselves
+        # below) so that the call stack depth seen by `validate_no_params()` (in
+        # `_DownloadBase.__call__()`) matches that of `download_button`/
+        # `download_link`, keeping its `stacklevel`-based warnings pointed at the
+        # user's code instead of this subclass's `__init__`.
+        super().__init__(
+            filename=filename,
+            media_type=media_type,
+            encoding=encoding,
+            label=label,
+            width=width,
+        )
+        if fn is not None:
+            self(fn)

--- a/shiny/render/_render.py
+++ b/shiny/render/_render.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Union, cast
 
 from htmltools import Tag, TagAttrValue, TagChild
 
+from ._data_frame import data_frame as _data_frame
 from ._data_frame_utils._tbl_data import as_data_frame
 from ._data_frame_utils._types import IntoDataFrame
 
@@ -825,3 +826,35 @@ class download(download_button):
         )
         if fn is not None:
             self(fn)
+
+
+# --------------------------------------------------------------------------------------
+# Render ↔ UI 1:1 mapping (verified by tests/pytest/test_express_ui.py)
+# --------------------------------------------------------------------------------------
+
+# Maps each output render decorator to the UI component it pairs 1:1 with.
+_renderer_output_ui_pairs: dict[type[Renderer[Any]], Callable[..., Tag]] = {
+    text: _ui.output_text,
+    code: _ui.output_code,
+    plot: _ui.output_plot,
+    image: _ui.output_image,
+    table: _ui.output_table,
+    ui: _ui.output_ui,
+    _data_frame: _ui.output_data_frame,
+    download_button: _ui.download_button,
+    download_link: _ui.download_link,
+}
+
+# Deliberate exceptions to the render↔ui 1:1 mapping.
+_known_missing_renderer: dict[str, tuple[str, ...]] = {
+    # Renderers (in shiny.render.__all__) with no 1:1 output UI component.
+    "shiny.render": (
+        "express",  # meta-renderer (Renderer[None]); no paired UI component
+        "download",  # deprecated alias of download_button
+    ),
+    # Output UI components (in shiny.ui.__all__) with no 1:1 renderer.
+    "shiny.ui": (
+        "output_text_verbatim",  # legacy alias of output_code
+        "output_markdown_stream",  # class-based (ui.MarkdownStream)
+    ),
+}

--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -563,7 +563,7 @@ class Session(ABC):
         encoding: str = "utf-8",
     ) -> Callable[[DownloadHandler], None]:
         """
-        Deprecated. Please use :class:`~shiny.render.download` instead.
+        Deprecated. Please use :class:`~shiny.render.download_button` instead.
 
         Parameters
         ----------
@@ -1216,7 +1216,7 @@ class AppSession(Session):
                                 warnings.warn(
                                     "Unable to infer a filename for the "
                                     f"'{download_id}' download handler; please use "
-                                    "@render.download(filename=) to specify one "
+                                    "@render.download_button(filename=) to specify one "
                                     "manually",
                                     SessionWarning,
                                     stacklevel=2,
@@ -1578,7 +1578,7 @@ class AppSession(Session):
         encoding: str = "utf-8",
     ) -> Callable[[DownloadHandler], None]:
         warn_deprecated(
-            "session.download() is deprecated. Please use render.download() instead."
+            "session.download() is deprecated. Please use render.download_button() instead."
         )
 
         def wrapper(fn: DownloadHandler):

--- a/shiny/ui/_download_button.py
+++ b/shiny/ui/_download_button.py
@@ -41,7 +41,7 @@ def download_button(
 
     See Also
     --------
-    * :class:`~shiny.render.download`
+    * :class:`~shiny.render.download_button`
     * :func:`~shiny.ui.download_link`
     """
 
@@ -97,7 +97,7 @@ def download_link(
 
     See Also
     --------
-    * :class:`~shiny.render.download`
+    * :class:`~shiny.render.download_link`
     * :func:`~shiny.ui.download_button`
     """
 

--- a/tests/playwright/shiny/bugs/0696-resolve-id/app.py
+++ b/tests/playwright/shiny/bugs/0696-resolve-id/app.py
@@ -256,7 +256,7 @@ def mod_x_server(
 
     download_button_count = 0
 
-    @render.download(filename=lambda: f"download_button-{session.ns}.csv")
+    @render.download_button(filename=lambda: f"download_button-{session.ns}.csv")
     async def download_button():
         nonlocal download_button_count
         download_button_count += 1
@@ -265,7 +265,7 @@ def mod_x_server(
 
     download_link_count = 0
 
-    @render.download(filename=lambda: f"download_link-{session.ns}.csv")
+    @render.download_button(filename=lambda: f"download_link-{session.ns}.csv")
     async def download_link():
         nonlocal download_link_count
         download_link_count += 1

--- a/tests/playwright/shiny/components/download_button/app.py
+++ b/tests/playwright/shiny/components/download_button/app.py
@@ -39,7 +39,7 @@ def server(input: Inputs, output: Outputs, session: Session) -> None:
         nonlocal inventory_total
         inventory_total += 1
 
-    @render.download(filename=lambda: f"plain-{plain_total + 1}.csv")
+    @render.download_button(filename=lambda: f"plain-{plain_total + 1}.csv")
     async def plain_csv():
         nonlocal plain_total
         plain_total += 1
@@ -48,7 +48,7 @@ def server(input: Inputs, output: Outputs, session: Session) -> None:
         yield "kind,inventory,count\n"
         yield f"plain,{current_inventory},{current_plain}\n"
 
-    @render.download(
+    @render.download_button(
         filename=lambda: f"styled-{inventory_total}-{styled_total + 1}.csv"
     )
     async def styled_csv():

--- a/tests/playwright/shiny/components/download_link/app.py
+++ b/tests/playwright/shiny/components/download_link/app.py
@@ -71,7 +71,7 @@ def server(input: Inputs, output: Outputs, session: Session) -> None:
         include_summary()
         sync_controls()
 
-    @render.download(filename=lambda: f"{current_prefix}-plain.txt")
+    @render.download_link(filename=lambda: f"{current_prefix}-plain.txt")
     async def plain_link():
         nonlocal plain_total
         plain_total += 1
@@ -82,7 +82,7 @@ def server(input: Inputs, output: Outputs, session: Session) -> None:
         if include_footer:
             yield "Summary: plain link\n"
 
-    @render.download(filename=lambda: f"{current_prefix}-styled.csv")
+    @render.download_link(filename=lambda: f"{current_prefix}-styled.csv")
     async def styled_link():
         nonlocal styled_total
         styled_total += 1

--- a/tests/pytest/test_express_ui.py
+++ b/tests/pytest/test_express_ui.py
@@ -16,17 +16,17 @@ from shiny.express._run import run_express
 def test_express_ui_is_complete():
     """
     Make sure shiny.express.ui covers everything that shiny.ui does, or explicitly lists
-    the item in `_known_missing`.
-    These entries are in `_known_missing` in shiny/express/ui/__init__.py
+    the item in `_known_missing_express_ui`.
+    These entries are in `_known_missing_express_ui` in shiny/express/ui/__init__.py
     """
 
     ui_all = set(ui.__all__)
     xui_all = set(xui.__all__)
-    ui_known_missing = set(xui._known_missing["shiny.ui"])
-    xui_known_missing = set(xui._known_missing["shiny.express.ui"])
+    ui_known_missing = set(xui._known_missing_express_ui["shiny.ui"])
+    xui_known_missing = set(xui._known_missing_express_ui["shiny.express.ui"])
 
     # Make sure that there's no overlap between shiny.express.ui.__all__ and
-    # _known_missing["shiny.ui"]; and same for other combinations. Note that the use of
+    # _known_missing_express_ui["shiny.ui"]; and same for other combinations. Note that the use of
     # `.intersection() == set()` instead of `disjoint()` is intentional, because if the
     # test fails, the first form provides an error message that shows the difference,
     # while the second form does note.
@@ -39,7 +39,7 @@ def test_express_ui_is_complete():
     assert ui_known_missing.difference(ui_all) == set()
 
     # Make sure that everything from shiny.ui is either exported by shiny.express.ui, or
-    # explicitly listed in shiny.express.ui._known_missing.
+    # explicitly listed in shiny.express.ui._known_missing_express_ui.
     assert ui_all.union(xui_known_missing) == xui_all.union(ui_known_missing)
 
 

--- a/tests/pytest/test_express_ui.py
+++ b/tests/pytest/test_express_ui.py
@@ -71,6 +71,24 @@ def test_render_output_controls():
     with pytest.raises(TypeError, match="width"):
         code2.tagify()
 
+    @render.download_button
+    def dl_btn():
+        yield "data"
+
+    assert (
+        ui.TagList(dl_btn.tagify()).get_html_string()
+        == ui.download_button("dl_btn", label="Download").get_html_string()
+    )
+
+    @render.download_link
+    def dl_link():
+        yield "data"
+
+    assert (
+        ui.TagList(dl_link.tagify()).get_html_string()
+        == ui.download_link("dl_link", label="Download").get_html_string()
+    )
+
 
 def test_hold():
     old_displayhook = sys.displayhook

--- a/tests/pytest/test_express_ui.py
+++ b/tests/pytest/test_express_ui.py
@@ -90,6 +90,64 @@ def test_render_output_controls():
     )
 
 
+def test_render_output_controls_complete():
+    """
+    Enforce the 1:1 mapping between output render decorators and output UI components.
+    A new output renderer or output UI component that is not paired (and not explicitly
+    allowlisted in `_known_missing_renderer`) fails this test.
+    """
+    import inspect
+
+    from shiny.render._render import (
+        _known_missing_renderer,
+        _renderer_output_ui_pairs,
+    )
+    from shiny.render.renderer import Renderer
+
+    # (1) Every mapped renderer's auto-placed UI matches its UI component's HTML.
+    for renderer_cls, ui_fn in _renderer_output_ui_pairs.items():
+        fn_name = renderer_cls.__name__
+
+        @renderer_cls
+        def out():
+            yield "x"
+
+        rendered = ui.TagList(out.tagify()).get_html_string()
+        # Some UI components (e.g. download_button/download_link) have a required
+        # `label` parameter with no default; auto_output_ui() supplies the renderer's
+        # own default ("Download") for it, so mirror that here for a fair comparison.
+        ui_fn_kwargs: dict[str, Any] = {}
+        ui_fn_sig = inspect.signature(ui_fn)
+        if (
+            "label" in ui_fn_sig.parameters
+            and ui_fn_sig.parameters["label"].default is inspect.Parameter.empty
+        ):
+            ui_fn_kwargs["label"] = "Download"
+        expected = ui.TagList(ui_fn("out", **ui_fn_kwargs)).get_html_string()
+        assert rendered == expected, f"{fn_name} auto_output_ui mismatch"
+
+    # (2) Every Renderer subclass exported by shiny.render is mapped or allowlisted.
+    mapped_renderers = {cls.__name__ for cls in _renderer_output_ui_pairs}
+    allowed_renderers = set(_known_missing_renderer["shiny.render"])
+    for name in render.__all__:
+        obj = getattr(render, name)
+        if inspect.isclass(obj) and issubclass(obj, Renderer):
+            assert name in mapped_renderers or name in allowed_renderers, (
+                f"render.{name} is a Renderer with no paired UI component; "
+                f"add it to _renderer_output_ui_pairs or _known_missing_renderer"
+            )
+
+    # (3) Every output_*/download_* UI component is a mapping target or allowlisted.
+    mapped_ui = {fn.__name__ for fn in _renderer_output_ui_pairs.values()}
+    allowed_ui = set(_known_missing_renderer["shiny.ui"])
+    for name in ui.__all__:
+        if name.startswith("output_") or name.startswith("download_"):
+            assert name in mapped_ui or name in allowed_ui, (
+                f"ui.{name} is an output component with no paired renderer; "
+                f"add it to _renderer_output_ui_pairs or _known_missing_renderer"
+            )
+
+
 def test_hold():
     old_displayhook = sys.displayhook
     try:

--- a/tests/pytest/test_express_ui.py
+++ b/tests/pytest/test_express_ui.py
@@ -93,20 +93,64 @@ def test_render_output_controls():
 def test_render_output_controls_complete():
     """
     Enforce the 1:1 mapping between output render decorators and output UI components.
-    A new output renderer or output UI component that is not paired (and not explicitly
-    allowlisted in `_known_missing_renderer`) fails this test.
+
+    The pairing is by naming convention: ``ui.output_<name>`` pairs with
+    ``render.<name>``. A new ``ui.output_*`` component with no matching renderer -- or a
+    new renderer with no matching UI component -- fails this test unless it is
+    explicitly allowlisted below. Renderers whose UI component does not follow the
+    ``output_`` convention (e.g. the download renderers) are listed in
+    ``renderer_ui_pairs``.
     """
     import inspect
 
-    from shiny.render._render import (
-        _known_missing_renderer,
-        _renderer_output_ui_pairs,
-    )
     from shiny.render.renderer import Renderer
 
-    # (1) Every mapped renderer's auto-placed UI matches its UI component's HTML.
-    for renderer_cls, ui_fn in _renderer_output_ui_pairs.items():
-        fn_name = renderer_cls.__name__
+    # Renderers (in shiny.render.__all__) that deliberately have no paired UI component.
+    known_missing_renderers = {
+        "express",  # meta-renderer (Renderer[None]); no paired UI component
+        "download",  # deprecated alias of download_button
+    }
+    # output_* UI components (in shiny.ui.__all__) that deliberately have no renderer.
+    known_missing_output_ui = {
+        "output_text_verbatim",  # legacy alias of output_code
+        "output_markdown_stream",  # class-based (ui.MarkdownStream)
+    }
+    # Renderers whose UI component does not follow the `output_<name>` convention.
+    # Maps renderer name -> ui function name.
+    renderer_ui_pairs = {
+        "download_button": "download_button",
+        "download_link": "download_link",
+    }
+
+    # Renderer subclasses exported by shiny.render, keyed by their export name.
+    render_classes: dict[str, type[Renderer[Any]]] = {}
+    for name in render.__all__:
+        obj = getattr(render, name)
+        if inspect.isclass(obj) and issubclass(obj, Renderer):
+            render_classes[name] = obj
+
+    # (1) Fail-safe: every `ui.output_*` component must have a corresponding renderer
+    #     (by convention `output_<name>` -> `render.<name>`), unless allowlisted.
+    for name in ui.__all__:
+        if not name.startswith("output_") or name in known_missing_output_ui:
+            continue
+        renderer_name = name[len("output_") :]
+        assert renderer_name in render_classes, (
+            f"ui.{name} has no corresponding render.{renderer_name}; add the renderer "
+            f"or allowlist ui.{name} in known_missing_output_ui"
+        )
+
+    # (2) Every renderer must map to a UI component, and its auto-placed UI must match
+    #     that component's HTML, unless the renderer is allowlisted.
+    for name, renderer_cls in render_classes.items():
+        if name in known_missing_renderers:
+            continue
+        ui_fn_name = renderer_ui_pairs.get(name, f"output_{name}")
+        ui_fn = getattr(ui, ui_fn_name, None)
+        assert ui_fn is not None, (
+            f"render.{name} expects ui.{ui_fn_name}, which does not exist; add the UI "
+            f"component, list the pair in renderer_ui_pairs, or allowlist the renderer"
+        )
 
         @renderer_cls
         def out():
@@ -124,28 +168,7 @@ def test_render_output_controls_complete():
         ):
             ui_fn_kwargs["label"] = "Download"
         expected = ui.TagList(ui_fn("out", **ui_fn_kwargs)).get_html_string()
-        assert rendered == expected, f"{fn_name} auto_output_ui mismatch"
-
-    # (2) Every Renderer subclass exported by shiny.render is mapped or allowlisted.
-    mapped_renderers = {cls.__name__ for cls in _renderer_output_ui_pairs}
-    allowed_renderers = set(_known_missing_renderer["shiny.render"])
-    for name in render.__all__:
-        obj = getattr(render, name)
-        if inspect.isclass(obj) and issubclass(obj, Renderer):
-            assert name in mapped_renderers or name in allowed_renderers, (
-                f"render.{name} is a Renderer with no paired UI component; "
-                f"add it to _renderer_output_ui_pairs or _known_missing_renderer"
-            )
-
-    # (3) Every output_*/download_* UI component is a mapping target or allowlisted.
-    mapped_ui = {fn.__name__ for fn in _renderer_output_ui_pairs.values()}
-    allowed_ui = set(_known_missing_renderer["shiny.ui"])
-    for name in ui.__all__:
-        if name.startswith("output_") or name.startswith("download_"):
-            assert name in mapped_ui or name in allowed_ui, (
-                f"ui.{name} is an output component with no paired renderer; "
-                f"add it to _renderer_output_ui_pairs or _known_missing_renderer"
-            )
+        assert rendered == expected, f"render.{name} auto_output_ui mismatch"
 
 
 def test_hold():

--- a/tests/pytest/test_renderer.py
+++ b/tests/pytest/test_renderer.py
@@ -152,8 +152,10 @@ def test_download_warning_stacklevel_points_to_caller():
         def my_download(x: str = "file.txt") -> str:
             return x
 
-    assert len(w) == 1
-    assert w[0].filename == __file__
+    # `render.download` now also emits its own deprecation warning (in addition to
+    # the default-params warning), so both warnings should point to the caller.
+    assert len(w) == 2
+    assert all(warning.filename == __file__ for warning in w)
 
 
 def test_effect():
@@ -163,3 +165,13 @@ def test_effect():
         @render.text
         def my_output():
             return "42"
+
+
+def test_render_download_is_deprecated():
+    from shiny._deprecated import ShinyDeprecationWarning
+
+    with pytest.warns(ShinyDeprecationWarning, match="render.download_button"):
+
+        @render.download
+        def dl():
+            yield "data"


### PR DESCRIPTION
## Summary

Adds `@render.download_button` and `@render.download_link` output renderers that pair 1:1 with `ui.download_button()` / `ui.download_link()`, and soft-deprecates `@render.download`.

- A private `_DownloadBase(Renderer[str])` holds all shared download logic (the `url()` value-function swap and `session._downloads` registration). `download_button` and `download_link` subclass it and differ only in `auto_output_ui`.
- `render.download` becomes a thin deprecated subclass of `download_button` — still fully functional, but emits a `ShinyDeprecationWarning` on construction pointing to `render.download_button`.
- Express gets the new renderers automatically (`shiny.express.render is shiny.render`). The `download_link` Express example no longer needs the `ui.hold()` workaround.

## Render ↔ UI 1:1 invariant

Adds `test_render_output_controls_complete`, backed by `_renderer_output_ui_pairs` and `_known_missing_renderer` in `shiny/render/_render.py`. A future output renderer or `output_*`/`download_*` UI component that isn't paired (and isn't explicitly allowlisted) now fails this test. Also renames the express-ui allowlist `_known_missing` → `_known_missing_express_ui` to disambiguate.

## Also included

- quartodoc registration (core + express) and `See Also` cross-refs for the new renderers.
- Migrated all api-examples, the `examples/annotation-export` app, and the download Playwright test apps off `@render.download`.
- Updated user-facing `session.download()` / download messages in `shiny/session/_session.py` to point at `render.download_button`.
- CHANGELOG: New features + Deprecations entries.

## Test plan

- [x] `pytest tests/pytest/test_express_ui.py tests/pytest/test_renderer.py` — 19 passing (incl. new completeness + deprecation tests).
- [x] black / isort / flake8 clean.
- [ ] pyright (`make check-types`) — verified by CI (local sandbox lacks generated `typings/`).
- [ ] Download Playwright suites — verified by CI.

## Follow-ups (separate PRs, after merge)

- py-shiny-template — migrate `render.download` → `render.download_button`/`link`.
- py-shiny-site — migrate docs/examples to the new renderer names.

> Note: replace the `(#<PR>)` placeholders in `CHANGELOG.md` with this PR's number.