### PR TITLE
chore(docs): Bump shinylive to >=0.8.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,7 @@ doc = [
     "jupyter",
     "jupyter_client < 8.0.0",
     "tabulate",
-    "shinylive>=0.8.9",
+    "shinylive>=0.8.10",
     "pydantic>=2.7.4",
     "quartodoc>=0.8.1",
     "griffe>=1.3.2,<2.0.0",


### PR DESCRIPTION
Bumps the `shinylive` bound in the `[doc]` extra from `>=0.8.9` to `>=0.8.10`, so docs builds pick up Shinylive web assets 0.10.13 (which bundle Shiny for Python 1.6.4).

Part of the v1.6.4 release train. py-shinylive 0.8.10 is on PyPI: https://pypi.org/project/shinylive/0.8.10/