### PR TITLE
docs: Add version/date to CITATION.cff and automate updates in release skill

### DIFF
--- a/.claude/skills/py-shiny-release/references/release-phases.md
+++ b/.claude/skills/py-shiny-release/references/release-phases.md
@@ -56,7 +56,7 @@ Repo: `posit-dev/py-shiny`
 - [ ] Verify `pyproject.toml` has no git-based dependencies (e.g., no `htmltools @ git+https://...`)
 - [ ] Note: for py-shiny, tagging the commit triggers the version bump automatically (no manual `__init__.py` edit needed)
 - [ ] Bump version in CHANGELOG.md
-- [ ] Update `CITATION.cff`: set `version:` to `X.Y.Z` and `date-released:` to today's date (`YYYY-MM-DD`, the intended release date). This keeps GitHub's "Cite this repository" metadata current — see [issue #2359](https://github.com/posit-dev/py-shiny/issues/2359).
+- [ ] Update `CITATION.cff`: set `version:` to `X.Y.Z` and `date-released:` to today's date (`YYYY-MM-DD`, the intended release date).
 - [ ] Commit, push, open PR
 - [ ] Wait for CI to pass
 - [ ] Verify no additional commits were added beyond release prep

--- a/.claude/skills/py-shiny-release/references/release-phases.md
+++ b/.claude/skills/py-shiny-release/references/release-phases.md
@@ -56,6 +56,7 @@ Repo: `posit-dev/py-shiny`
 - [ ] Verify `pyproject.toml` has no git-based dependencies (e.g., no `htmltools @ git+https://...`)
 - [ ] Note: for py-shiny, tagging the commit triggers the version bump automatically (no manual `__init__.py` edit needed)
 - [ ] Bump version in CHANGELOG.md
+- [ ] Update `CITATION.cff`: set `version:` to `X.Y.Z` and `date-released:` to today's date (`YYYY-MM-DD`, the intended release date). This keeps GitHub's "Cite this repository" metadata current — see [issue #2359](https://github.com/posit-dev/py-shiny/issues/2359).
 - [ ] Commit, push, open PR
 - [ ] Wait for CI to pass
 - [ ] Verify no additional commits were added beyond release prep

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,3 +8,5 @@ license-url: "https://github.com/posit-dev/py-shiny/blob/main/LICENSE"
 repository-code: "https://github.com/posit-dev/py-shiny"
 type: software
 url: "https://shiny.posit.co/py/"
+version: "1.6.3"
+date-released: "2026-06-01"


### PR DESCRIPTION
## Problem

Closes #2359. Our `CITATION.cff` has never carried a released `version` or `date-released`, so GitHub's "Cite this repository" box produces a version-less citation. The reporter asked us to keep it current with each release.

## Changes

- **`CITATION.cff`**: add the optional CFF keys `version` and `date-released`, seeded with the current release (`1.6.3` / `2026-06-01`).
- **`py-shiny-release` skill**: add a Phase 3 step to update `version`/`date-released` in `CITATION.cff` during each py-shiny release, so the metadata stays current going forward.

Automating via the release skill (rather than a GitHub Actions workflow that commits back to `main`) keeps the update in the same RC PR that already bumps the changelog, so it goes through normal review and branch protection.

## Notes

- Both keys are optional in [CFF 1.2.0](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md); `version` is a string, `date-released` is `YYYY-MM-DD`.
- The `date-released` should be set to the intended release date at RC time.