### PR TITLE
docs: document ui.card_body in the API reference

### DIFF
--- a/docs/_quartodoc-core.yml
+++ b/docs/_quartodoc-core.yml
@@ -32,6 +32,7 @@ quartodoc:
         - ui.layout_column_wrap
         - ui.card
         - ui.card_header
+        - ui.card_body
         - ui.card_footer
         - ui.offcanvas
         - ui.popover

--- a/docs/_quartodoc-express.yml
+++ b/docs/_quartodoc-express.yml
@@ -65,6 +65,7 @@ quartodoc:
         - express.ui.layout_column_wrap
         - express.ui.card
         - express.ui.card_header
+        - express.ui.card_body
         - express.ui.card_footer
         - express.ui.value_box
         - express.ui.value_box_theme


### PR DESCRIPTION
## Problem

`ui.card_body` (and `express.ui.card_body`) is a public, exported function — it's in both `shiny.ui.__all__` and `shiny.express.ui.__all__`, has a docstring, and already has an `@add_example()`-registered example (`shiny/api-examples/card_body/` with both `app-core.py` and `app-express.py`).

However, it was **missing from the quartodoc configs** (`docs/_quartodoc-core.yml` and `docs/_quartodoc-express.yml`), unlike its siblings `card_header` and `card_footer`. As a result, no API reference page was generated, and links to `https://shiny.posit.co/py/api/ui.card_body.html` (used in the py-shiny-site docs) return **404**.

## Change

Add `ui.card_body` / `express.ui.card_body` to the quartodoc `UI Layouts` / `Layouts and other UI tools` sections, right after `card_header` (header → body → footer order). No code changes — the function and its example already exist.

## Verification

Built the docs against py-shiny-site with these configs: `make quartodoc` succeeds and generates `api/core/ui.card_body.qmd` and `api/express/express.ui.card_body.qmd`, both wired into the sidebars.