### PR TITLE
fix(release-skill): Read shinylive examples from examples/index.json

### DIFF
--- a/.claude/skills/py-shiny-release/references/test_shinylive_site.py
+++ b/.claude/skills/py-shiny-release/references/test_shinylive_site.py
@@ -17,18 +17,25 @@ import time
 from playwright.async_api import async_playwright
 
 CACHE_BUSTER = str(int(time.time()))
-MIN_EXAMPLES = 50
+MIN_EXAMPLES = 25
 
 
 def fetch_examples() -> list[str]:
-    """Dynamically fetch the list of Python examples from the shinylive repo."""
+    """Dynamically fetch the list of Python examples from the shinylive repo.
+
+    `examples/index.json` is the source of truth: it drives which apps get built
+    into `examples.json`, and that is the only example content the site serves.
+    Listing `examples/python/` instead over-counts, because unindexed app
+    directories can linger on disk without ever being built or served.
+    """
     result = subprocess.run(
         [
             "gh",
             "api",
-            "repos/posit-dev/shinylive/contents/examples/python",
+            "repos/posit-dev/shinylive/contents/examples/index.json",
             "--jq",
-            ".[].name",
+            '.content | @base64d | fromjson | .[] | select(.engine == "python")'
+            " | .examples[].apps[]",
         ],
         capture_output=True,
         text=True,


### PR DESCRIPTION
## Why

The release skill's shinylive example sweep enumerated examples by listing `examples/python/` in the shinylive repo. That directory can contain app directories that are not listed in `examples/index.json` — and `index.json` is the source of truth: it drives which apps get built into `examples.json`, which is the only example content the site serves. An unindexed directory is never built, never served, and cannot be loaded by URL.

So the sweep had been over-counting by 23 examples, silently, and its `MIN_EXAMPLES = 50` guard was calibrated against that inflated number.

This surfaced during the v1.7.0 release: [posit-dev/shinylive#234](https://github.com/posit-dev/shinylive/pull/234) removed the 23 orphaned directories, the listing dropped 51 → 28, and the guard aborted the sweep before testing anything:

```
AssertionError: Expected at least 50 examples, but found 28.
```

The number of examples the site actually serves never changed.

## What

- Enumerate examples from `examples/index.json` (filtered to `engine == "python"`) instead of the directory listing.
- Lower `MIN_EXAMPLES` to 25.
- Document why `index.json` is the right source.

## Verification

`fetch_examples()` now returns 28 names, matching `index.json` and the surviving directories exactly. Full sweep against the deployed docs site passed 28/28 with no console errors:

```
Site: https://posit-dev.github.io/py-shiny/shinylive/py/examples/
Results: 28 passed, 0 errors out of 28 examples
```

Part of the py-shiny v1.7.0 release train; found while running Phase 3's sweep.