### PR TITLE
feat: Add bundled Agent Skills for shiny's public APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added an `otel` Agent Skill (under `shiny/.agents/skills/`) that teaches coding agents to observe Shiny apps with OpenTelemetry: zero-code auto-instrumentation via `opentelemetry-instrument shiny run`, collection levels with `SHINY_OTEL_COLLECT`, per-object control with `otel.suppress`/`otel.collect`, and exporting to OTLP backends. (#2356)
 
+* Added 17 more bundled Agent Skills (under `shiny/.agents/skills/`) that document shiny's public APIs for coding agents, joining the existing `debugging`, `testing`, `bookmarking`, and `otel` skills: (#2365)
+  * Core concepts: `reactivity` (the reactive graph — `reactive.value`/`calc`/`effect`/`event`, `req`, `isolate`, `poll`), `express` (Express mode), and `modules-core` / `modules-express` (reusable namespaced components).
+  * Layout and UI: `layouts` (pages, cards, sidebars, columns, value boxes), `navigation` (navsets and `page_navbar`), `dynamic-ui` (`@render.ui`, `update_*`, `insert_ui`, `panel_conditional`), and `theming` (`ui.Theme`, presets, dark mode).
+  * Outputs and generative AI: `data-frames` (`render.data_frame`), `plots` (`render.plot`/`render.image` and interactions), `chat` (`ui.Chat`), and `markdown-streaming` (`ui.MarkdownStream`).
+  * App capabilities: `files` (upload/download), `feedback` (notifications, modals, progress, busy indicators), `extended-tasks` (non-blocking long-running work), and `session-lifecycle` (`on_ended`/`on_flush`, request info, dynamic routes).
+  * Extending shiny: `custom-components` (custom JavaScript input/output bindings) and `custom-renderers` (authoring a `Renderer` subclass).
+
 * Added `offcanvas()` for creating sliding Bootstrap Offcanvas panels that appear from a viewport edge. Panels can be triggered by a UI element, revealed programmatically with `show_offcanvas()`, or controlled by id with `hide_offcanvas()` and `toggle_offcanvas()`. (#2279)
 
 ### Improvements

--- a/shiny/.agents/skills/chat/SKILL.md
+++ b/shiny/.agents/skills/chat/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: chat
+description: Covers building an LLM chatbot interface in Shiny for Python with `ui.Chat` - rendering the chat, handling user submissions, and streaming model responses. Use when building an AI chatbot or LLM chat interface, wiring a provider (chatlas / OpenAI / Anthropic / LangChain / Ollama) into a Shiny app, streaming model output token-by-token, seeding or reactively reading chat history, transforming or guard-railing user input, or when tempted to hand-roll a message list with text inputs and manual output updates.
+---
+
+# Building chatbots with `ui.Chat`
+
+## Overview
+
+`ui.Chat` is a complete conversational UI: a scrolling transcript, a
+markdown-rendering message area, and a submit box. You create one `Chat`,
+render it, register an `@chat.on_user_submit` callback, and append responses.
+Do NOT build a chat out of `input_text_area` + `output_ui` + manual state — the
+component handles streaming, markdown, loading indicators, and cancellation for
+you.
+
+All response methods are async; write async callbacks and `await` them.
+
+## Minimal app (echo bot)
+
+```python
+from shiny.express import ui
+
+ui.page_opts(title="Hello Chat", fillable=True)
+
+chat = ui.Chat(id="chat")
+chat.ui(messages=["Hi! Send a message and I'll echo it."])
+
+
+@chat.on_user_submit
+async def handle(user_input: str):
+    await chat.append_message(f"You said: {user_input}")
+```
+
+In **Shiny Core**, place `ui.chat_ui("chat")` in the UI and create
+`chat = ui.Chat(id="chat")` inside `server` — the `id=` must match.
+
+## Stream a response
+
+Prefer streaming: it is more responsive and is the real-world path for LLMs.
+`append_message_stream()` takes an (async) iterable of chunks. Each chunk is a
+markdown string (or a `{"content": ..., "role": "assistant"}` dict):
+
+```python
+import asyncio
+from shiny.express import ui
+
+chat = ui.Chat(id="chat")
+chat.ui()
+
+
+@chat.on_user_submit
+async def handle(user_input: str):
+    async def response():
+        for word in ["Thinking", " ", "about", " ", user_input]:
+            yield word
+            await asyncio.sleep(0.1)
+
+    await chat.append_message_stream(response())
+```
+
+## Connect an LLM provider
+
+Any provider works; [chatlas](https://posit-dev.github.io/chatlas/) is the
+recommended wrapper. Passing `client=` auto-wires an `on_user_submit` handler
+that streams the reply and tracks conversation history for you — no callback
+needed:
+
+```python
+import os
+from chatlas import ChatOpenAI
+from shiny.express import ui
+
+chat_client = ChatOpenAI(
+    api_key=os.environ["OPENAI_API_KEY"],
+    model="gpt-4o",
+    system_prompt="You are a helpful assistant.",
+)
+
+ui.page_opts(title="Assistant", fillable=True)
+chat = ui.Chat(id="chat", client=chat_client)
+chat.ui()
+```
+
+Swap `ChatOpenAI` for `ChatAnthropic`, `ChatGoogle`, `ChatOllama`, etc. To keep
+control of the callback (custom logic, non-chatlas provider), omit `client=` and
+stream manually — `stream_async()` returns an async iterable:
+
+```python
+@chat.on_user_submit
+async def handle(user_input: str):
+    response = await chat_client.stream_async(user_input)
+    await chat.append_message_stream(response)
+```
+
+## Seed and read message history
+
+- **Startup messages:** pass `messages=` to `chat.ui(...)` (Express) or
+  `ui.chat_ui(...)` (Core). Use `greeting=` for a welcome shown before any
+  conversation.
+- **Read the transcript reactively:** `chat.messages()` returns a tuple of
+  `{"content", "role"}` dicts, oldest first (last item is the newest user
+  message). Call it inside a reactive context / callback:
+
+```python
+@chat.on_user_submit
+async def handle(user_input: str):
+    history = chat.messages()  # e.g. feed to a provider that needs full context
+    await chat.append_message_stream(my_model(history))
+```
+
+With `client=`, chatlas keeps its own history — you rarely need `messages()`.
+
+## Guardrails and markdown
+
+Transform or validate user input **inside** `on_user_submit` before sending it
+to the model (the old `transform_user_input` hook was removed):
+
+```python
+@chat.on_user_submit
+async def handle(user_input: str):
+    if "forbidden" in user_input.lower():
+        await chat.append_message("Sorry, I can't help with that.")
+        return
+    await chat.append_message_stream(chat_client.stream_async(user_input))
+```
+
+Response strings are rendered as **markdown** automatically. To insert raw HTML
+verbatim (skip markdown), wrap it: `await chat.append_message(ui.HTML(html))`.
+
+For streaming markdown *outside* a chat (e.g. a report that types out), use the
+separate `ui.MarkdownStream` / `ui.output_markdown_stream` component instead.
+
+## Quick reference
+
+| Need | API |
+|---|---|
+| Create chat | `ui.Chat(id, client=None, greeting=None)` |
+| Render (Express / Core) | `chat.ui(messages=..., greeting=...)` / `ui.chat_ui(id, ...)` |
+| Handle submissions | `@chat.on_user_submit` (callback takes `user_input: str`, optional `attachments`) |
+| Append full message | `await chat.append_message(msg)` |
+| Stream a message | `await chat.append_message_stream(async_iterable)` |
+| Read transcript | `chat.messages()` (reactive) |
+| Latest user input | `chat.user_input()` |
+| Prefill / submit input box | `chat.update_user_input(value=..., submit=True)` |
+| Clear transcript | `await chat.clear_messages()` |
+| File uploads | `chat.ui(allow_attachments=True)` -> handler's 2nd arg |
+| Bookmark state | `chat.enable_bookmarking(chat_client, bookmark_store="url")` |
+
+## Common mistakes
+
+- Core `id=` on `ui.Chat` not matching `ui.chat_ui("...")` -> chat never wires
+  up. They must be identical.
+- Using `append_message()` for a streamed/generator response -> use
+  `append_message_stream()`; reserve `append_message()` for a complete string.
+- Sync callback or forgetting `await` -> responses never appear. Callbacks are
+  async and every append/stream call must be awaited.
+- Passing `messages=` to `ui.Chat(...)` -> deprecated; pass it to `chat.ui(...)`.
+- Expecting `client=` and a manual `on_user_submit` to conflict -> they don't;
+  your handler runs *in addition* to the auto-wired streaming handler.
+- Reaching for `transform_user_input` / `transform_assistant_response` -> both
+  are removed/deprecated; transform input in the callback and post-process
+  response strings before appending.

--- a/shiny/.agents/skills/custom-components/SKILL.md
+++ b/shiny/.agents/skills/custom-components/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: custom-components
+description: Covers integrating custom browser JavaScript with Shiny for Python (py-shiny) - shipping component JS/CSS via an htmltools.HTMLDependency, writing custom input and output bindings against Shiny's client-side registries, reading custom inputs with Shiny.setInputValue, and pushing data from the server with session.send_custom_message. Use when integrating a third-party JavaScript widget or web component, building a custom input or output binding, sending messages from the server to browser JS, shipping component assets from a www/ folder, or when tempted to inject <script> tags ad hoc, poll the DOM, or manipulate elements outside Shiny's binding system.
+---
+
+# Custom JavaScript components in Shiny for Python
+
+## Overview
+
+Shiny apps talk to the browser over a WebSocket. Instead of hand-wiring that
+channel, register your JavaScript with Shiny's client-side registries
+(`Shiny.inputBindings`, `Shiny.outputBindings`) or its message bus
+(`Shiny.addCustomMessageHandler`). Shiny then handles serialization, initial
+values, reconnects, and namespacing for you.
+
+Do NOT reach into `#id` elements from stray `<script>` tags, poll the DOM, or
+open your own socket. Ship assets through an `HTMLDependency` (never a bare
+`<script src>` pointing outside the app) so ordering and deduplication work. For
+pure-Python dynamic UI use the dynamic-ui skill; to wrap an existing Jupyter
+widget use shinywidgets (external) rather than writing a binding by hand.
+
+## Ship a component's JS/CSS
+
+Put files in a `www/` folder and register them as one dependency. Attaching the
+dependency to any `Tag` (or returning it from the UI) injects the assets once,
+in order.
+
+```python
+from pathlib import Path
+from htmltools import HTMLDependency
+from shiny import ui
+
+my_dep = HTMLDependency(
+    "my-widget",          # unique name
+    "1.0.0",              # version (used for dedup)
+    source={"subdir": str(Path(__file__).parent / "www")},
+    script={"src": "my-widget.js"},        # or {"src": "index.js", "type": "module"}
+    stylesheet={"href": "my-widget.css"},
+)
+
+app_ui = ui.page_fluid(
+    my_dep,
+    ui.div(id="clock", class_="my-widget"),
+)
+```
+
+## Custom input
+
+Give the element an `id`, then tell Shiny its value with
+`Shiny.setInputValue("id", value)`. The server reads it as `input.id()`.
+
+```js
+// www/my-widget.js
+const el = document.getElementById("counter");
+let n = 0;
+el.addEventListener("click", () => {
+  n += 1;
+  Shiny.setInputValue("counter", n);   // id must match input.counter()
+});
+```
+
+For a reusable element type, register an input binding so Shiny finds every
+instance, restores values, and namespaces ids inside modules:
+
+```js
+class CounterBinding extends Shiny.InputBinding {
+  find(scope) { return scope.querySelectorAll(".my-counter"); }
+  getValue(el) { return Number(el.dataset.value || 0); }
+  subscribe(el, callback) {
+    el.addEventListener("click", () => callback(true));  // callback() -> re-read getValue
+  }
+  unsubscribe(el) { el.replaceWith(el.cloneNode(true)); }
+}
+Shiny.inputBindings.register(new CounterBinding(), "my.counter");
+```
+
+Read it on the server like any input: `input.counter()`. Pass `resolve_id(id)`
+(from `shiny.module`) when building the UI so bindings work inside modules.
+
+## Custom output
+
+Emit an output placeholder, then register an output binding whose
+`renderValue(el, data)` receives whatever the server's renderer returns.
+
+```python
+# server
+from shiny import render
+@render.text          # or a custom Renderer; payload must be JSON-serializable
+def clock():
+    return time.strftime("%H:%M:%S")
+```
+
+```js
+class ClockBinding extends Shiny.OutputBinding {
+  find(scope) { return scope.querySelectorAll(".my-clock"); }
+  renderValue(el, data) { el.textContent = data; }   // data = server payload
+}
+Shiny.outputBindings.register(new ClockBinding(), "my.clock");
+```
+
+The placeholder element's `id` must match the render function name; give it the
+class your `find()` selects (e.g. `ui.div(id="clock", class_="my-clock")`).
+
+## Server to client messages
+
+For updates that are not tied to an output, push a typed message and handle it
+in JS. This is the general server-initiated channel.
+
+```python
+# server
+@reactive.effect
+@reactive.event(input.go)
+async def _():
+    await session.send_custom_message("flash", {"text": "hi"})
+```
+
+```js
+Shiny.addCustomMessageHandler("flash", (msg) => {   // type must match
+  document.getElementById("banner").textContent = msg.text;
+});
+```
+
+`send_custom_message` is async - `await` it (or call from an async effect). To
+run code right before/after values are sent to the client, use
+`@session.on_flush` / `@session.on_flushed` (see the session-lifecycle skill).
+
+## Quick reference
+
+| Need | Python | JavaScript |
+|---|---|---|
+| Ship JS/CSS | `HTMLDependency(name, ver, source=..., script=..., stylesheet=...)` | files in `www/` |
+| Read a value from JS | `input.id()` | `Shiny.setInputValue("id", value)` |
+| Reusable input type | UI tag with `id`/class | `Shiny.inputBindings.register(new Shiny.InputBinding(), "ns.name")` |
+| Push to an output | `@render.*` returning JSON | `Shiny.outputBindings.register(new Shiny.OutputBinding(), "ns.name")` |
+| One-off server->client | `await session.send_custom_message(type, msg)` | `Shiny.addCustomMessageHandler(type, fn)` |
+| Namespace ids (modules) | `resolve_id(id)` | handled by binding `find()` |
+
+## Common mistakes
+
+- Bare `<script src>` or CDN tag instead of an `HTMLDependency` -> assets load
+  out of order or twice, and break inside modules. Always use a dependency.
+- Output placeholder `id` or class doesn't match the render name / binding
+  `find()` -> `renderValue` never fires. Keep id == function name and class ==
+  selector.
+- `send_custom_message` called without `await` -> message never sent (it
+  returns a coroutine). Await it in an async effect.
+- Message `type` / handler name mismatch -> silently dropped. They must be
+  identical strings.
+- Hardcoded ids inside a module -> collisions. Wrap ids with `resolve_id()`;
+  input/output bindings namespace automatically via `find()`.
+- Reading `input.id()` before JS has ever called `setInputValue` -> value is
+  `None`; guard with `req(input.id())` (reactivity skill).
+- Need a build step (TypeScript, Lit, React)? Start from the `shiny create`
+  custom-component templates rather than hand-rolling the toolchain.
+```

--- a/shiny/.agents/skills/custom-renderers/SKILL.md
+++ b/shiny/.agents/skills/custom-renderers/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: custom-renderers
+description: Covers authoring a reusable output renderer in Shiny for Python (py-shiny) by subclassing shiny.render.renderer.Renderer - turning a Python return value into a JSON-serializable client payload, supplying an auto_output_ui() so it works in both Core and Express, and accepting decorator arguments. Use when creating a reusable @render.xxx output decorator, subclassing shiny.render.renderer.Renderer, implementing transform()/render(), turning a Python value into a custom client payload/output, making one output work in both Core and Express, reaching for the deprecated output_transformer/OutputRenderer, or when tempted to hand-roll rendering logic inside every @render.ui or duplicate output-formatting code across apps.
+---
+
+# Authoring custom output renderers in Shiny for Python
+
+## Overview
+
+A `Renderer` subclass packages "run this output function, turn its return
+value into a JSON-serializable payload, ship it to the browser" into a reusable
+`@render.my_thing` decorator. Subclass `shiny.render.renderer.Renderer[IT]`
+(`IT` is the type the app author's function returns) and implement two things:
+`auto_output_ui()` and either `transform()` (common) or `render()` (rare).
+
+Do NOT copy the same formatting logic into every `@render.ui`/`@render.text`
+function, and do NOT reach for `shiny.render.transformer.output_transformer` or
+`OutputRenderer` — those are **deprecated/superseded by `Renderer`**. If you
+only need custom *client* rendering (a JS widget), you still author the payload
+here; the browser side is a separate output binding — see the
+`custom-components` skill.
+
+## Subclass and transform the value
+
+Implement `async def transform(self, value)` to convert a non-`None` return
+value into a JSON-serializable object. The base `render()` calls your value
+function, short-circuits on `None` (nothing is sent), and otherwise calls
+`transform()`. `auto_output_ui()` returns the default UI placeholder.
+
+```python
+from shiny.render.renderer import Renderer, ValueFn
+from shiny.ui import output_code
+
+
+class render_upper(Renderer[str]):
+    """Render a string in upper case."""
+
+    def auto_output_ui(self):
+        return output_code(self.output_id)
+
+    async def transform(self, value: str) -> str:
+        # Only non-None values reach here; return must be JSON-serializable.
+        return str(value).upper()
+```
+
+Use it like any built-in renderer. `self.output_id` is the decorated function's
+name (no module prefix); `self.fn` is the app author's value function, always
+wrapped async.
+
+```python
+from shiny import App, ui
+
+app_ui = ui.page_fluid(ui.output_code("greeting"))
+
+def server(input, output, session):
+    @render_upper
+    def greeting():
+        return "hello"
+
+app = App(app_ui, server)
+```
+
+Implement `render()` **instead of** `transform()` only when you need full
+control (e.g. `None` should still send a payload). Never implement both.
+
+```python
+async def render(self):
+    value = await self.fn()   # None short-circuit is now YOUR responsibility
+    return {} if value is None else {"text": str(value)}
+```
+
+## Accept decorator arguments
+
+Add an `__init__` that takes the optional value function first, then keyword-only
+params. Always call `super().__init__(_fn)` last-ish and store your params. This
+enables both `@render_capitalize` and `@render_capitalize(to_case="lower")`.
+
+```python
+from typing import Literal, Optional
+from shiny.render.renderer import Renderer, ValueFn
+from shiny.ui import output_code
+
+
+class render_capitalize(Renderer[str]):
+    def auto_output_ui(self):
+        return output_code(self.output_id)
+
+    def __init__(
+        self,
+        _fn: Optional[ValueFn[str]] = None,
+        *,
+        to_case: Literal["upper", "lower"] = "upper",
+    ) -> None:
+        super().__init__(_fn)
+        self.to_case = to_case
+
+    async def transform(self, value: str) -> str:
+        return value.upper() if self.to_case == "upper" else value.lower()
+```
+
+```python
+@render_capitalize(to_case="lower")
+def title():
+    return "SHOUTING"
+```
+
+## Core vs Express, and async
+
+`auto_output_ui()` is what makes your renderer work in **Express** with no
+`ui.output_*` call — Express auto-renders it. In **Core**, add the matching
+`ui.output_*` placeholder whose id equals the function name (as in the first
+example). `auto_output_ui()` returns the output placeholder that matches your
+renderer, such as `output_code` for `render_capitalize`, or the renderer's
+corresponding `ui.output_*` content (see the custom-components skill for wiring
+a custom output binding).
+
+The app author's function may be sync **or** async — `self.fn` is always awaited,
+so `transform`/`render` are `async` and handle both. Scrub non-deterministic
+snapshot values with `self.snapshot_preprocess(fn)` (see the `testing` skill).
+
+## Quick reference
+
+| Member | Purpose |
+|---|---|
+| `class MyR(Renderer[IT])` | `IT` = type the app function returns |
+| `async def transform(self, value)` | Non-`None` value → JSON-serializable payload (common path) |
+| `async def render(self)` | Full control; you call `self.fn()` and handle `None` (rare) |
+| `def auto_output_ui(self)` | Default UI placeholder → enables Express; return `ui.output_*` |
+| `def __init__(self, _fn=None, *, ...)` | Accept decorator args; call `super().__init__(_fn)` |
+| `self.fn` | App author's value function (awaitable, `await self.fn()`) |
+| `self.output_id` | Decorated function name / `@output(id=)` (no module prefix) |
+| `self.snapshot_preprocess(fn)` | Scrub value for test snapshots only |
+
+## Common mistakes
+
+- Implementing both `transform()` and `render()` → pick one. `render()`
+  overrides the base and never calls `transform()`.
+- Returning a non-JSON object (a `Figure`, a `datetime`) from
+  `transform()` → serialization fails. Return `dict`/`list`/`str`/`int`/`None`.
+- Expecting `transform()` to run on `None` → the base `render()` short-circuits
+  first; if `None` must send something, override `render()` instead.
+- `__init__` not signed `(_fn=None, *, ...)` or not forwarding `_fn` to
+  `super().__init__(_fn)` → the bare `@render_x` (no parens) form breaks.
+- No `auto_output_ui()` → the renderer errors in Express and `tagify()` raises;
+  return a real `ui.output_*` placeholder.
+- Making `transform`/`render` sync (`def`) → they must be `async def`; `self.fn`
+  is always awaitable.
+- Reaching for `output_transformer`/`OutputRenderer` → deprecated; subclass
+  `Renderer`. Need the browser to draw a custom payload → author the payload
+  here and register the client `OutputBinding` per the `custom-components` skill.
+```

--- a/shiny/.agents/skills/data-frames/SKILL.md
+++ b/shiny/.agents/skills/data-frames/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: data-frames
+description: Covers rendering interactive data frames (grids/tables) in a Shiny for Python (py-shiny) app with @render.data_frame returning render.DataGrid or render.DataTable. Use when displaying a pandas/polars DataFrame with sorting, filtering, row/cell selection, or cell editing; reading which rows a user selected or how they sorted/filtered/edited the table; pushing selections or new data back to the grid; or when tempted to render an HTML table by hand, build a custom <table>, or poll the whole DataFrame on a timer to detect a row selection.
+---
+
+# Rendering interactive data frames in Shiny for Python
+
+## Overview
+
+Return a pandas, polars, or eager narwhals `DataFrame` from a
+`@render.data_frame`-decorated function paired with a `ui.output_data_frame(id)`
+placeholder. Wrap the frame in `render.DataGrid` or `render.DataTable` to set
+options. Do **not** hand-build an HTML `<table>` or poll the frame to detect
+interaction — selection, sorting, filtering, and edits are all reactive inputs
+you read from the renderer object.
+
+```python
+from shiny import App, render, ui
+import pandas as pd
+
+df = pd.DataFrame({"name": ["a", "b", "c"], "value": [1, 2, 3]})
+
+app_ui = ui.page_fluid(ui.output_data_frame("grid"))
+
+def server(input, output, session):
+    @render.data_frame
+    def grid():
+        return render.DataGrid(df, selection_mode="rows", filters=True)
+
+app = App(app_ui, server)
+```
+
+Returning a bare `DataFrame` is shorthand for `render.DataGrid(df)`.
+
+## DataGrid vs DataTable
+
+Identical API; they differ only in browser styling and default height. Use
+`DataGrid` for a compact, spreadsheet-like virtualized grid (default
+`height=None`, grows to fit / fills its container). Use `DataTable` for a more
+document-like table (default `height="500px"`, body scrolls).
+
+## Read the selected rows
+
+Read selection from the renderer inside another reactive. `.cell_selection()`
+returns a `CellSelection` dict with `type` (`"none"`/`"row"`/`"col"`/`"rect"`),
+`rows`, and `cols`. Simpler: `.data_view(selected=True)` returns the selected
+rows as a DataFrame (with sorting/filtering/edits already applied).
+
+```python
+@render.data_frame
+def grid():
+    return render.DataGrid(df, selection_mode="rows")
+
+@render.text
+def selected():
+    rows = grid.cell_selection()["rows"]   # tuple of row indices
+    return f"{len(rows)} rows selected"
+
+@render.data_frame
+def subset():
+    return render.DataGrid(grid.data_view(selected=True))
+```
+
+`selection_mode` is `"none"` (default, not selectable), `"row"` (one row), or
+`"rows"` (multiple).
+
+## Read sorted / filtered / edited state
+
+`.data_view()` returns the frame exactly as the user currently sees it — edits
+applied, then filtering and sorting. `.data_view_rows()` gives the visible row
+indices. `filters=True` shows per-column filter inputs; sorting works by
+clicking headers (no option needed).
+
+```python
+@render.data_frame
+def grid():
+    return render.DataGrid(df, filters=True)
+
+@render.text
+def visible_count():
+    return f"{len(grid.data_view_rows())} rows shown"
+```
+
+## Edit cells
+
+Set `editable=True`, then register a patch handler to coerce/persist each edit.
+`@<name>.set_patch_fn` handles one cell; `@<name>.set_patches_fn` handles a
+batch. A `CellPatch` is a dict with `row_index`, `column_index`, and `value`
+(a string as typed); return the processed `CellValue`.
+
+```python
+@render.data_frame
+def grid():
+    return render.DataGrid(df, editable=True)
+
+@grid.set_patch_fn
+def _(*, patch: render.CellPatch) -> render.CellValue:
+    if patch["column_index"] == 1:
+        return int(patch["value"])   # store numeric column as int
+    return patch["value"]
+```
+
+Read the edited frame with `grid.data_patched()` or `grid.data_view()`.
+
+## Style cells
+
+Pass `styles=` a style-info dict, a list of them, or a function of the frame.
+Each entry targets `rows`/`cols` (omit either to mean "all") with a `style`
+dict (kebab- or camel-cased CSS) and/or a `class` string.
+
+```python
+render.DataGrid(df, styles=[{"cols": [1], "style": {"background-color": "yellow"}}])
+```
+
+## Programmatic updates (async)
+
+From an effect, drive the grid: `await grid.update_cell_selection({"type": "row", "rows": [0, 2]})`
+(or `"all"` / `None`), `await grid.update_sort([{"col": 1, "desc": True}])`,
+`await grid.update_filter(...)`, `await grid.update_data(new_df)` (replaces data,
+drops edits, keeps sort/filter), and `await grid.update_cell_value(v, row=0, col="name")`.
+
+## Quick reference
+
+| Item | Options |
+|---|---|
+| Wrappers | `render.DataGrid` (grid, `height=None`), `render.DataTable` (table, `height="500px"`) |
+| `selection_mode` | `"none"`, `"row"`, `"rows"` |
+| Key `DataGrid`/`DataTable` args | `width`, `height`, `summary`, `filters`, `editable`, `selection_mode`, `styles` |
+| Read state | `.cell_selection()`, `.data_view(selected=...)`, `.data_view_rows()`, `.data_patched()`, `.sort()`, `.filter()` |
+| Edit hooks | `@<name>.set_patch_fn`, `@<name>.set_patches_fn` |
+| Update (async) | `.update_cell_selection()`, `.update_sort()`, `.update_filter()`, `.update_data()`, `.update_cell_value()` |
+| Raw inputs | `input.<id>_cell_selection()`, `input.<id>_data_view_rows()`, `input.<id>_column_sort()`, `input.<id>_column_filter()` |
+
+## Common mistakes
+
+- No rows ever selectable → you left `selection_mode` at its `"none"` default.
+- Reading `input.<id>_selected_rows()` → the input is `input.<id>_cell_selection()`; prefer the renderer's `.cell_selection()`.
+- Edits do nothing / aren't the right type → set `editable=True` **and** a `set_patch_fn` that returns the coerced value; `patch["value"]` arrives as a string.
+- `update_*` raising "not awaited" or silently no-op → these are async; call them with `await` inside a `@reactive.effect`.
+- Selection ignored on programmatic update → `.selection_mode` must be `"row"`/`"rows"`; `update_cell_selection` warns and clears under `"none"`.
+- Mutating `.data_view()` / `.data()` in place corrupts the source — they are shallow copies; `.copy()` before mutating.
+- Need to assert on the grid in a Playwright test → see the `testing` skill (`controller.OutputDataFrame`).

--- a/shiny/.agents/skills/dynamic-ui/SKILL.md
+++ b/shiny/.agents/skills/dynamic-ui/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: dynamic-ui
+description: Covers Shiny for Python (py-shiny) UI that changes after initial render - @render.ui / ui.output_ui to compute a chunk of UI reactively, ui.update_* to change an existing input's value/label/choices from the server, ui.insert_ui / ui.remove_ui to inject or remove arbitrary UI, and ui.panel_conditional to show/hide UI from a client-side JS condition. Use when generating UI that depends on inputs or data, populating or updating a select's choices or an input's value/label from the server, showing or hiding a section, inserting or removing controls at runtime, or when tempted to rebuild the whole page, manipulate the DOM with custom JavaScript, or hard-code every possible input state. For nav/tab insertion use the navigation skill; for cards/sidebars use layouts; for dark mode use theming.
+---
+
+# Dynamic UI in Shiny for Python (Core)
+
+## Overview
+
+UI does not have to be fixed at startup. Prefer, in order: render a reactive
+chunk with `@render.ui`; adjust an existing input in place with a `ui.update_*`
+function; and only for arbitrary, persistent injection reach for
+`ui.insert_ui` / `ui.remove_ui`. To merely show or hide static UI based on
+input values, use `ui.panel_conditional` — it runs client-side with no server
+round-trip.
+
+Do NOT rebuild the whole page, write custom JavaScript to poke the DOM, or
+hard-code every possible input state and toggle visibility by hand. Reactivity
+(`@reactive.effect`; see the reactivity skill) drives all of this.
+
+This documents the Core form. In Express mode, use `@render.express` instead of
+`@render.ui` (see the express skill); everything else below is identical.
+
+## Compute UI reactively: `@render.ui` + `ui.output_ui`
+
+The primary approach. Put an `output_ui(id)` placeholder in the UI, then a
+`@render.ui` function whose name matches the id returns any UI object. It
+re-runs whenever a reactive source it reads changes.
+
+```python
+from shiny import App, Inputs, Outputs, Session, render, ui
+
+app_ui = ui.page_fluid(
+    ui.input_select("kind", "Control", ["slider", "text"]),
+    ui.output_ui("control"),
+)
+
+def server(input: Inputs, output: Outputs, session: Session):
+    @render.ui
+    def control():
+        if input.kind() == "slider":
+            return ui.input_slider("n", "N", min=1, max=100, value=50)
+        return ui.input_text("label", "Label")
+
+app = App(app_ui, server)
+```
+
+## Update an existing input: `ui.update_*`
+
+Change a control's value, label, or choices without recreating it. Match the
+function to the input type (`update_select`, `update_text`, `update_numeric`,
+`update_slider`, `update_checkbox`, `update_date`, `update_action_button`, ...).
+**Call it inside a `@reactive.effect`** — calling `update_*` at server top level
+runs once with no dependencies and never reacts.
+
+```python
+from shiny import App, Inputs, Outputs, Session, reactive, ui
+
+app_ui = ui.page_fluid(
+    ui.input_select("country", "Country", ["US", "CA"]),
+    ui.input_select("city", "City", []),
+)
+
+def server(input: Inputs, output: Outputs, session: Session):
+    @reactive.effect
+    def _():
+        cities = {"US": ["NYC", "LA"], "CA": ["Toronto", "Montreal"]}
+        ui.update_select("city", choices=cities[input.country()])
+
+app = App(app_ui, server)
+```
+
+## Inject / remove arbitrary UI: `ui.insert_ui` / `ui.remove_ui`
+
+Use sparingly, when you need UI that persists and accumulates (e.g. a button
+that adds a new row each click). Inserted UI stays until removed — unlike
+`@render.ui`, it is not managed for you. `selector` is a jQuery/CSS selector.
+
+```python
+from shiny import App, Inputs, Outputs, Session, reactive, ui
+
+app_ui = ui.page_fluid(ui.input_action_button("add", "Add field"))
+
+def server(input: Inputs, output: Outputs, session: Session):
+    @reactive.effect
+    @reactive.event(input.add)
+    def _():
+        ui.insert_ui(
+            ui.input_text(f"txt_{input.add()}", "Enter text"),
+            selector="#add",
+            where="afterEnd",
+        )
+
+app = App(app_ui, server)
+```
+
+Remove with `ui.remove_ui(selector=...)`. Inputs are wrapped in a `<div>`, so
+target the wrapper: `ui.remove_ui("div:has(> #txt_1)")`.
+
+## Show / hide UI client-side: `ui.panel_conditional`
+
+Wrap UI in `panel_conditional(condition, ...)` where `condition` is a
+JavaScript expression over input values (e.g. `"input.show"`). Toggling is
+instant and needs no server. The UI still exists and its inputs stay
+registered when hidden.
+
+```python
+from shiny import App, Inputs, Outputs, Session, ui
+
+app_ui = ui.page_fluid(
+    ui.input_checkbox("advanced", "Show advanced", False),
+    ui.panel_conditional(
+        "input.advanced",
+        ui.input_slider("threshold", "Threshold", min=0, max=1, value=0.5),
+    ),
+)
+
+def server(input: Inputs, output: Outputs, session: Session):
+    pass
+
+app = App(app_ui, server)
+```
+
+## Quick reference
+
+| Need | Use |
+|---|---|
+| UI that depends on inputs/data | `@render.ui` + `ui.output_ui(id)` |
+| Express: same, capture syntax | `@render.express` (express skill) |
+| Change an input's value/label/choices | `ui.update_*(id, ...)` in a `@reactive.effect` |
+| Inject persistent/accumulating UI | `ui.insert_ui(ui, selector, where=)` |
+| Remove injected UI | `ui.remove_ui(selector)` |
+| Show/hide static UI, no round-trip | `ui.panel_conditional("input.x", ...)` |
+| Insert/update nav or tab panels | navigation skill (`nav_insert`, `update_navs`) |
+
+## Common mistakes
+
+- `ui.update_*` called at server top level (not in an effect) -> runs once and
+  never reacts. Wrap it in `@reactive.effect`.
+- `@render.ui` function name does not match its `ui.output_ui(id)` -> nothing
+  renders. The function name (or `@output(id=...)`) must equal the id.
+- Reaching for `insert_ui` to swap between input variants -> use `@render.ui`;
+  `insert_ui` UI accumulates and must be removed manually.
+- `remove_ui("#txt")` targets the input, not its wrapper `<div>`, and leaves the
+  label -> use a wrapper selector like `"div:has(> #txt)"`.
+- Using `panel_conditional` when the shown/hidden content depends on server-side
+  data -> that's a `@render.ui` job; `panel_conditional` only tests client-side
+  input values in JavaScript (`input.x`, `&&`, `===`), not Python.

--- a/shiny/.agents/skills/express/SKILL.md
+++ b/shiny/.agents/skills/express/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: express
+description: Covers writing Shiny for Python apps in Express mode, where top-level code in the app file is the UI and outputs are defined inline. Use when writing or converting a Shiny Express app, using `from shiny.express import input, render, ui`, laying out UI with context managers like `with ui.sidebar():`/`with ui.card():`, setting page options with `page_opts()`, reusing UI with `@expressify`, deciding between Express and Core, or when tempted to add an explicit `app_ui`/`server()` split or nest UI calls the Core way inside an Express app. (For reusable namespaced components with `@module`, use the modules-express skill.)
+---
+
+# Writing Shiny Express apps
+
+## Overview
+
+In **Express mode**, the app file *is* the app. Top-level statements build the
+UI as the file executes, and `@render.*` functions defined at the top level
+place their output where they are written. There is no explicit `app_ui`
+object and no `server()` function, and you never construct an `App(...)` — Shiny
+detects an Express app by the presence of `from shiny.express import ...` and
+wires it up for you.
+
+Do **not** try to add a Core-style `app_ui = ...` / `def server(...)` split, and
+do **not** nest UI calls as positional arguments the Core way. Express uses
+`with` blocks for layout containers instead.
+
+## The Express import and mental model
+
+```python
+from shiny.express import input, render, ui
+
+ui.input_slider("n", "N", 1, 100, 50)  # rendered where it appears
+
+@render.text
+def out():
+    return f"n = {input.n()}"        # rendered where it appears
+```
+
+- `input` — read reactive input values: `input.n()`.
+- `render` — output decorators (`render.text`, `render.plot`, `render.table`,
+  `render.data_frame`, `render.ui`, ...). A decorated function renders in place;
+  you do **not** also add an `output_*()` placeholder (Core does).
+- `ui` — Express UI: inputs, plus **context-manager** layout containers.
+- `session` is also importable (`from shiny.express import session`) for
+  lifecycle hooks, bookmarking, etc.
+
+## Layout with context managers
+
+Core nests components as arguments; Express opens a `with` block and puts
+children inside it.
+
+```python
+from shiny.express import input, render, ui
+
+with ui.sidebar():
+    ui.input_select("var", "Variable", choices=["a", "b"])
+
+with ui.layout_columns():
+    with ui.card():
+        ui.card_header("Left")
+
+        @render.plot
+        def hist(): ...
+
+    with ui.card():
+        ui.card_header("Right")
+```
+
+Common container managers: `ui.sidebar()`, `ui.card()`, `ui.layout_columns()`,
+`ui.layout_column_wrap()`, `ui.layout_sidebar()`, `ui.accordion()` /
+`ui.accordion_panel()`, `ui.nav_panel()` and the `ui.navset_*()` family,
+`ui.value_box()`, `ui.popover()`, `ui.tooltip()`, `ui.panel_well()`.
+
+## Page-level options
+
+Instead of choosing a `page_*()` function, call `ui.page_opts()` once at the top:
+
+```python
+from shiny.express import ui
+
+ui.page_opts(title="My app", fillable=True)
+```
+
+The page function is chosen automatically: a top-level `ui.nav_panel()` yields a
+navbar page, a top-level `with ui.sidebar():` yields a sidebar page, otherwise
+`fillable`/`full_width` pick between fixed, fluid, and fillable layouts.
+
+## Same app: Core vs Express
+
+```python
+# --- Core ---
+from shiny import App, render, ui
+
+app_ui = ui.page_sidebar(
+    ui.sidebar(ui.input_select("var", "Variable", choices=["a", "b"])),
+    ui.output_plot("hist"),
+    title="Hello sidebar!",
+)
+
+def server(input, output, session):
+    @render.plot
+    def hist(): ...
+
+app = App(app_ui, server)
+```
+
+```python
+# --- Express (same app) ---
+from shiny.express import input, render, ui
+
+ui.page_opts(title="Hello sidebar!")
+
+with ui.sidebar():
+    ui.input_select("var", "Variable", choices=["a", "b"])
+
+@render.plot
+def hist(): ...
+```
+
+## Reusable UI with `@expressify`
+
+A plain function called at the top level only contributes its return value. To
+make a helper emit UI line-by-line like the top level, decorate it with
+`@expressify`:
+
+```python
+from shiny.express import expressify, ui
+
+@expressify
+def labeled_card(title: str):
+    with ui.card():
+        ui.card_header(title)
+        ui.markdown("Body content")
+
+labeled_card("First")
+labeled_card("Second")
+```
+
+Use `ui.hold()` (a context manager) to capture UI without displaying it, so you
+can place it elsewhere (e.g. pass it as a `footer=`).
+
+## Express modules
+
+For reusable, namespaced components, Express uses a single `@module` decorator
+(`from shiny.express import module`) — the counterpart to Core's
+`module.ui()` / `module.server()` pair. See the **modules-express** skill for
+the full pattern.
+
+## When to choose Express vs Core
+
+- **Express**: rapid, linear, single-file apps; dashboards; prototypes;
+  notebooks-to-app. Less boilerplate.
+- **Core**: large or highly structured apps, dynamic UI assembled
+  programmatically, or when you want the UI as a first-class value to inspect,
+  reuse, or return from functions.
+- An app file is **either** Express or Core, never both. You cannot mix
+  `from shiny.express import ...` with `App(app_ui, server)` in one file.
+
+## Quick reference (Core → Express)
+
+| Core | Express |
+|---|---|
+| `from shiny import App, render, ui` | `from shiny.express import input, render, ui` |
+| `app_ui = ui.page_sidebar(...)` + `App(app_ui, server)` | top-level code; no `App(...)` |
+| `def server(input, output, session):` | no server function; define outputs at top level |
+| `ui.page_*(..., title=...)` | `ui.page_opts(title=...)` |
+| `ui.sidebar(child1, child2)` | `with ui.sidebar():` then children |
+| `ui.card(ui.output_plot("p"))` + `@render.plot def p()` | `with ui.card():` then `@render.plot def p()` |
+| `module.ui()` + `module.server()` | `@module` on one Express function (see modules-express skill) |
+| reusable UI helper returning a Tag | `@expressify` helper emitting UI |
+
+## Common mistakes
+
+- Adding `app_ui = ...`, `def server(...)`, or `app = App(...)` in an Express
+  file → Express has no such split; delete them and write top-level code.
+- Adding `ui.output_plot("hist")` *and* a `@render.plot def hist()` → the
+  decorated function renders in place; the extra placeholder is Core-only.
+- Nesting layout the Core way (`ui.card(ui.card_header(...), ...)`) inside
+  Express → use `with ui.card():` and put children in the block.
+- A helper function that builds UI shows nothing → decorate it with
+  `@expressify` (or return a single Tag/TagList and display that).
+- Calling `ui.page_opts()` or importing `shiny.ui`'s `page_*()` functions in
+  Express → page layout is automatic; use `ui.page_opts()` only.
+- Mixing Core and Express imports in one file → pick one mode per file.

--- a/shiny/.agents/skills/extended-tasks/SKILL.md
+++ b/shiny/.agents/skills/extended-tasks/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: extended-tasks
+description: Covers running non-blocking, long-running work in Shiny for Python (py-shiny) with reactive.extended_task - invoking an async task off the reactive flush, reading its result and status, cancelling it, and pairing it with input_task_button / update_task_button for automatic busy state. Use when running a slow API call, model inference, or long computation without freezing the app, keeping the UI (and other users' sessions) responsive during background work, showing a busy button while a task runs, or when tempted to run blocking work in a reactive.calc/effect or block the event loop with a long synchronous call.
+---
+
+# Extended tasks in Shiny for Python
+
+## Overview
+
+A slow computation inside a `@reactive.calc`, `@reactive.effect`, or `@render.*`
+blocks the reactive flush - even an `async def` one - so the whole session (and,
+for shared resources, other sessions) freezes until it returns. Do NOT put a
+slow API call, model inference, or long loop directly in a calc/effect.
+
+`@reactive.extended_task` runs an **async** function in a background asyncio
+task, off the reactive flush. Reactivity keeps processing while it runs; the
+result flows back into the reactive graph when it finishes.
+
+Because it runs outside the reactive flush, the task **cannot read reactive
+sources** (`input.x()`, a `reactive.value`, a calc). Read those values *before*
+invoking and pass them in as arguments; reading one inside raises an error.
+
+## Define and invoke a task
+
+Decorate an async function. Call the returned object (or `.invoke(...)`) from an
+effect - usually gated on a button - passing any reactive values as arguments.
+
+```python
+import asyncio
+from shiny import App, reactive, render, ui
+
+app_ui = ui.page_fluid(
+    ui.input_numeric("x", "x", 1),
+    ui.input_numeric("y", "y", 2),
+    ui.input_task_button("run", "Compute, slowly"),
+    ui.output_text("result"),
+)
+
+def server(input, output, session):
+    @reactive.extended_task
+    async def slow_sum(a: int, b: int) -> int:
+        await asyncio.sleep(3)          # stand-in for a slow API / model call
+        return a + b
+
+    @reactive.effect
+    @reactive.event(input.run)
+    def _():
+        slow_sum(input.x(), input.y())  # read inputs HERE, pass as args
+
+    @render.text
+    def result():
+        return str(slow_sum.result())   # read result in a reactive context
+
+app = App(app_ui, server)
+```
+
+`.invoke(*args)` returns immediately (`None`). `slow_sum(...)` is shorthand for
+`slow_sum.invoke(...)`.
+
+## Read the result and status
+
+- `task.result()` - call inside a reactive context (a `@render.*`, calc, or
+  effect). On success it returns the value; on error it re-raises; while running
+  or before the first run it raises a silent exception that leaves the output
+  blank or in a progress state. Reading it establishes a reactive dependency, so
+  outputs update automatically when the task finishes.
+- `task.status()` - a reactive read returning `"initial"`, `"running"`,
+  `"success"`, `"error"`, or `"cancelled"`. Use it to drive conditional UI.
+
+```python
+@render.ui
+def status_msg():
+    if slow_sum.status() == "running":
+        return ui.markdown("Working...")
+    return None
+```
+
+## Pair with a task button
+
+`ui.input_task_button` auto-disables and shows a busy label on click, then
+resets when reactive processing settles. `ui.bind_task_button` keeps it busy for
+the task's full lifetime - place it above `@reactive.extended_task`:
+
+```python
+    @ui.bind_task_button(button_id="run")
+    @reactive.extended_task
+    async def slow_sum(a: int, b: int) -> int:
+        ...
+```
+
+Binding does not invoke the task - you still need the effect. For manual
+control, call `ui.update_task_button("run", state="busy" | "ready")`, or pass
+`auto_reset=False` to keep the button busy until you reset it yourself.
+
+## Cancel and re-invoke
+
+`task.cancel()` cancels the running invocation (status becomes `"cancelled"`)
+and clears any queued invocations. Invoking again while a run is in progress
+does **not** interrupt it - the new call is **queued** and runs after the
+current one finishes.
+
+```python
+    @reactive.effect
+    @reactive.event(input.cancel)
+    def _():
+        slow_sum.cancel()
+```
+
+## Quick reference
+
+| Need | Use |
+|---|---|
+| Mark an async fn as background work | `@reactive.extended_task` |
+| Start a run (non-blocking) | `task(args)` / `task.invoke(args)` |
+| Get the result reactively | `task.result()` (in a reactive context) |
+| Check state | `task.status()` -> initial/running/success/error/cancelled |
+| Stop the current + queued runs | `task.cancel()` |
+| Auto busy button | `ui.input_task_button("id", ...)` + `@ui.bind_task_button(button_id="id")` |
+| Manual button state | `ui.update_task_button("id", state="busy"/"ready")` |
+
+## Common mistakes
+
+- Reading `input.x()` / a `reactive.value` inside the task body -> raises "not
+  allowed to read reactive sources". Read before invoking; pass as arguments.
+- Decorating a plain `def` -> `TypeError`; the function must be `async def`.
+- Long synchronous work (a blocking library call) inside the async task still
+  blocks the event loop - offload it with `asyncio.to_thread(...)` or an async
+  client.
+- Calling `task.result()` outside a reactive context -> no dependency is tracked
+  and it errors; read it inside a `@render.*`, calc, or effect.
+- Expecting a fresh `.invoke()` to interrupt the running task -> it queues
+  instead; call `.cancel()` first if you need to abort.
+- Awaiting `.invoke()` or using its return value -> it returns `None`
+  immediately; get output via `.result()`.
+</content>
+</invoke>

--- a/shiny/.agents/skills/feedback/SKILL.md
+++ b/shiny/.agents/skills/feedback/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: feedback
+description: Covers transient, server-driven user feedback in Shiny for Python (py-shiny) - ui.notification_show / ui.notification_remove for toast messages, ui.modal / ui.modal_show / ui.modal_remove / ui.modal_button for dialog boxes, ui.Progress for progress bars during multi-step work, and ui.busy_indicators.use / ui.busy_indicators.options for spinner and pulse loading indicators. Use when showing a toast/notification, popping a modal dialog, reporting progress during a long or multi-step operation, adding loading spinners, or when tempted to fake a popup with panel_conditional + render.ui, print status to the console, or block the app with a bare sleep and no feedback. For persistent UI that changes use dynamic-ui; for tooltips/popovers/cards use layouts; for long-running task buttons use extended-tasks.
+---
+
+# Transient user feedback in Shiny for Python
+
+## Overview
+
+Feedback that appears briefly and then goes away — toasts, dialogs, progress
+bars, spinners — is sent from the **server**, almost always from inside a
+`@reactive.effect`. These are overlays managed by Shiny: you show them and
+Shiny handles rendering and dismissal.
+
+Do NOT fake these with `ui.panel_conditional` + `@render.ui`, do NOT
+`print()` status to the console (the user never sees it), and do NOT run a long
+loop with no visible indication that the app is working. Use the built-in
+overlays below.
+
+## Toast notifications
+
+Non-blocking messages that stack in a corner and auto-dismiss. Call
+`ui.notification_show(msg, type=, duration=, id=)`; `type` is one of
+`"default"`, `"message"`, `"warning"`, `"error"`. It returns the notification
+id. Pass `duration=None` to keep it up until removed, and reuse the same `id`
+to update a notification in place.
+
+```python
+from shiny import App, Inputs, Outputs, Session, reactive, ui
+
+app_ui = ui.page_fluid(ui.input_action_button("save", "Save"))
+
+def server(input: Inputs, output: Outputs, session: Session):
+    @reactive.effect
+    @reactive.event(input.save)
+    def _():
+        id = ui.notification_show("Saving...", duration=None)
+        # ...do work...
+        ui.notification_remove(id)
+        ui.notification_show("Saved!", type="message", duration=3)
+
+app = App(app_ui, server)
+```
+
+## Modal dialogs
+
+A blocking dialog for important messages or for collecting input. Build it with
+`ui.modal(...)` and display it with `ui.modal_show(...)`. Close it from the
+server with `ui.modal_remove()`, or give the user a `ui.modal_button(label)` in
+the footer (it dismisses the modal client-side). `easy_close=True` lets the
+user dismiss by clicking outside or pressing Escape.
+
+```python
+from shiny import App, Inputs, Outputs, Session, reactive, ui
+
+app_ui = ui.page_fluid(ui.input_action_button("show", "Show dialog"))
+
+def server(input: Inputs, output: Outputs, session: Session):
+    @reactive.effect
+    @reactive.event(input.show)
+    def _():
+        m = ui.modal(
+            "This action cannot be undone.",
+            title="Are you sure?",
+            easy_close=True,
+            footer=ui.modal_button("Cancel"),
+        )
+        ui.modal_show(m)
+
+app = App(app_ui, server)
+```
+
+Inputs placed inside a modal are ordinary Shiny inputs: read them by id after
+the user acts, then call `ui.modal_remove()`.
+
+## Progress bars for multi-step work
+
+For a known sequence of steps, use `ui.Progress` as a context manager and call
+`p.set(value, message=, detail=)` as you advance. The bar closes automatically
+on exit. Use `p.inc(amount)` to advance by a step instead of setting an
+absolute value.
+
+```python
+import asyncio
+from shiny import App, Inputs, Outputs, Session, reactive, render, ui
+
+app_ui = ui.page_fluid(
+    ui.input_action_button("go", "Run"),
+    ui.output_text("done"),
+)
+
+def server(input: Inputs, output: Outputs, session: Session):
+    @render.text
+    @reactive.event(input.go)
+    async def done():
+        with ui.Progress(min=1, max=15) as p:
+            p.set(message="Working", detail="This may take a while...")
+            for i in range(1, 15):
+                p.set(i, message="Computing")
+                await asyncio.sleep(0.1)
+        return "Done!"
+
+app = App(app_ui, server)
+```
+
+For a single long-running computation triggered by a button, an
+`@ui.input_task_button` with an extended task often fits better (see the
+extended-tasks skill); `Progress` is for reporting incremental steps.
+
+## Busy indicators (spinners and pulse)
+
+Busy indicators are the automatic spinners on recalculating outputs and the
+pulsing banner shown while the app is busy — they need **no server code**. They
+are on by default. Configure them by placing the result of these functions in
+the app UI (not in the server):
+
+- `ui.busy_indicators.use(spinners=, pulse=, fade=)` — enable/disable each.
+- `ui.busy_indicators.options(spinner_type=, spinner_color=, spinner_size=, ...)`
+  — customize appearance.
+
+```python
+from shiny import App, render, ui
+
+app_ui = ui.page_fluid(
+    ui.busy_indicators.use(spinners=True, pulse=False),
+    ui.busy_indicators.options(spinner_type="bars3", spinner_color="#0d6efd"),
+    ui.output_plot("plot"),
+)
+```
+
+## Quick reference
+
+| Need | Use |
+|---|---|
+| Brief, non-blocking message | `ui.notification_show(msg, type=, duration=)` |
+| Remove/update a notification | `ui.notification_remove(id)` (reuse `id` to replace) |
+| Blocking dialog / collect input | `ui.modal(...)` + `ui.modal_show(...)` |
+| Close a modal from server / user | `ui.modal_remove()` / `ui.modal_button(label)` |
+| Report progress over known steps | `with ui.Progress() as p: p.set(value, message=)` |
+| Spinner/pulse on busy outputs | `ui.busy_indicators.use(...)` / `.options(...)` in UI |
+
+## Common mistakes
+
+- Calling `ui.notification_show` / `ui.modal_show` / `ui.Progress` at server top
+  level or in the UI -> they need an active session and a reactive trigger.
+  Call them inside a `@reactive.effect` (usually with `@reactive.event`).
+- Expecting `ui.notification_remove` to work without an id -> capture the id
+  returned by `notification_show` and pass it back.
+- Putting `ui.busy_indicators.use/options` in the server function -> they are UI
+  elements; add them to the `app_ui`.
+- `duration` is in **seconds**, not milliseconds; `duration=None` means "stay
+  until removed", not "no notification".
+- Building a fake popup with `panel_conditional` + `@render.ui` -> use `ui.modal`
+  for dialogs and `ui.notification_show` for toasts.
+- Running a long loop with only `print()` for status -> the user sees nothing;
+  use `ui.Progress` or a notification.

--- a/shiny/.agents/skills/files/SKILL.md
+++ b/shiny/.agents/skills/files/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: files
+description: Covers Shiny for Python (py-shiny) file uploads and downloads - ui.input_file plus the list[FileInfo] server value, and @render.download paired with ui.download_button / ui.download_link. Use when letting users upload a file and reading its contents on the server, reading an uploaded CSV/image/data file from its datapath, offering a generated file (CSV, report, image, zip) for download, setting a dynamic download filename, guarding an output against an empty file input, or when tempted to build a raw HTML <input type=file>, write your own multipart parser, or wire a custom Starlette route to serve a download.
+---
+
+# File uploads and downloads in Shiny for Python
+
+## Overview
+
+Shiny handles the browser plumbing for you. For uploads, `ui.input_file`
+receives the file, stores it in a temp file, and hands the server a
+`list[FileInfo]` describing each upload. For downloads, `@render.download`
+registers a handler that streams bytes to the browser when a paired
+`ui.download_button`/`ui.download_link` is clicked.
+
+Do NOT build a raw `<input type="file">`, parse multipart bodies yourself, or
+add a custom Starlette route to serve a file — Shiny already exposes both
+directions through the components below.
+
+## Upload a file: `ui.input_file`
+
+Add the input to the UI; read it in the server as `list[FileInfo]`. The value
+is `None` until the user picks a file, so guard with `req` (see the
+**reactivity** skill) before touching it. Each `FileInfo` is a dict with
+`name` (the browser filename), `size`, `type` (MIME), and `datapath` (path to
+a temp file holding the data — open this, not `name`).
+
+```python
+import pandas as pd
+from shiny import App, Inputs, Outputs, Session, reactive, render, req, ui
+from shiny.types import FileInfo
+
+app_ui = ui.page_fluid(
+    ui.input_file("file1", "Choose CSV file", accept=[".csv"], multiple=False),
+    ui.output_data_frame("preview"),
+)
+
+def server(input: Inputs, output: Outputs, session: Session):
+    @reactive.calc
+    def df() -> pd.DataFrame:
+        files: list[FileInfo] | None = input.file1()
+        req(files)                       # wait until a file is chosen
+        return pd.read_csv(files[0]["datapath"])
+
+    @render.data_frame
+    def preview():
+        return df()
+
+app = App(app_ui, server)
+```
+
+Use `multiple=True` to accept several files (iterate the whole list).
+`accept=` sets the file input's DOM `accept` attribute — a hint to the browser's
+file picker: extensions (`".csv"`), MIME types (`"text/plain"`), or wildcards
+(`"image/*"`). It only filters the picker; it is not enforced server-side, so
+still validate the uploaded file's type/name yourself.
+
+## Download a generated file: `@render.download`
+
+Pair a handler with a `ui.download_button` (or `ui.download_link`) whose id
+matches the function name. The handler either **returns a path** to an existing
+file on disk, or **yields** strings/bytes for content generated on the fly.
+When yielding, pass `filename=` so the browser knows what to name it.
+
+```python
+import io
+from datetime import date
+import pandas as pd
+from shiny import App, Inputs, Outputs, Session, render, ui
+
+app_ui = ui.page_fluid(
+    ui.download_button("download_csv", "Download CSV"),
+)
+
+def server(input: Inputs, output: Outputs, session: Session):
+    @render.download(filename=lambda: f"data-{date.today().isoformat()}.csv")
+    def download_csv():
+        df = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
+        with io.StringIO() as buf:
+            df.to_csv(buf, index=False)
+            yield buf.getvalue()
+
+app = App(app_ui, server)
+```
+
+`filename` accepts a plain string or a no-arg callable for a **dynamic name**
+(evaluated per click, so it can read reactive values). Return a path only for a
+file that already exists on disk — for temp files you create, `yield` the
+bytes instead so Shiny does not leave the temp file behind. The handler may be
+sync or async.
+
+In Express mode, `@render.download` renders its own button — pass
+`label=` and skip the separate `ui.download_button` (see the **express** skill).
+
+## Quick reference
+
+| Need | Use |
+|---|---|
+| Upload control | `ui.input_file("id", "Label", accept=[".csv"], multiple=False)` |
+| Read uploaded files | `input.id()` -> `list[FileInfo]` (or `None`) |
+| Open uploaded data | `open(fileinfo["datapath"])` / `pd.read_csv(fileinfo["datapath"])` |
+| Guard empty upload | `req(input.id())` before reading |
+| Download button / link | `ui.download_button("id", "Label")` / `ui.download_link(...)` |
+| Download handler | `@render.download(filename=...)` returning a path or yielding bytes/str |
+| Dynamic filename | `@render.download(filename=lambda: ...)` |
+
+## Common mistakes
+
+- Reading `input.file1()` without a guard -> `None`/`TypeError` before any
+  upload. Call `req(input.file1())` (or check `is None`) first.
+- Opening `fileinfo["name"]` -> file-not-found; `name` is the browser's label.
+  Open `fileinfo["datapath"]`, the temp file Shiny wrote.
+- Assuming the temp file persists -> a later upload may delete it. Read it
+  immediately (e.g. inside a `@reactive.calc`).
+- `yield`ing content with no `filename=` -> the browser downloads an
+  unhelpful default name. Set `filename=` when yielding.
+- Returning a path to a temp file you created -> Shiny won't clean it up;
+  `yield` the bytes instead.
+- Download button never fires -> the function name must match the button id,
+  and the button must be registered in the UI.
+- Building a raw `<input type="file">` or a custom download route -> use
+  `ui.input_file` and `@render.download`; Shiny wires the transport for you.

--- a/shiny/.agents/skills/layouts/SKILL.md
+++ b/shiny/.agents/skills/layouts/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: layouts
+description: Covers Shiny for Python (py-shiny) Core-mode page structure and bslib layout containers - page_sidebar, page_fillable, page_fluid, page_fixed, sidebar()/layout_sidebar(), card()/card_header()/card_footer(), layout_columns() and layout_column_wrap() (12-column grid), value_box() for KPIs, accordion()/accordion_panel(), and fill/fillable sizing. Use when arranging a dashboard into cards, columns, or a sidebar, adding value boxes or collapsible accordions, making content fill the browser window, or when tempted to hand-write Bootstrap grid `<div class='row'>`/`col-*` markup or raw CSS flexbox for app layout. Does NOT cover navsets/tabs/page_navbar (see navigation), @render.ui/insert_ui/conditional_panel (see dynamic-ui), or theming/colors (see theming).
+---
+
+# Layouts in Shiny for Python (Core)
+
+## Overview
+
+Build page structure by composing bslib layout functions from `shiny.ui`, not by
+hand-writing Bootstrap `<div class="row">`/`col-*` markup or raw CSS flexbox.
+Every app starts with one page function that sets the container and (optionally)
+a filling body; inside it you nest `card()`, `layout_columns()`,
+`layout_sidebar()`, `value_box()`, and `accordion()`. These containers are
+responsive and theme-aware for free.
+
+This skill documents the Core (function-call) form, e.g. `ui.card(...)`. For the
+Express context-manager form (`with ui.card():`) see the `express` skill.
+
+## Choose a page function
+
+Every app_ui is wrapped in exactly one page function:
+
+```python
+from shiny import App, ui
+
+app_ui = ui.page_sidebar(          # sidebar + main area (most dashboards)
+    ui.sidebar("Controls go here", title="Filters"),
+    ui.card("Main content"),
+    title="My Dashboard",
+)
+app = App(app_ui, None)
+```
+
+- `page_sidebar(sidebar, *args)` — dashboard with a left sidebar and a title.
+- `page_fillable(*args)` — body fills the viewport height; children flex to fit.
+  Best for full-window dashboards with no scrolling.
+- `page_fluid(*args)` — full-width flowing document; content scrolls normally.
+- `page_fixed(*args)` — like fluid but capped at Bootstrap's max container width.
+
+## Group content in a card
+
+`card()` is the standard content box. `card_header()` / `card_footer()` are
+optional and must be direct children. `full_screen=True` adds an expand button.
+
+```python
+ui.card(
+    ui.card_header("Sales"),
+    ui.output_plot("sales_plot"),
+    ui.card_footer("Updated hourly"),
+    full_screen=True,
+)
+```
+
+## Arrange cards in a grid: `layout_columns`
+
+`layout_columns()` uses a responsive 12-column grid. `col_widths` sets each
+child's width in grid units (out of 12); values wrap to the next row past 12,
+and a dict sets widths per breakpoint (`sm`, `md`, `lg`, ...).
+
+```python
+ui.layout_columns(
+    ui.card("A"),
+    ui.card("B"),
+    ui.card("C"),
+    col_widths={"sm": (12,), "lg": (4, 4, 4)},  # stacked on mobile, 3-up on large
+    row_heights=(1, 2),
+)
+```
+
+## Equal-size tiles: `layout_column_wrap`
+
+When every item should be the same width, use `layout_column_wrap()`. `width`
+is a fraction (`1/2` = two per row) or a CSS width (`"250px"` = as many as fit).
+
+```python
+ui.layout_column_wrap(
+    ui.card("one"), ui.card("two"), ui.card("three"), ui.card("four"),
+    width=1 / 2,
+)
+```
+
+## Sidebar inside a card or region: `layout_sidebar`
+
+Use `page_sidebar` for a page-level sidebar; use `layout_sidebar()` to put a
+sidebar inside a card or any region. Give `sidebar()` an `id` to read its
+open/closed state as `input.<id>()`.
+
+```python
+ui.card(
+    ui.layout_sidebar(
+        ui.sidebar("Options", id="opts", open="desktop", position="left"),
+        ui.output_plot("plot"),
+    ),
+)
+```
+
+## KPI tiles: `value_box`
+
+```python
+ui.value_box(
+    "Total revenue",              # title
+    "$1.2M",                      # value
+    "Up 30% vs last month",       # optional supporting text
+    showcase=ui.tags.i(class_="bi bi-cash"),
+    theme="bg-gradient-orange-red",
+)
+```
+
+## Collapsible sections: `accordion`
+
+```python
+ui.accordion(
+    ui.accordion_panel("Section A", "Content A"),
+    ui.accordion_panel("Section B", "Content B"),
+    id="acc",              # optional: read open panels via input.acc()
+    open="Section A",      # False = all closed, True = all open, or panel name(s)
+    multiple=True,
+)
+```
+
+## Quick reference
+
+| Need | Use |
+|---|---|
+| Page with sidebar + title | `ui.page_sidebar(ui.sidebar(...), ...)` |
+| Full-window flexbox page | `ui.page_fillable(...)` |
+| Scrolling document page | `ui.page_fluid(...)` / `ui.page_fixed(...)` |
+| Content box | `ui.card(ui.card_header(...), ..., full_screen=True)` |
+| Responsive 12-col grid | `ui.layout_columns(..., col_widths=(4, 8))` |
+| Equal-width wrapping tiles | `ui.layout_column_wrap(..., width=1/2)` |
+| Sidebar within a region | `ui.layout_sidebar(ui.sidebar(..., id="s"), ...)` |
+| KPI tile | `ui.value_box(title, value, *info)` |
+| Collapsible sections | `ui.accordion(ui.accordion_panel(...), ...)` |
+
+## Common mistakes
+
+- **Content won't fill the window / plot is tiny.** Filling needs an unbroken
+  chain of fillable containers from the page down. Use `page_fillable()` (or
+  `page_sidebar(..., fillable=True)`); `card` and `layout_columns` fill by
+  default, but a plain `page_fluid` does not. An output only expands if every
+  ancestor fills.
+- **Explicit `height=` gets ignored inside a fill container.** A fillable parent
+  stretches children to share space. Set `height`/`row_heights` on the
+  container, or drop it into a non-filling page.
+- **Hand-writing `ui.div(class_="row")` + `col-*`.** Use `layout_columns` /
+  `layout_column_wrap`; they are responsive and theme-aware.
+- **`card_header`/`card_footer` not rendering as header/footer.** They must be
+  direct children of `card()`, not nested inside another element.
+- **`input.<id>()` is `None` for a sidebar/accordion.** You must pass an `id=`
+  to `sidebar()` / `accordion()` to create the input binding.
+- **More than one page function.** An app has exactly one top-level page; nest
+  layout containers inside it, don't stack pages.

--- a/shiny/.agents/skills/markdown-streaming/SKILL.md
+++ b/shiny/.agents/skills/markdown-streaming/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: markdown-streaming
+description: Covers streaming Markdown/LLM output into a non-chat UI region in Shiny for Python with `ui.MarkdownStream` - rendering the target, pushing an (async) generator with `.stream()`, choosing markdown/html/text content, and replacing vs. appending. Use when progressively revealing a generated report, summary, or LLM response token-by-token into a card or page area that is NOT a conversation, streaming any incremental text into an output region, or when tempted to repeatedly overwrite an `output_text`/`render.ui` on a timer to fake streaming. For a full chatbot conversation (transcript + submit box) use the `chat` skill and `ui.Chat` instead.
+---
+
+# Streaming Markdown with `ui.MarkdownStream`
+
+## Overview
+
+`ui.MarkdownStream` renders a single region that incrementally displays Markdown
+(or HTML/plain text) as it arrives — ideal for an LLM-generated report, summary,
+or any text you want to reveal token-by-token. It is NOT a chat: there is no
+transcript, no user submit box, no message roles. Create one `MarkdownStream`,
+render it, and feed it an async generator via `.stream()`.
+
+Do NOT fake streaming by calling `render.text`/`render.ui` repeatedly on a timer
+or rebuilding the full string on every reactive tick — `.stream()` handles
+incremental rendering, Markdown parsing, and auto-scroll for you.
+
+`.stream()` is async; write async generators and `await` the call.
+
+## Express: stream into a card
+
+```python
+import asyncio
+from shiny import reactive
+from shiny.express import ui
+
+md = ui.MarkdownStream("summary")
+
+with ui.card(height="400px"):
+    ui.card_header("Generated summary")
+    md.ui(content="Click generate to begin.")
+
+
+@reactive.effect
+async def _():
+    async def gen():
+        for word in "# Report\n\nStreaming **markdown** word by word.".split(" "):
+            yield word + " "
+            await asyncio.sleep(0.05)
+
+    await md.stream(gen())
+```
+
+## Core: `output_markdown_stream`
+
+In Shiny Core, place `ui.output_markdown_stream(id)` in the UI and create the
+`MarkdownStream` with the **same id** in `server`:
+
+```python
+import asyncio
+from shiny import App, reactive, ui
+
+app_ui = ui.page_fluid(
+    ui.card(ui.output_markdown_stream("summary"), height="400px"),
+)
+
+
+def server(input, output, session):
+    md = ui.MarkdownStream("summary")
+
+    @reactive.effect
+    async def _():
+        async def gen():
+            for chunk in ["Hello", " ", "**world**"]:
+                yield chunk
+                await asyncio.sleep(0.1)
+
+        await md.stream(gen())
+
+
+app = App(app_ui, server)
+```
+
+## Stream an LLM response
+
+Any provider that yields chunks works. Wrap its stream in an async generator
+that yields Markdown strings (trigger it from a button with `@reactive.event`):
+
+```python
+from chatlas import ChatOpenAI
+from shiny import reactive
+from shiny.express import input, ui
+
+client = ChatOpenAI(system_prompt="Write a short report.")
+
+ui.input_action_button("go", "Generate", class_="btn-primary")
+md = ui.MarkdownStream("report")
+md.ui(content="Press Generate.")
+
+
+@reactive.effect
+@reactive.event(input.go)
+async def _():
+    await md.stream(client.stream_async("Summarize today's sales."))
+```
+
+`chatlas`'s `stream_async()` already yields text chunks. For a raw SDK, adapt it:
+`async for part in resp: yield part.content`.
+
+## Set, replace, and append content
+
+- **Set complete content** (no streaming): pass a one-item list —
+  `await md.stream(["# Done\n\nAll finished."])`.
+- **Replace** (default): `.stream(gen())` clears existing content first
+  (`clear=True`).
+- **Append** to what is already shown: `.stream(gen(), clear=False)`.
+- **Clear** the region: `await md.clear()`.
+
+## Content type
+
+Content is parsed as **Markdown** (CommonMark) by default. To render raw HTML or
+avoid parsing entirely, set `content_type` on the render call:
+
+```python
+md.ui(content_type="html")                 # Express
+ui.output_markdown_stream("x", content_type="text")  # Core
+```
+
+## Quick reference
+
+| Need | API |
+|---|---|
+| Create stream | `ui.MarkdownStream(id, on_error="auto")` |
+| Render (Express) | `md.ui(content="", content_type="markdown", auto_scroll=True, width=..., height=...)` |
+| Render (Core) | `ui.output_markdown_stream(id, content=..., content_type=..., ...)` |
+| Stream chunks | `await md.stream(async_iterable, clear=True)` |
+| Append instead of replace | `await md.stream(gen(), clear=False)` |
+| Set full string at once | `await md.stream([content])` |
+| Clear region | `await md.clear()` |
+| Final streamed value | `task = await md.stream(...)`; `task.result()` (in a reactive context) |
+| Content types | `"markdown"` (default), `"html"`, `"text"` |
+
+## Common mistakes
+
+- Core `id` on `ui.MarkdownStream` not matching `ui.output_markdown_stream("...")`
+  -> nothing renders. They must be identical.
+- Sync function or forgetting `await` on `.stream()` -> content never appears.
+  The generator may be sync or async, but `.stream()` itself must be awaited.
+- Rebuilding the whole string and re-yielding it each tick -> yield only the new
+  chunk; `MarkdownStream` accumulates them.
+- Using it for a back-and-forth conversation -> that is `ui.Chat` (see the
+  `chat` skill). `MarkdownStream` has no message history or input box.
+- Passing UI/output bindings as `content_type="text"` -> they render as literal
+  text; use `"markdown"` or `"html"` for embedded UI.

--- a/shiny/.agents/skills/modules-core/SKILL.md
+++ b/shiny/.agents/skills/modules-core/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: modules-core
+description: Use when a Shiny for Python (py-shiny) Core-mode app (explicit app_ui + server) needs a reusable, repeatable UI+server component - the same widget or panel appearing multiple times, avoiding input/output id collisions across copies, sharing one piece of server logic, destroying a dynamically added module instance, or when tempted to manually prefix input ids (like "counter1_button") or copy-paste server functions to make ids unique. For Express-mode apps, use the modules-express skill instead.
+---
+
+# Shiny for Python modules (Core mode)
+
+## Overview
+
+A module is a reusable pair of functions — a UI function and a server function —
+that can be dropped into an app (or another module) more than once without id
+collisions. The framework **namespaces every input/output id automatically** for
+each instance. Reach for a module instead of copy-pasting server logic or
+hand-prefixing ids like `"counter1_button"`, `"counter2_button"`.
+
+A module has two halves linked by a shared instance `id`:
+
+- `@module.ui` — builds the HTML. The decorator injects a leading `id` argument.
+- `@module.server` — the reactive logic. You write the function with
+  `input, output, session` as its first parameters, but you **call** it with a
+  leading `id` instead (`foo_server("counter1")`); the decorator supplies
+  `input, output, session` for that namespace automatically.
+
+Calling `foo_ui("counter1")` and `foo_server("counter1")` with the **same id**
+wires that UI instance to that server instance.
+
+## End-to-end example
+
+```python
+from shiny import App, Inputs, Outputs, Session, module, reactive, render, ui
+
+
+# --- Module UI: do NOT add an `id` param; the decorator injects it. ---
+@module.ui
+def counter_ui(label: str = "Increment") -> ui.TagChild:
+    return ui.card(
+        ui.h2(label),
+        ui.input_action_button("button", label),  # plain id, auto-namespaced
+        ui.output_text("out"),
+    )
+
+
+# --- Module server: starts with input/output/session, then extra args. ---
+@module.server
+def counter_server(
+    input: Inputs, output: Outputs, session: Session, start: int = 0
+):
+    count = reactive.value(start)
+
+    @reactive.effect
+    @reactive.event(input.button)       # refer to ids WITHOUT the namespace
+    def _():
+        count.set(count() + 1)
+
+    @render.text
+    def out() -> str:
+        return f"Count is {count()}"
+
+    return count                        # expose a value to the caller
+
+
+# --- App uses the module twice; ids must be unique per instance. ---
+app_ui = ui.page_fluid(
+    counter_ui("counter1", "Counter 1"),
+    counter_ui("counter2", "Counter 2"),
+)
+
+
+def server(input: Inputs, output: Outputs, session: Session):
+    counter_server("counter1")
+    total = counter_server("counter2", start=100)
+
+    @render.text
+    def _():
+        return f"Second counter: {total()}"
+
+
+app = App(app_ui, server)
+```
+
+## Pass data in, get values out
+
+- **In:** add parameters after `input, output, session` on the server function
+  (and after the label params on the UI function). Pass **reactive** inputs by
+  handing the caller's reactive itself, e.g. `foo_server("id", data=my_calc)`,
+  and call `data()` inside the module.
+- **Out:** `return` reactives (calcs/values) or plain values from the server
+  function. The caller receives whatever you return, as shown above with
+  `total`.
+
+## Reading a nested module's input from outside
+
+Inside a module, refer to ids by their bare name (`input.button`). From the
+**parent**, the same input lives under the namespace. Prefer returning a value
+from the server function over reaching in. When you must resolve a namespaced
+id (e.g. for `input[...]` or a manual selector), build it with the module's
+`session` scope rather than string-concatenating:
+
+```python
+child = session.make_scope("counter1")
+resolved = child.ns("button")   # -> "counter1-button"
+```
+
+## Nesting modules
+
+A module UI can call another module's UI, and a module server can call another
+module's server. Because you use bare ids inside each module, the framework
+composes the namespaces (`outer-inner-button`) for you — never assemble that
+string yourself.
+
+## Remove a dynamically added module
+
+When you add module instances at runtime (e.g. with `ui.insert_ui`) and later
+remove them, tear down the instance's reactive graph too, or its effects keep
+firing (duplicate observers, repeated side effects). `session.destroy(id)` is
+**async** and destroys everything under that namespace:
+
+```python
+@reactive.effect
+async def _():
+    ...
+    ui.remove_ui(f"#{mod_id}")
+    await session.destroy(mod_id)   # tear down that instance's reactive graph
+```
+
+`destroy` wipes the instance's state. If a value must **persist** across
+add/remove cycles, keep a `reactive.value` created *outside* the module and pass
+it in; update it from within the module. Then destroying the instance leaves the
+value intact for the next instance.
+
+## Express mode
+
+Express-mode apps use a different, single-decorator module API. See the
+**modules-express** skill.
+
+## Quick reference
+
+| Need | API |
+|---|---|
+| Define module UI | `@module.ui` (first arg `id` is injected) |
+| Define module server | `@module.server` with `(input, output, session, ...)` |
+| Place an instance | `foo_ui("id", ...ui args)` |
+| Activate its logic | `foo_server("id", ...extra args)` |
+| Link UI to server | pass the **same** `id` string to both |
+| Pass reactive data in | extra server param; call it inside the module |
+| Send values out | `return` from the server function |
+| Namespaced id (rare) | `session.make_scope(id).ns("child_id")` |
+| Destroy a dynamic instance | `await session.destroy(id)` (async) |
+| Express equivalent | see the **modules-express** skill |
+
+## Common mistakes
+
+- **Manually prefixing ids** inside a module (`"counter1_button"`) → the
+  framework already namespaces; use the bare id (`"button"`) in both `ui.*`
+  and `input.*`. Manual prefixes break the wiring.
+- **Adding an `id` parameter** to the `@module.ui` function → the decorator
+  injects it; a second one shifts your other args.
+- **Mismatched ids** between `foo_ui("a")` and `foo_server("b")` → the UI and
+  server never connect and outputs stay blank. Use one shared id.
+- **Reusing the same id** for two instances → collisions return. Each instance
+  needs a distinct id.
+- **Reaching into a module's inputs from the parent** via a guessed string like
+  `input["counter1_button"]` → return the value from the server function
+  instead, or resolve the id with `session.make_scope(id).ns(...)`.
+- **Keeping `input, output, session`** in the *call* (`foo_server(input, ...)`)
+  → the decorator removed them; call with the `id` first: `foo_server("id")`.

--- a/shiny/.agents/skills/modules-express/SKILL.md
+++ b/shiny/.agents/skills/modules-express/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: modules-express
+description: Use when a Shiny for Python (py-shiny) Express-mode app (top-level UI, no explicit app_ui/server) needs a reusable, repeatable component - the same widget or panel appearing multiple times, avoiding input/output id collisions across copies, or when tempted to manually prefix input ids or copy-paste a block of Express UI+logic to reuse it. Uses the single `@module` decorator from `shiny.express`. For Core-mode apps (explicit app_ui + server), use the modules-core skill instead.
+---
+
+# Shiny for Python modules (Express mode)
+
+## Overview
+
+In Express mode a module is a **single function** — UI and server code together —
+decorated with `@module` from `shiny.express`. This differs from Core mode, which
+splits a module into a `@module.ui` / `@module.server` pair. As in Core, the
+framework **namespaces every input/output id automatically** per instance, so
+reach for a module instead of copy-pasting an Express block or hand-prefixing ids
+like `"counter1_button"`.
+
+Call the decorated function once per instance, passing a unique `id` first.
+
+## End-to-end example
+
+```python
+from shiny import reactive
+from shiny.express import module, render, ui
+
+
+# One function holds BOTH the UI and the reactive logic.
+# First three params are always input, output, session; then your own args.
+@module
+def counter(input, output, session, label, starting_value: int = 0):
+    count = reactive.value(starting_value)
+
+    with ui.card():                     # UI is written inline, in place
+        ui.h2(f"This is {label}")
+        ui.input_action_button("button", label)   # bare id, auto-namespaced
+
+        @render.text
+        def out():
+            return f"Click count is {count()}"
+
+    @reactive.effect
+    @reactive.event(input.button)       # refer to ids WITHOUT the namespace
+    def _():
+        count.set(count() + 1)
+
+
+# Use the module twice; ids must be unique per instance.
+counter("counter1", "Counter 1")
+ui.hr()
+counter("counter2", "Counter 2", starting_value=100)
+```
+
+## Pass data in
+
+Add parameters after `input, output, session`. Pass a **reactive** in by handing
+the caller's reactive itself (`counter("id", data=my_calc)`) and calling it
+(`data()`) inside the module. Returning values out is uncommon in Express because
+each instance renders where it is called; when you do return a reactive, capture
+it from the call (`total = counter("id")`).
+
+## Nesting modules
+
+A module function can call another module function; because you use bare ids
+inside each, the framework composes namespaces (`outer-inner-button`) for you —
+never assemble that string yourself.
+
+## Quick reference
+
+| Need | API |
+|---|---|
+| Import | `from shiny.express import module` |
+| Define a module | `@module` on one function `(input, output, session, ...)` |
+| Place an instance | `foo("id", ...extra args)` (call it where the UI should appear) |
+| Link UI to logic | automatic — they live in the same function |
+| Pass reactive data in | extra param; call it inside the module |
+| Namespaced id (rare) | `session.make_scope(id).ns("child_id")` |
+| Core equivalent | see the **modules-core** skill |
+
+## Common mistakes
+
+- **Reaching for `@module.ui` / `@module.server`** in an Express app → that is
+  the Core API. In Express use the single `@module` decorator; one function,
+  called once per instance.
+- **Manually prefixing ids** (`"counter1_button"`) → the framework namespaces
+  already; use the bare id (`"button"`) in both `ui.*` and `input.*`.
+- **Adding an explicit `id` parameter** to the function → the first three params
+  must be `input, output, session`; the `id` is supplied at the call site, not
+  in the signature.
+- **Reusing the same id** for two instances → collisions return; each instance
+  needs a distinct id.
+- **Not calling the module** (only defining it) → an Express module renders
+  nothing until you call `foo("id")` at the point where its UI belongs.

--- a/shiny/.agents/skills/navigation/SKILL.md
+++ b/shiny/.agents/skills/navigation/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: navigation
+description: Covers Shiny for Python (py-shiny) multi-panel navigation - the navset_*() family (tab, pill, underline, card variants, pill_list, bar, hidden), nav_panel/nav_menu/nav_control/nav_spacer children, page_navbar() for a top-level navbar app, reading the active panel via the navset id input, switching it with update_navset(), and adding/removing panels at runtime with insert_nav_panel/remove_nav_panel/update_nav_panel. Use when organizing an app into tabs, pills, or a navbar with multiple pages, reading or switching the active tab from the server, adding or removing tabs at runtime, or when tempted to build tab buttons with input_action_button + conditional_panel to fake tabbed navigation.
+---
+
+# Navigation in Shiny for Python
+
+## Overview
+
+Group content into switchable panels with a `navset_*()` container holding
+`nav_panel()` children. Each `nav_panel(title, *content, value=)` is one panel;
+the container renders the tab strip and shows one panel at a time.
+
+Do NOT fake tabs with `input_action_button` + `conditional_panel` or by
+toggling `@render.ui` — a navset gives you the tab strip, active styling,
+keyboard/ARIA behavior, and a server-readable selection for free. To read or
+change which panel is active, give the container an `id=` (see below); don't
+track the selection in a separate `reactive.value`.
+
+This documents the Core form. Express mode uses `with ui.nav_panel(...):`
+context managers — see the `express` skill.
+
+## Choose a container
+
+Every `navset_*()` takes the same core args: `*args` (nav items), `id=`,
+`selected=`, `header=`, `footer=`. Pick by appearance:
+
+```python
+from shiny import ui
+
+ui.navset_tab(                      # classic bordered tabs
+    ui.nav_panel("Plot", "plot content"),
+    ui.nav_panel("Table", "table content"),
+    id="which",                     # optional: exposes input.which()
+)
+```
+
+Swap `navset_tab` for `navset_pill` (rounded buttons), `navset_underline`
+(underlined links), or the `navset_card_*` variants to wrap the panels in a
+`card` with the tabs in its header. `navset_pill_list` renders a vertical list
+beside the content. `navset_hidden` shows no tab strip at all — you drive it
+entirely from the server (pair it with `update_navset`).
+
+## A top-level navbar app: `page_navbar`
+
+`page_navbar()` is a full page whose top-level nav items become navbar pages.
+Its `*args` are nav items directly (no inner `navset_*`):
+
+```python
+from shiny import App, ui
+
+app_ui = ui.page_navbar(
+    ui.nav_panel("Home", "welcome"),
+    ui.nav_panel("Analysis", ui.output_plot("p")),
+    ui.nav_menu(                     # dropdown of nav items
+        "More",
+        ui.nav_panel("About", "about page"),
+        "----",                      # a string of hyphens is a divider
+        ui.nav_control(ui.a("Docs", href="https://shiny.posit.co")),
+    ),
+    title="My App",
+    id="page",                       # input.page() == active panel value
+    sidebar=ui.sidebar("Shared across pages"),
+)
+```
+
+- `nav_menu(title, *items)` — a dropdown; string args become section headers,
+  `"---"` becomes a divider.
+- `nav_control(...)` — arbitrary UI (e.g. a link) in the nav strip.
+- `nav_spacer()` — pushes later items to the right.
+- `sidebar=` puts one sidebar on every page. Style the bar with
+  `navbar_options=ui.navbar_options(position=..., bg=..., theme=...)`.
+
+To build a navbar *inside* a larger page instead of as the whole page, use
+`ui.navset_bar(..., title=...)`.
+
+## Read the active panel
+
+Give the container an `id`. That `id` becomes an input holding the `value` of
+the selected panel (its `title` if no `value=` was set):
+
+```python
+@render.text
+def current():
+    return f"You are on: {input.which()}"   # matches the navset id=
+```
+
+## Switch panels from the server: `update_navset`
+
+```python
+from shiny import reactive, ui
+
+@reactive.effect
+@reactive.event(input.go_to_table)
+def _():
+    ui.update_navset("which", selected="Table")   # id, then panel value
+```
+
+## Add / remove / show / hide panels at runtime
+
+Target panels by their `value`. Insert relative to an existing `target`:
+
+```python
+@reactive.effect
+@reactive.event(input.add)
+def _():
+    ui.insert_nav_panel(
+        "which",                                   # navset id
+        ui.nav_panel("New", "fresh content", value="new"),
+        target="Table", position="before", select=True,
+    )
+
+@reactive.effect
+@reactive.event(input.drop)
+def _():
+    ui.remove_nav_panel("which", target="new")
+```
+
+`ui.update_nav_panel("which", target="new", method="hide")` (or `"show"`)
+toggles visibility without removing the panel. Showing a hidden panel does not
+select it — follow with `update_navset("which", selected="new")` if needed.
+
+## Quick reference
+
+| Container | Looks like |
+|---|---|
+| `navset_tab` | Classic bordered tabs |
+| `navset_pill` | Rounded pill buttons |
+| `navset_underline` | Underlined active link |
+| `navset_card_tab` | Tabs in a card header |
+| `navset_card_pill` | Pills in a card header |
+| `navset_card_underline` | Underlined links in a card header |
+| `navset_pill_list` | Vertical pill list beside content |
+| `navset_bar` | Bootstrap navbar (inside a page) |
+| `navset_hidden` | No tab strip; server-driven only |
+| `page_navbar` | Full page whose top-level items are navbar pages |
+
+| Task | Call |
+|---|---|
+| Read active panel | `input.<navset_id>()` |
+| Switch panel | `ui.update_navset(id, selected=value)` |
+| Add panel | `ui.insert_nav_panel(id, nav_panel, target=, position=, select=)` |
+| Remove panel | `ui.remove_nav_panel(id, target=value)` |
+| Show/hide panel | `ui.update_nav_panel(id, target=value, method="show"/"hide")` |
+
+## Common mistakes
+
+- Reading the active tab and finding no input -> the navset needs an `id=`.
+  Without it there is no `input.<id>()`; the selection is not exposed.
+- `input.<id>()` / `update_navset` / `insert_nav_panel` use the panel's
+  `value`, not its `title`. If you set `value="table"`, then `input.id()` is
+  `"table"` and `selected="Table"` will not match. When `value=` is omitted it
+  defaults to `str(title)`.
+- Passing `nav_panel` items straight into `page_fluid`/`page_sidebar` -> nav
+  items only render inside a `navset_*()` (or `page_navbar`); otherwise they
+  raise "must appear within navset_*() container".
+- Building tab buttons with `input_action_button` + `conditional_panel` -> use
+  a `navset_*()` with an `id` instead; you get styling, ARIA, and the selection
+  input for free.
+- Nesting a `navset_bar` as a whole page -> use `page_navbar` for a top-level
+  navbar; `navset_bar` is for a navbar embedded in another page.

--- a/shiny/.agents/skills/plots/SKILL.md
+++ b/shiny/.agents/skills/plots/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: plots
+description: Covers rendering matplotlib/seaborn/plotnine figures and static images in a Shiny for Python (py-shiny) app with @render.plot and @render.image, plus reading plot click/hover/brush interactions. Use when displaying a figure or image, sizing a plot, making a plot respond to clicks/hover/brush selection, reading which points or region a user selected (input.<id>_click / _brush / _hover), or when tempted to save a figure to a temp PNG and serve it manually, poll for plot clicks, or wire up JavaScript event handlers by hand. For fully interactive JS charts (Plotly/Altair/ipywidgets) use shinywidgets instead.
+---
+
+# Rendering plots and images in Shiny for Python
+
+## Overview
+
+Return a figure from a `@render.plot`-decorated function paired with a
+`ui.output_plot(id)` placeholder; return an `ImgData` dict from `@render.image`
+paired with `ui.output_image(id)` for static image files. Do **not** call
+`fig.savefig(tmp.png)` and serve the file yourself — `@render.plot` encodes the
+figure for you. Do **not** poll or add JS listeners to detect clicks — instead, enable
+`click`/`hover`/`brush` on `output_plot` and read the resulting reactive inputs.
+
+## Render a plot
+
+`@render.plot` accepts a matplotlib `Figure`/`Axes`, a seaborn object (return
+its `.figure`), or a plotnine `ggplot`. You may also draw with the pyplot global
+interface and return nothing (sync functions only).
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from shiny import App, render, ui
+
+app_ui = ui.page_fluid(
+    ui.input_slider("n", "Bins", 5, 50, 20),
+    ui.output_plot("hist", width="600px", height="400px"),
+)
+
+def server(input, output, session):
+    @render.plot(alt="A histogram")
+    def hist():
+        fig, ax = plt.subplots()
+        ax.hist(np.random.randn(500), bins=input.n())
+        return fig
+
+app = App(app_ui, server)
+```
+
+Set the display size on `ui.output_plot(width=, height=)` (CSS units; the plot
+auto-fits). `@render.plot(alt=...)` sets screen-reader text; `@render.plot(width=,
+height=)` forces a pixel size and is rarely needed. Extra kwargs pass through to
+the backend's save method (e.g. matplotlib `savefig`). In Express, the same
+decorator works inline with no `output_plot` call — see the `express` skill.
+
+## Render a static image
+
+Return an `ImgData` dict (`src` required; optional `width`/`height`/`alt`).
+Use `@render.image(delete_file=True)` to remove a generated temp file after
+sending.
+
+```python
+from pathlib import Path
+from shiny import render, ui
+from shiny.types import ImgData
+
+# ui: ui.output_image("logo")
+@render.image
+def logo() -> ImgData:
+    return {"src": str(Path(__file__).parent / "logo.png"), "width": "200px"}
+```
+
+## Read plot interactions
+
+Enable interaction on the output container. Each enabled event exposes a reactive
+input named `input.<id>_<event>()`:
+
+```python
+ui.output_plot("scatter", click=True, brush=True)
+```
+
+- `input.scatter_click()` → `{"x": ..., "y": ...}` in data coordinates (also
+  `dblclick`, `hover`).
+- `input.scatter_brush()` → `{"xmin", "xmax", "ymin", "ymax", ...}`.
+
+Both are `None` until the user acts. Pass `ui.click_opts()`, `ui.hover_opts()`,
+`ui.dblclick_opts()`, or `ui.brush_opts(direction="x")` instead of `True` to tune
+behavior.
+
+## Map interactions back to data rows
+
+Do not compute hit-testing yourself. `shiny.plotutils.near_points` (click/hover)
+and `brushed_points` (brush) return the underlying `DataFrame` rows, inferring
+`xvar`/`yvar` from the plot mapping when possible (always inferable for plotnine;
+supply them explicitly for matplotlib/seaborn).
+
+```python
+import matplotlib.pyplot as plt
+from shiny import App, reactive, render, ui
+from shiny.plotutils import brushed_points, near_points
+import pandas as pd
+
+df = pd.DataFrame({"wt": [2, 3, 4, 5], "mpg": [30, 25, 20, 15]})
+
+app_ui = ui.page_fluid(
+    ui.output_plot("p", click=True, brush=True),
+    ui.output_data_frame("selected"),
+)
+
+def server(input, output, session):
+    @render.plot
+    def p():
+        fig, ax = plt.subplots()
+        ax.scatter(df["wt"], df["mpg"])
+        return fig
+
+    @render.data_frame
+    def selected():
+        brush = brushed_points(df, input.p_brush(), xvar="wt", yvar="mpg")
+        if not brush.empty:
+            return brush
+        return near_points(df, input.p_click(), xvar="wt", yvar="mpg")
+
+app = App(app_ui, server)
+```
+
+`all_rows=True` returns every row with a boolean `selected_` column instead of
+filtering.
+
+## Quick reference
+
+| Item | Value |
+|---|---|
+| Renderers | `@render.plot(alt=, width=, height=, **savefig_kwargs)`, `@render.image(delete_file=)` |
+| Containers | `ui.output_plot(id, width=, height=, click=, dblclick=, hover=, brush=)`, `ui.output_image(...)` |
+| Supported figures | matplotlib `Figure`/`Axes`, seaborn (`.figure`), plotnine `ggplot`, PIL `Image` |
+| Interaction inputs | `input.<id>_click()`, `_dblclick()`, `_hover()` → `{x, y}`; `_brush()` → `{xmin, xmax, ymin, ymax}` |
+| Option builders | `ui.click_opts()`, `ui.dblclick_opts()`, `ui.hover_opts()`, `ui.brush_opts(direction=, delay=, ...)` |
+| Row selection | `plotutils.near_points(df, input.<id>_click(), xvar=, yvar=)`, `plotutils.brushed_points(df, input.<id>_brush(), ...)` |
+| `ImgData` keys | `src` (required), `width`, `height`, `alt`, `coordmap` |
+
+## Common mistakes
+
+- Saving to a temp PNG and serving it → return the `Figure` from `@render.plot`;
+  it encodes the image itself. Only static files on disk need `@render.image`.
+- Interaction input always `None` → you did not enable it on `output_plot`
+  (`click=True`, `brush=True`, ...); the flag lives on the container, not the renderer.
+- Wrong input name → it is `input.<id>_brush()` / `_click()`, not `input.<id>()`.
+- `near_points`/`brushed_points` raising "not able to infer `xvar`" → for
+  matplotlib/seaborn pass `xvar=`/`yvar=` explicitly (only plotnine auto-infers).
+- Async `@render.plot` erroring on pyplot → the global pyplot interface is unsafe
+  in async functions; build and return a `Figure` object instead.
+- Reaching for `@render.plot` to get zoom/tooltips/pan → those are static images;
+  use shinywidgets with Plotly/Altair/ipywidgets for client-side interactivity.

--- a/shiny/.agents/skills/reactivity/SKILL.md
+++ b/shiny/.agents/skills/reactivity/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: reactivity
+description: Covers Shiny for Python (py-shiny) reactive programming - reactive.value, reactive.calc, reactive.effect, reactive.event, req(), isolate(), invalidate_later, poll, and file_reader - the reactive graph that decides when code re-runs. Use when a value should recompute or an output update as inputs change, when deciding between a calc and an effect, when an output recomputes an expensive value on every render instead of caching it, when reactivity fires too often or not at all, when code reads input.x() outside a reactive context and errors, when tempted to poll a database or file in a loop, or when a mutable value must be shared reactively across outputs.
+---
+
+# Reactivity in Shiny for Python
+
+## Overview
+
+Shiny builds a dependency graph automatically: reading a reactive source
+(`input.x()`, a `reactive.value`, a `@reactive.calc`) inside a reactive context
+registers a dependency, so when that source changes, everything that read it
+re-runs. You do not call outputs or schedule updates yourself.
+
+Do NOT recompute non-trivial work in every output, poll in a `while` loop, or
+read `input.x()` at module top level or inside a plain helper. Reactive sources
+are only readable inside a reactive context: a `@render.*` output, a
+`@reactive.calc`, a `@reactive.effect`, or an `isolate()` block. For work that
+blocks the session (a slow API call, a long computation), do not run it in a
+calc/effect either — use `reactive.extended_task` (see the tasks skill).
+
+## Share a mutable value: `reactive.value`
+
+A settable reactive source. Read with `()` or `.get()`; write with `.set()`.
+Writing invalidates every reader.
+
+```python
+from shiny import reactive
+
+count = reactive.value(0)
+
+@reactive.effect
+@reactive.event(input.increment)
+def _():
+    count.set(count() + 1)   # read current, write new
+```
+
+## Cache a derived value: `@reactive.calc`
+
+Use a calc for a value derived from other reactive sources. It is **cached**:
+it runs once, memoizes, and re-runs only when a dependency invalidates. Many
+outputs can call it without repeating the work.
+
+```python
+@reactive.calc
+def filtered():
+    return df[df["group"] == input.group()]
+
+@render.data_frame
+def table():
+    return filtered()          # cheap; computed once per change
+
+@render.text
+def n_rows():
+    return f"{filtered().shape[0]} rows"
+```
+
+## Perform a side effect: `@reactive.effect`
+
+Use an effect for actions with no return value: updating inputs, writing files,
+`ui.insert_ui`, logging. Effects run automatically when a dependency changes.
+
+```python
+@reactive.effect
+def _():
+    ui.update_select("city", choices=cities_for(input.country()))
+```
+
+Rule of thumb — pick by what the code produces:
+
+- `@reactive.calc` — cache an intermediate value other code reads.
+- `@render.*` — display a value in the UI.
+- `@reactive.effect` — perform a side effect (no return value).
+
+Never put display logic in an effect.
+
+## Control when reactivity fires: `@reactive.event`
+
+Place it below `@reactive.effect`/`@reactive.calc`/`@render.*` to restrict
+dependencies to the listed events only. The body may read other reactive
+values without depending on them.
+
+```python
+@reactive.effect
+@reactive.event(input.submit)        # runs ONLY when submit is clicked
+def _():
+    save(input.name(), input.email())  # read, but don't react to, these
+```
+
+`ignore_none=True` (default) skips runs when the event is `None`/`0`;
+`ignore_init=True` skips the initial run on load.
+
+## Short-circuit / validate: `req()`
+
+Stops execution when a value is missing (falsy), silently pausing dependent
+outputs until the requirement is met.
+
+```python
+from shiny import req
+
+@render.text
+def greeting():
+    req(input.name())               # wait until name is non-empty
+    return f"Hello, {input.name()}"
+```
+
+Use `req(x, cancel_output=True)` to keep the previous output visible instead of
+blanking it.
+
+## Read without depending: `isolate()`
+
+Read a reactive source without registering a dependency, so changes to it do
+not trigger a re-run.
+
+```python
+@reactive.effect
+@reactive.event(input.go)
+def _():
+    with reactive.isolate():
+        seed = input.seed()        # used, but does not trigger re-runs
+    run_model(seed)
+```
+
+## Timers and streaming: `invalidate_later`, `poll`, `file_reader`
+
+Invalidate on a timer (re-runs the containing context after N seconds):
+
+```python
+@reactive.effect
+def _():
+    reactive.invalidate_later(1)   # tick every second
+    tick.set(tick() + 1)
+```
+
+Stream from a data source without a loop. `poll` runs a cheap check on an
+interval and re-reads only when it changes; `file_reader` watches a file's
+mtime/size:
+
+```python
+@reactive.poll(lambda: os.path.getmtime(path), interval_secs=1)
+def data():
+    return pd.read_csv(path)
+
+@reactive.file_reader(path)        # same idea, file-aware
+def data2():
+    return pd.read_csv(path)
+```
+
+Declare `poll`/`file_reader` at module top level to share one cache across
+sessions.
+
+(For long-running async work that must not block the session, see
+`reactive.extended_task` - out of scope here.)
+
+## Quick reference
+
+| Need | Use |
+|---|---|
+| Settable reactive value | `v = reactive.value(x)`; `v()` / `v.set(x)` |
+| Cached derived value | `@reactive.calc` |
+| Side effect (update UI, log, write) | `@reactive.effect` |
+| Fire only on a specific event | `@reactive.event(input.btn)` |
+| Wait for / validate a value | `req(x)`, `req(x, cancel_output=True)` |
+| Read without depending | `with reactive.isolate():` |
+| Timer | `reactive.invalidate_later(secs)` |
+| Poll a data source / file | `@reactive.poll(...)` / `@reactive.file_reader(...)` |
+| Force sync execution in tests | `reactive.flush()` |
+
+## Common mistakes
+
+- `input.x()` read at module scope or in a plain helper -> "no current
+  reactive context" error. Read it inside a `@render.*`, `calc`, `effect`, or
+  `isolate()`.
+- Non-trivial computation duplicated across outputs -> wrap it in a
+  `@reactive.calc` and call that from each output.
+- Using a `@reactive.effect` to compute a displayed value -> effects return
+  nothing; use a `calc` or `@render.*` function.
+- Effect re-runs on every incidental input change -> add
+  `@reactive.event(...)` (below the effect decorator) to pin the trigger.
+- Reading a `reactive.value` you also `.set()` in the same effect without
+  `isolate()` -> self-invalidating loop; wrap the read in `reactive.isolate()`.
+- `while`/`sleep` loop to watch a DB or file -> use `reactive.poll` or
+  `reactive.file_reader`.

--- a/shiny/.agents/skills/session-lifecycle/SKILL.md
+++ b/shiny/.agents/skills/session-lifecycle/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: session-lifecycle
+description: Covers the Shiny for Python (py-shiny) Session object - per-session cleanup with session.on_ended, before/after reactive-flush hooks with on_flush/on_flushed, reading the incoming request (headers, cookies, URL) via session.http_conn and session.clientdata, registering a per-session HTTP endpoint with session.dynamic_route, and obtaining the session with require_active_session. Use when running cleanup as a user disconnects (close a DB handle, cancel work), reading request headers/cookies/URL, serving a session-specific URL for another client to fetch, hooking work immediately before or after the reactive flush is sent to the client, or when tempted to use a module-level global for per-session state or a teardown at import time that never fires per user.
+---
+
+# Session lifecycle in Shiny for Python
+
+## Overview
+
+Every connected browser gets its own `Session` object. It is the natural home
+for per-user state and cleanup: resources opened for one user must be released
+when *that* user disconnects, not at process exit. Get the session as the
+`server` function's third argument, or call
+`require_active_session()` anywhere a reactive context is active.
+
+Do NOT store per-user state in a module-level global (it is shared across every
+connected session) and do NOT rely on `atexit`/module teardown for cleanup (it
+fires once at process shutdown, never per user). Use `session.on_ended` instead.
+
+```python
+from shiny import App, Inputs, Outputs, Session, reactive, render, ui
+
+def server(input: Inputs, output: Outputs, session: Session):
+    ...
+```
+
+To reach the session from a helper called inside a reactive context, use
+`require_active_session(None)` (it raises if no session is active).
+
+## Clean up when a user disconnects: `session.on_ended`
+
+Register a callback that runs after the client disconnects. Use it to close DB
+connections, cancel background work, or delete temp files. The callback may be
+sync or async; it returns a function that cancels the registration.
+
+```python
+def server(input, output, session):
+    conn = open_db()
+
+    @session.on_ended
+    def _():
+        conn.close()          # runs once, when this user's session ends
+```
+
+`on_ended` takes a single function; you can also call it directly:
+`session.on_ended(conn.close)`.
+
+`on_ended` fires when the whole session disconnects. To tear down just one
+module instance's reactive graph (not the entire session), use
+`session.destroy(id)` — see the modules-core skill.
+
+## Read the incoming request: `http_conn` and `clientdata`
+
+`session.http_conn` is the Starlette
+[`HTTPConnection`](https://www.starlette.io/requests/) for the WebSocket
+handshake — read headers, cookies, and query params from it. It is a plain
+attribute (not reactive), so it is safe to read anywhere in `server`.
+
+```python
+def server(input, output, session):
+    token = session.http_conn.headers.get("authorization")
+    theme = session.http_conn.cookies.get("theme", "light")
+```
+
+The browser's live URL is exposed reactively through `session.clientdata`
+(read only inside a reactive context):
+
+```python
+@render.text
+def where():
+    cd = session.clientdata
+    return f"{cd.url_protocol()}//{cd.url_hostname()}{cd.url_pathname()}{cd.url_search()}"
+```
+
+## Serve a per-session URL: `session.dynamic_route`
+
+Register an ad-hoc HTTP endpoint scoped to this session and get back its URL
+path. The handler takes a Starlette `Request` and returns a Starlette response.
+Useful for serving a session-specific asset or value for another client to
+`fetch`.
+
+```python
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+def server(input, output, session):
+    async def handler(request: Request) -> JSONResponse:
+        return JSONResponse({"n": input.serve()})
+
+    @reactive.effect
+    @reactive.event(input.serve)
+    def _():
+        path = session.dynamic_route("my_handler", handler)   # register, get URL
+        ui.insert_ui(ui.tags.script(f"fetch('{path}')..."), selector="body")
+```
+
+## Hook the reactive flush: `on_flush` / `on_flushed`
+
+A flush is when Shiny recomputes invalidated reactives and sends the resulting
+output updates to the client. `on_flush(fn)` runs *before* that send;
+`on_flushed(fn)` runs *after*. Both default to `once=True` (fire on the next
+flush only); pass `once=False` to run on every flush.
+
+```python
+def server(input, output, session):
+    session.on_flushed(lambda: print("client updated"), once=False)
+```
+
+## Quick reference
+
+| Need | Use |
+|---|---|
+| Get the session in `server` | third arg: `def server(input, output, session)` |
+| Get the session elsewhere | `require_active_session(None)` |
+| Run cleanup on disconnect | `@session.on_ended` |
+| Request headers / cookies | `session.http_conn.headers` / `.cookies` |
+| Live browser URL (reactive) | `session.clientdata.url_*()` |
+| Per-session HTTP endpoint | `path = session.dynamic_route(name, handler)` |
+| Run before flush is sent | `session.on_flush(fn, once=False)` |
+| Run after flush is sent | `session.on_flushed(fn, once=False)` |
+| Close the session | `await session.close()` |
+
+## Common mistakes
+
+- Per-user state in a module-level global -> shared across all sessions; create
+  it inside `server` (or a `reactive.value`) so each session gets its own.
+- Cleanup in `atexit`/module teardown -> fires once at shutdown, not per user;
+  register it with `session.on_ended`.
+- Reading `session.clientdata.url_*()` at module scope or in a plain helper ->
+  "no current reactive context" error; read inside a `@render.*`, `calc`, or
+  `effect`. `session.http_conn` is not reactive and can be read anywhere.
+- `await`ing `session.close()` without `async` -> `close` is a coroutine; call
+  it from an async `@reactive.effect`.
+- Passing a coroutine function to `on_ended`/`on_flush` -> fine, they accept
+  sync *or* async callbacks; just don't call the function yourself.
+
+## Related skills
+
+- Module namespaces (`session.make_scope`, `session.destroy(id)`,
+  `session.on_destroy`) -> **modules-core**.
+- Sending custom JS messages (`session.send_custom_message`) -> **custom-components**.
+  This skill owns `session.send_input_message` (the low-level primitive behind
+  `ui.update_*`; prefer the `ui.update_*` wrappers).
+- Saving/restoring session state across reconnects -> **bookmarking**.

--- a/shiny/.agents/skills/theming/SKILL.md
+++ b/shiny/.agents/skills/theming/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: theming
+description: Covers styling and appearance of Shiny for Python (py-shiny) apps with the ui.Theme Python API - applying a preset (Bootstrap/Bootswatch/shiny), customizing Sass variables (colors, fonts) via add_defaults/add_rules/add_mixins, brand.yml via Theme.from_brand, and light/dark mode with input_dark_mode/update_dark_mode. Use when changing an app's colors, fonts, or Bootstrap theme, applying a Bootswatch preset, adding a light/dark mode toggle, customizing Sass variables, or when tempted to paste large raw CSS overrides or hand-edit compiled Bootstrap CSS instead of using ui.Theme. Not for card/sidebar/navset layout structure.
+---
+
+# Theming Shiny for Python apps
+
+## Overview
+
+App appearance is controlled by a `ui.Theme` object passed to the `theme=`
+argument of a page function. A theme starts from a **preset** (Bootstrap,
+`"shiny"`, or a Bootswatch theme) and is customized by chaining `.add_*()`
+methods that inject Sass **before** the preset compiles — so you set Bootstrap
+Sass variables like `$primary` and get consistent, coherent styling across every
+component.
+
+Do NOT hand-edit compiled `bootstrap.min.css`, and do NOT paste large raw CSS
+overrides fighting Bootstrap's specificity. Set the Sass variable instead.
+Compiling a customized theme requires `libsass` (`pip install "shiny[theme]"`);
+the bundled `"bootstrap"` and `"shiny"` presets are pre-compiled and need no
+extra install.
+
+## Apply a preset
+
+Pass a `ui.Theme` (or just its preset name via the constructor) to the page's
+`theme=`. In Express, use `ui.page_opts(theme=...)` (see the `express` skill).
+
+```python
+from shiny import App, ui
+
+app_ui = ui.page_sidebar(
+    ui.sidebar(ui.input_slider("n", "N", 0, 100, 20)),
+    ui.h2("Themed app"),
+    title="My App",
+    theme=ui.Theme("flatly"),   # any Bootswatch preset, "bootstrap", or "shiny"
+)
+
+def server(input, output, session):
+    pass
+
+app = App(app_ui, server)
+```
+
+`ui.Theme.available_presets()` lists all valid preset names.
+
+## Pre-built themes and a runtime picker: shinyswatch
+
+`ui.Theme` already bundles every Bootswatch preset, so a static Bootswatch look
+needs no extra package. Reach for the separate **shinyswatch** package
+(`pip install shinyswatch`) when you want ready-made theme objects or a
+**live theme switcher** the user can operate at runtime:
+
+```python
+import shinyswatch
+from shiny import App, ui
+
+app_ui = ui.page_sidebar(
+    shinyswatch.theme_picker_ui(),          # dropdown to switch themes live
+    ui.h2("Themed app"),
+    title="My App",
+    theme=shinyswatch.theme.slate(),        # a ready-made Bootswatch theme object
+)
+
+def server(input, output, session):
+    shinyswatch.theme_picker_server()       # wire up the live switcher
+
+app = App(app_ui, server)
+```
+
+Omit `theme_picker_ui()`/`theme_picker_server()` if you only want the theme
+object. See `shiny/api-examples/theme/` for full examples.
+
+## Customize Sass variables (colors, fonts)
+
+`.add_defaults(...)` sets Bootstrap Sass **variables** (as `!default`, so the
+preset can still override structural values). Keyword names use underscores and
+convert to kebab-case: `primary_color="#..."` becomes `$primary-color`. The
+methods return the theme, so chain them.
+
+```python
+from shiny import ui
+
+my_theme = (
+    ui.Theme("shiny")
+    .add_defaults(
+        primary="#00aa88",                          # $primary
+        bootstrap_font_size_base="1.1rem",          # $font-size-base
+    )
+    # .add_mixins(...)  — inject Sass placed after preset mixins
+    .add_rules("""
+        .card { border-radius: 1rem; }              # literal CSS/Sass rules
+        em { color: $warning; }                     # can reference Sass vars
+    """)
+)
+
+app_ui = ui.page_fluid(ui.h2("Hi"), theme=my_theme)
+```
+
+- `.add_defaults(...)` — set/override Sass variables (colors, fonts, spacing).
+- `.add_rules(...)` — append custom CSS/Sass rules (may reference `$variables`).
+- `.add_mixins(...)` — add/override Sass mixins after the preset's.
+
+To avoid the runtime `libsass` dependency, precompile once with
+`my_theme.to_css()` and pass the resulting `.css` file path to `theme=`.
+
+## Dark mode
+
+`ui.input_dark_mode()` adds a light/dark toggle (Bootstrap color modes). Give it
+an `id` to read the current mode reactively as `input.<id>()`; drive it from the
+server with `ui.update_dark_mode("light"|"dark")`.
+
+```python
+from shiny import reactive
+from shiny.express import input, render, ui
+
+ui.input_dark_mode(id="mode")          # omit id if you don't need to read it
+
+@render.text
+def current():
+    return f"Mode: {input.mode()}"     # "light" or "dark"
+
+@reactive.effect
+@reactive.event(input.go_dark)
+def _():
+    ui.update_dark_mode("dark")
+```
+
+`mode=` on `input_dark_mode` forces the initial mode; the default follows the
+user's system preference.
+
+## brand.yml
+
+`ui.Theme.from_brand()` builds a theme from a `_brand.yml` file (shared brand
+colors, fonts, logo). Pass `__file__`, a directory, or the file path:
+
+```python
+from shiny.express import ui
+ui.page_opts(theme=ui.Theme.from_brand(__file__))
+```
+
+For authoring the `_brand.yml` file itself, use the external `shiny:brand-yml`
+skill — do not hand-write the spec here.
+
+## Custom CSS / JS assets
+
+For one-off styling outside the theme, include a stylesheet with
+`ui.include_css(path)` (or inline `ui.tags.style(...)`), and serve files from a
+`www/` directory or via `static_assets` on `App`. Reach for `ui.Theme` first for
+anything color/font/Bootstrap-wide; use raw CSS only for genuinely local tweaks.
+
+## Quick reference
+
+| Need | Use |
+|---|---|
+| Default Shiny look | `ui.Theme("shiny")` (bundled, no libsass) |
+| Plain Bootstrap 5 | `ui.Theme("bootstrap")` (bundled) |
+| A Bootswatch look | `ui.Theme("flatly")`, `"darkly"`, `"cosmo"`, `"minty"`, ... |
+| List all presets | `ui.Theme.available_presets()` |
+| Live theme switcher | shinyswatch: `theme_picker_ui()` + `theme_picker_server()` |
+| Set a Sass variable | `.add_defaults(primary="#...")` |
+| Add custom CSS/Sass rules | `.add_rules("...")` |
+| Add/override Sass mixins | `.add_mixins(...)` |
+| Theme from brand.yml | `ui.Theme.from_brand(__file__)` |
+| Precompile to CSS | `theme.to_css()` -> save, pass file path to `theme=` |
+| Dark/light toggle | `ui.input_dark_mode(id="mode")` |
+| Set mode from server | `ui.update_dark_mode("dark")` |
+| Include a stylesheet | `ui.include_css(path)` |
+
+## Common mistakes
+
+- Editing `bootstrap.min.css` or piling on `!important` CSS -> set the Bootstrap
+  Sass variable with `.add_defaults(...)` so the whole app stays consistent.
+- `ImportError` about `libsass`/`sass` when using a customized theme ->
+  `pip install "shiny[theme]"`; or precompile with `.to_css()` and ship the CSS.
+- Passing `ui.Theme(...)` somewhere other than a page's `theme=` (e.g. as a
+  child tag) -> it raises; it is only valid as the `theme=` argument.
+- Reading `input.mode()` with no `id` on `input_dark_mode` -> add
+  `id="mode"` so the current color mode is reported as an input.
+- Using kebab-case keyword names like `.add_defaults("primary-color"=...)` ->
+  use underscores (`primary_color=`); they convert to `$primary-color` for you.
+- Invalid preset name -> `ValueError`; check `ui.Theme.available_presets()`.


### PR DESCRIPTION
## Summary

Adds **17 bundled [Agent Skills](https://agentskills.io)** under `shiny/.agents/skills/`, expanding coverage from the existing four (`debugging`, `testing`, `bookmarking`, `otel`) to shiny's major public-API surface. Each skill is a reference doc that teaches coding agents how to use a public API — following the contract in `.claude/references/agent-skills.md`.

### New skills

- **Core concepts:** `reactivity`, `express`, `modules-core`, `modules-express`
- **Layout & UI:** `layouts`, `navigation`, `dynamic-ui`, `theming`
- **Outputs & generative AI:** `data-frames`, `plots`, `chat`, `markdown-streaming`
- **App capabilities:** `files`, `feedback`, `extended-tasks`, `session-lifecycle`
- **Extending shiny:** `custom-components`, `custom-renderers`

### Notes

- Each skill: unprefixed name matching its directory, a scoped `description` with non-overlapping boundaries, ~400–800 words, public-API-only copy-paste examples, a quick-reference table, and common mistakes.
- Descriptions were deliberately kept non-overlapping so agents load the right skill for a given symptom.
- Every skill was validated against the shipped source; several stale/deprecated APIs were steered away from in the process (e.g. `nav_insert`/`update_navs` → `insert_nav_panel`/`update_navset`, `conditional_panel` → `ui.panel_conditional`, `output_transformer`/`OutputRenderer` → `Renderer`, `session.download` → `render.download`, the removed `Chat.transform_*` hooks).
- `tests/pytest/test_packaging.py` passes (frontmatter/name contract + package-data globs).

Deployment was intentionally left out of this batch.