### PR TITLE
chore(ci): Track py-shiny-templates default branch again

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -292,12 +292,6 @@ jobs:
         with:
           repository: posit-dev/py-shiny-templates
           path: py-shiny-templates
-          # TODO: release - Temporarily pinned to the branch of
-          # posit-dev/py-shiny-templates#55, which migrates the templates to
-          # render.download_button/link (deprecating render.download, py-shiny#2364).
-          # Before release: merge py-shiny-templates#55 after this py-shiny version is
-          # on PyPI, then remove this `ref:` so CI tracks the default branch again.
-          ref: migrate-render-download-button
 
       - name: Install py-shiny-templates dependencies
         run: |


### PR DESCRIPTION
## Why

`.github/workflows/pytest.yaml` temporarily pinned the py-shiny-templates checkout to the branch of [posit-dev/py-shiny-templates#55](https://github.com/posit-dev/py-shiny-templates/pull/55), which migrated the templates to `@render.download_button` / `@render.download_link` (deprecating `@render.download`, #2364). The pin carried a `TODO: release` marker saying to remove it once that PR merged, after this py-shiny version reached PyPI.

Both preconditions are met:

- `shiny` **1.7.0** is on PyPI.
- py-shiny-templates#55 is merged (`a7bc3893`).

## What

Drop the `ref: migrate-render-download-button` line and its `TODO: release` comment, so CI tracks the templates' default branch again.

## Note

Before merging #55 I also had to resolve the `TODO: release` markers *inside* it — its three touched `requirements.txt` files pinned `shiny @ git+https://github.com/posit-dev/py-shiny.git@main` as a pre-1.7.0 stopgap. Those now read `shiny>=1.7.0`, a floor rather than the bare `shiny` used by the other 31 templates, since `gen-ai/dinner-recipe`, `gen-ai/workout-plan` and `monitor-folder` genuinely require an API that does not exist in 1.6.x. Had they been merged as-is, the templates repo would have shipped a git dependency.

This removes the last `TODO: release` marker from the v1.7.0 release train. Part of that train; see #2377.