### PR TITLE
docs(bookmark): update outdated commit sha reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Fixed a path-traversal vulnerability in bookmark restore (CWE-22). Introduced in 1.4.0. Reported by @0xRenSec.
 
-* When bookmarked state cannot be restored, the notification shown in the client is now a generic message. The reason is logged server-side as a warning on the `shiny.bookmark._restore_state` logger, so app authors can still see it. (423aae3e)
+* When bookmarked state cannot be restored, the notification shown in the client is now a generic message. The reason is logged server-side as a warning on the `shiny.bookmark._restore_state` logger, so app authors can still see it. (ab10e069)
 
 ### Other changes
 

--- a/shiny/bookmark/_bookmark_state.py
+++ b/shiny/bookmark/_bookmark_state.py
@@ -8,7 +8,7 @@ shiny_bookmarks_folder_name = "shiny_bookmarks"
 
 # Allowlist for the client-supplied `_state_id_`: a single path segment that
 # can't express a separator, `..`, or an absolute path. (R uses `[a-zA-Z0-9]`;
-# `-`/`_` are allowed here for UUID/token-style ids.) (423aae3e)
+# `-`/`_` are allowed here for UUID/token-style ids.) (ab10e069)
 _valid_bookmark_id_re = re.compile(r"[A-Za-z0-9_-]+")
 
 # Guards only against an attacker echoing a huge id back through error/log output.
@@ -24,7 +24,7 @@ def _local_dir(id: str) -> Path:
     validate_bookmark_id(id)
     # `id` is a single safe path segment, so this join can't escape the store.
     # Not `.resolve()`d: that would follow a symlinked per-id dir out and break
-    # stores backed by symlinked/persistent storage. (423aae3e)
+    # stores backed by symlinked/persistent storage. (ab10e069)
     return Path(os.getcwd()) / shiny_bookmarks_folder_name / id
 
 

--- a/tests/pytest/test_bookmark_security.py
+++ b/tests/pytest/test_bookmark_security.py
@@ -1,4 +1,4 @@
-"""Tests for bookmark id validation and restore gating (423aae3e).
+"""Tests for bookmark id validation and restore gating (ab10e069).
 
 Covers the `_state_id_` id allowlist, the rule that a restore only reads from
 disk under `bookmark_store="server"`, and the file-input restore source checks.


### PR DESCRIPTION
The bookmark security code references pointed at `423aae3e`, which is not a valid object in this repository. This updates them to `ab10e069`.