### PR TITLE
docs: Record the 1.6.4 security patch in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,10 +67,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Fixed the `value_box()` `id` parameter docstring, which previously documented the wrong reactive-value syntax (`input.<id>()["full_screen"]`) for observing the value box's full screen state. It now correctly documents `input.<id>_full_screen()`, matching `card()`. (#2324)
 
-* Fixed a path-traversal vulnerability in bookmark restore (CWE-22). Introduced in 1.4.0. Reported by @0xRenSec.
-
-* When bookmarked state cannot be restored, the notification shown in the client is now a generic message. The reason is logged server-side as a warning on the `shiny.bookmark._restore_state` logger, so app authors can still see it. (ab10e069)
-
 ### Other changes
 
 * CI now runs the unit tests on Ubuntu with the oldest supported Python (3.10) and every runtime dependency resolved to its declared minimum version (via `uv pip compile --resolution lowest-direct`), so stale lower bounds in `pyproject.toml` are caught. As part of this, `starlette` and `prompt-toolkit` gained explicit lower bounds (`>=0.17.1` and `>=3.0.0`), and the `opentelemetry-api`/`opentelemetry-sdk` minimums were raised from 1.20.0 to 1.24.0 — older versions could leak unsanitized error messages in span exception stack traces. Shiny's OpenTelemetry log emission (which relied on the `Logger.emit()` keyword form added in opentelemetry 1.38.0 and was silently dropped on older versions) now falls back to constructing the `LogRecord` manually, so it works across the whole supported range. (#2335)
@@ -84,6 +80,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `shiny.run.run_shiny_app()` (and therefore `shiny.pytest.create_app_fixture()`) now picks random app ports from a disjoint per-worker port range when running under pytest-xdist, instead of the full 1024-49151 range shared by all workers. This prevents parallel test workers from racing to bind the same port and from reusing each other's recycled ports. When not running under pytest-xdist, the behavior is unchanged: ports are picked from `random_port()`'s full default range (1024-49151). (#2297)
 
 * Docs builds now fail when an `@add_example()` API reference is missing its example app, instead of emitting a warning and silently omitting the example. Several APIs whose examples had gone missing this way were fixed, and missing Shiny Express examples were added. (Thanks, @EltonChang1!) (#2278)
+
+## [1.6.4] - 2026-07-28
+
+### Bug fixes
+
+* Fixed a path-traversal vulnerability in bookmark restore (CWE-22). Introduced in 1.4.0. Reported by @0xRenSec.
+
+* When bookmarked state cannot be restored, the notification shown in the client is now a generic message. The reason is logged server-side as a warning on the `shiny.bookmark._restore_state` logger, so app authors can still see it. (ab10e069)
 
 ## [1.6.3] - 2026-06-01
 


### PR DESCRIPTION
Shiny 1.6.4 was released as a security patch off the `v1.6.3` tag (branch `rc-v1.6.4`), not off `main`, because `main` carries ~50 unreleased commits. The bookmark path-traversal fix (`ab10e069`) is already on `main`, but its changelog bullets were still sitting under `[UNRELEASED]`, which would have mis-attributed them to the next feature release.

This moves the two bullets into a `## [1.6.4] - 2026-07-28` section so `main`'s changelog matches what was actually published.

No code changes. The stale `423aae3e` placeholder refs were already corrected to `ab10e069` in #2374.

Release: https://github.com/posit-dev/py-shiny/releases/tag/v1.6.4