### PR TITLE
chore: Update sub-issue skill to use native gh CLI flags

### DIFF
--- a/.claude/skills/sub-issue/SKILL.md
+++ b/.claude/skills/sub-issue/SKILL.md
@@ -1,22 +1,22 @@
 ---
-# https://raw.githubusercontent.com/posit-dev/connect/refs/heads/main/.claude/skills/sub-issue/SKILL.md?token=GHSAT0AAAAAAC7BSG2IOYC77SLM7CEB3I3C2LKMOXQ
+# Source: https://github.com/posit-dev/connect/blob/5581fe8d1b7d1e78ba6b78ecfd1963122eb63049/.claude/skills/sub-issue/SKILL.md
 name: sub-issue
-description: Manage GitHub sub-issues using the gh-sub-issue extension. Use when the user asks to create, list, add, or remove sub-issues (child issues) from a parent issue.
+description: Manage GitHub sub-issues using the gh CLI (v2.94.0+). Use when the user asks to create, list, add, or remove sub-issues (child issues) from a parent issue.
 ---
 
 # GitHub Sub-Issue Management
 
-Manage GitHub sub-issues (child issues) using the `gh sub-issue` extension.
+Manage GitHub sub-issues (child issues) using native `gh` CLI commands (v2.94.0+).
 
 ## Prerequisites
 
-Before using any sub-issue commands, check if the extension is installed:
+Before using any sub-issue commands, verify the `gh` CLI is v2.94.0 or newer:
 
 ```bash
-gh extension list | grep -q sub-issue || gh extension install yahsan2/gh-sub-issue
+gh --version
 ```
 
-This will install the extension if it's not already present.
+If the version is older than 2.94.0, the native sub-issue flags (`--parent`, `--add-sub-issue`, `--remove-sub-issue`, `--remove-parent`) will not be available. In that case, advise the user to upgrade `gh` before proceeding.
 
 ## Commands
 
@@ -25,52 +25,63 @@ This will install the extension if it's not already present.
 Create a new issue directly linked as a child of a parent issue:
 
 ```bash
-gh sub-issue create --parent <parent-issue> --title "<title>" --body "<body>" --repo posit-dev/connect
+gh issue create --parent <parent-issue> --title "<title>" --body "<body>" --repo posit-dev/py-shiny
 ```
 
 **Flags:**
-- `-p, --parent` — Parent issue number or URL (required)
-- `-t, --title` — Title for new sub-issue (required)
-- `-b, --body` — Body text for the sub-issue
-- `-l, --label` — Comma-separated labels
-- `-a, --assignee` — Comma-separated usernames
-- `-m, --milestone` — Milestone name or number
-- `--project` — Projects (can specify multiple times)
+- `--parent` — Parent issue number or URL (required for sub-issue linking)
+- `--title` — Title for new sub-issue (required)
+- `--body` — Body text for the sub-issue
+- `--label` — Comma-separated labels
+- `--assignee` — Comma-separated usernames
+- `--milestone` — Milestone name or number
+- `--project` — Project to add the issue to
 
-### Link an existing issue as a sub-issue
+### Add an existing issue as a sub-issue
 
 ```bash
-gh sub-issue add <parent-issue> <sub-issue> --repo posit-dev/connect
+gh issue edit <parent-issue> --add-sub-issue <child-issue> --repo posit-dev/py-shiny
+```
+
+### Set or change the parent of an issue
+
+```bash
+gh issue edit <child-issue> --parent <parent-issue> --repo posit-dev/py-shiny
 ```
 
 ### List sub-issues of a parent
 
 ```bash
-gh sub-issue list <parent-issue> --repo posit-dev/connect
-gh sub-issue list <parent-issue> --state all --repo posit-dev/connect
+gh issue view <parent-issue> --json subIssues,subIssuesSummary --repo posit-dev/py-shiny
 ```
 
 ### Remove a sub-issue link
 
 ```bash
-gh sub-issue remove <parent-issue> <sub-issue> --repo posit-dev/connect
+gh issue edit <parent-issue> --remove-sub-issue <child-issue> --repo posit-dev/py-shiny
+```
+
+### Remove parent from an issue
+
+```bash
+gh issue edit <child-issue> --remove-parent --repo posit-dev/py-shiny
 ```
 
 ## Usage Notes
 
-1. Always include `--repo posit-dev/connect` to ensure correct repository context
+1. Always include `--repo posit-dev/py-shiny` to ensure correct repository context
 2. When creating multiple sub-issues, create them sequentially to avoid rate limiting
 3. Use `--body` with heredoc for multi-line descriptions:
 
 ```bash
-gh sub-issue create --parent 123 --title "My issue" --body "$(cat <<'EOF'
+gh issue create --parent 123 --title "My issue" --body "$(cat <<'EOF'
 Description here.
 
 **Acceptance criteria:**
 1. First item
 2. Second item
 EOF
-)" --repo posit-dev/connect
+)" --repo posit-dev/py-shiny
 ```
 
 4. Reference the parent issue in the body for context (e.g., "Part of #123")


### PR DESCRIPTION
## Summary

Updates `.claude/skills/sub-issue/SKILL.md` to match the upstream version in `posit-dev/connect` ([permalink](https://github.com/posit-dev/connect/blob/5581fe8d1b7d1e78ba6b78ecfd1963122eb63049/.claude/skills/sub-issue/SKILL.md)).

The skill no longer depends on the third-party `yahsan2/gh-sub-issue` extension. Sub-issue management now uses flags built into `gh` itself (v2.94.0+), so there is no extension to install and the prerequisite check is a version check instead. Command mapping: `gh sub-issue create --parent N` -> `gh issue create --parent N`; `gh sub-issue add P C` -> `gh issue edit P --add-sub-issue C`; `gh sub-issue list P` -> `gh issue view P --json subIssues,subIssuesSummary`; `gh sub-issue remove P C` -> `gh issue edit P --remove-sub-issue C`. Two new operations are documented that the extension didn't offer: setting an existing issue's parent (`gh issue edit C --parent P`) and clearing it (`--remove-parent`).

Two deliberate deviations from a verbatim copy of upstream: the hardcoded `--repo posit-dev/connect` is changed to `--repo posit-dev/py-shiny` throughout (the previous local copy had inherited connect's repo, which was wrong here), and the frontmatter source comment now uses a commit-pinned permalink rather than the tokenized `raw.githubusercontent.com` URL that was there before.

## Verification

Docs-only change to an Agent Skill; no runtime surface. To verify the documented commands work, `gh --version` must report 2.94.0 or newer, then:

```
gh issue view 2372 --json subIssues,subIssuesSummary --repo posit-dev/py-shiny
```

Note my local `gh` is 2.79.0, so I could not execute the new flags to confirm them; they are taken from upstream and GitHub's CLI docs.