### PR TITLE
docs(release-skill): Fold in corrections found during the v1.7.0 train

### DIFF
--- a/.claude/skills/py-shiny-release/SKILL.md
+++ b/.claude/skills/py-shiny-release/SKILL.md
@@ -23,6 +23,36 @@ explicit user confirmation before proceeding to the next.
 - If the user says "skip", mark the phase done and move on
 - If a phase fails, help debug before moving on
 - Never proceed to the next phase until the current one is resolved or explicitly skipped
+- **Shut down every long-running process a phase started before marking it complete** (see
+  below)
+
+### Clean up background processes at the end of each phase
+
+Several phases start servers or watchers that never exit on their own — most notably Phase 6's
+`make serve` (a watch-mode dev server on port 3000). Left running, they hold ports, keep
+rebuilding on file changes, and clutter the background task list for the rest of a release that
+spans many hours.
+
+When a phase is done, before marking it complete:
+
+1. Identify what the phase left behind, e.g.:
+   ```bash
+   lsof -nP -iTCP:3000 -sTCP:LISTEN     # Phase 6 `make serve`
+   lsof -nP -iTCP:8100 -sTCP:LISTEN     # Playwright's _shinylive webServer
+   ```
+2. Kill it and confirm the port actually closed, rather than assuming:
+   ```bash
+   kill <pid>
+   curl -s -o /dev/null -m 3 -w "%{http_code}\n" http://localhost:3000/ || echo closed
+   ```
+3. Say in the phase wrap-up which processes were shut down.
+
+Only keep a server alive past its phase if a later step genuinely needs it, and say so
+explicitly. Note that Playwright's own `webServer` (port 8100) stops itself when a run
+finishes — it is `make serve` that lingers.
+
+Watchers that poll CI or PyPI are fine to leave; they exit on their own. It is the servers
+that need killing.
 
 ### Pre-release gate (REQUIRED before any release action)
 

--- a/.claude/skills/py-shiny-release/SKILL.md
+++ b/.claude/skills/py-shiny-release/SKILL.md
@@ -77,16 +77,20 @@ For each marker:
 1. Read it — it says what to do and whether it happens **before** or **after** the PyPI
    publish, and links the holding PR it depends on.
 2. Add it to the TodoWrite checklist at the correct point in the phase order.
-3. Do NOT complete the release while any `TODO: release` marker is unresolved: either the
+3. **Scan the holding PR's own diff for `TODO: release` markers before merging it.** A
+   holding PR frequently carries its own stopgaps — most often a `requirements.txt` or
+   `pyproject.toml` switched to `git+https://github.com/posit-dev/py-shiny.git@main`
+   because the API it needs is not on PyPI yet. Merging the holding PR without reverting
+   those leaves a **git dependency in the downstream repo**, which is exactly what the
+   pre-release gate screens for everywhere else. Resolve them, verify against the newly
+   published wheel that the API really exists (check the parameter names the downstream
+   code passes, not just that the symbol imports), then merge.
+4. Do NOT complete the release while any `TODO: release` marker is unresolved: either the
    action has been performed and the marker removed, or the user has explicitly deferred it.
 
-**Known holding item (as of py-shiny #2364 — `render.download` deprecation):**
-`.github/workflows/pytest.yaml` temporarily pins the `py-shiny-templates` checkout to the
-branch of [posit-dev/py-shiny-templates#55](https://github.com/posit-dev/py-shiny-templates/pull/55)
-(which migrates the templates to `render.download_button`/`render.download_link`). During
-Phase 3 (py-shiny), **after** this py-shiny version is published to PyPI: merge
-py-shiny-templates#55, then open a follow-up py-shiny PR removing the `ref:` pin so CI
-tracks the templates' default branch again. Remove the `TODO: release` comment in that PR.
+There is no standing holding item at the moment. When one exists, describe it here with
+its holding PR link and whether it acts before or after publish, and delete the note once
+the release that consumes it has shipped.
 
 ## Phase Overview
 
@@ -141,19 +145,51 @@ Many phases (2-5, 7) follow this common flow:
 
 ### GH Release naming conventions
 
-Each repo's PyPI publish workflow triggers based on the GH Release **title** matching a specific
-prefix. Always check the workflow file if unsure, but the known patterns are:
+Most repos' PyPI publish workflows are gated on the GH Release **title**. The gate is not
+the same everywhere — check the workflow file if unsure. Use the titles below regardless,
+for consistency:
 
-| Repo | Release title must start with | Example |
-|------|-------------------------------|---------|
-| py-htmltools | `htmltools` | `htmltools 0.6.1` |
-| py-shiny | `shiny` | `shiny 1.6.1` |
-| py-shinyswatch | `shinyswatch` | `shinyswatch 0.10.0` |
-| py-shinywidgets | `shinywidgets` | `shinywidgets 0.8.0` |
-| py-shinylive | `shinylive` | `shinylive 0.8.8` |
+| Repo | Title to use | Publish gate |
+|------|--------------|--------------|
+| py-htmltools | `htmltools 0.7.0` | starts with `htmltools` |
+| py-shiny | `shiny 1.7.0` | starts with `shiny` |
+| py-shinyswatch | `shinyswatch 0.12.0` | **not** `TEST` (see below) |
+| py-shinywidgets | `shinywidgets 0.8.1` | starts with `shinywidgets` |
+| py-shinylive | `shinylive 0.8.10` | starts with `shinylive` |
+
+**Two different failure modes**, so it matters which gate a repo uses:
+
+- **Prefix gates** (py-shiny, py-htmltools, py-shinywidgets, py-shinylive) fail *silently*:
+  a mistitled release makes the publish step skip while the workflow still reports success,
+  so the package never reaches PyPI. See Phase 7 for how to recover (recreate the GH Release
+  object to re-fire `release: published`; keep the tag).
+- **py-shinyswatch inverts this.** `.github/workflows/pytest.yaml` gates prod publish on
+  `if: ${{ !startsWith(github.event.release.name, 'TEST') }}` and test-PyPI publish on
+  `startsWith(..., 'TEST')`. So *any* non-`TEST` title publishes to prod — the title is
+  cosmetic, and the real hazard is the opposite one: an accidental `TEST` prefix silently
+  diverts the release to test.pypi.org.
 
 Also, before writing release notes, check existing releases for format conventions:
 `gh api repos/<org>/<repo>/releases --jq '.[:3] | .[] | .body'`
+
+### Publishing to PyPI is not instantaneous
+
+After a `Deploy to PyPI` job reports success, PyPI's index can lag by minutes. Two
+consequences:
+
+- Poll **PyPI itself**, not just the workflow, before starting a phase that installs the
+  new version: `curl -s https://pypi.org/pypi/<pkg>/json | jq -r .info.version`.
+- A downstream repo's CI may still fail to resolve the new floor
+  (`ERROR: Could not find a version that satisfies the requirement shiny>=X.Y.Z`) on one
+  runner while the rest of the matrix succeeds. That is a stale index, not a bad pin —
+  **rerun the job**, do not weaken the requirement.
+
+### Verifying build commands
+
+When running a long build through a pipe (`make all 2>&1 | tail -60`), the reported exit
+status comes from `tail`, not from `make` — a failed build looks like success. Either drop
+the pipe, use `set -o pipefail`, or verify the build from its artifacts (expected wheels
+present and at the expected versions) rather than from the exit code.
 
 ## Parallelism
 

--- a/.claude/skills/py-shiny-release/SKILL.md
+++ b/.claude/skills/py-shiny-release/SKILL.md
@@ -221,6 +221,46 @@ status comes from `tail`, not from `make` — a failed build looks like success.
 the pipe, use `set -o pipefail`, or verify the build from its artifacts (expected wheels
 present and at the expected versions) rather than from the exit code.
 
+### Never report CI status from a truncated or PR-level view
+
+Two ways a status report goes wrong, both of which happened during the v1.7.0 train — once
+claiming green when a check was failing, once claiming no-CI when everything had passed:
+
+- **Do not pipe the check list through `head`.** These repos have 8-350 checks and the failing
+  one is rarely in the first few. Aggregate instead of sampling, then list only what is not
+  passing:
+
+  ```bash
+  gh pr checks <N> --repo <repo> --json state \
+    --jq '[.[]|.state]|group_by(.)|map({state:.[0],n:length})'
+  gh pr checks <N> --repo <repo> --json name,state,link \
+    --jq '.[]|select(.state!="SUCCESS" and .state!="SKIPPED")|"\(.name) \(.state)\n  \(.link)"'
+  ```
+
+- **`gh pr checks` reports on the PR's current head.** If anything pushed a commit after
+  yours (a formatter bot, for instance), checks can read as missing or blocked even though CI
+  passed on your commit. Confirm by listing runs with their SHAs (`gh run list --json
+  headSha,status,conclusion`) and comparing against `gh pr view --json headRefOid`.
+
+Relatedly, `mergeStateStatus: BLOCKED` does **not** mean CI failed — it usually means a
+required review is missing, or a check suite is awaiting approval. Check which before
+reporting.
+
+### Read existing PR and issue comments before investigating
+
+Downstream repos accumulate diagnosis in comment threads across release cycles. Before
+digging into a failure — especially a recurring one on a conda-forge feedstock — read the
+comments on the open and recently closed PRs. During the v1.7.0 train a full root-cause
+analysis of the feedstock failure already existed in a PR comment, and was re-derived from
+scratch instead.
+
+### Clone downstream repos outside the py-shiny working tree
+
+Cloning a release repo into a subdirectory of py-shiny (e.g. `.context/`) makes tooling walk
+up and pick up py-shiny's configuration. `pytest` in particular resolves py-shiny's
+`pytest.ini` as its rootdir and then fails with `unrecognized arguments: --numprocesses`.
+Clone to a sibling directory, or override with `-o addopts="" --rootdir=.`.
+
 ## Parallelism
 
 Once the PyPI packages are published (phases 2-7), several later phases can run concurrently

--- a/.claude/skills/py-shiny-release/references/release-phases.md
+++ b/.claude/skills/py-shiny-release/references/release-phases.md
@@ -292,6 +292,13 @@ land on disk; only the pinned ones load. Missing `*-tests.tar` entries are likew
 - [ ] **DEPLOY GATE 2 (shinylive.io)**: Wait for the `deploy` branch deploy to shinylive.io to finish. Then bust all browser caches and verify apps work on shinylive.io using the same testing procedure with cache-busting (fresh incognito context or `?v={timestamp}` query params).
 - [ ] Create GH Release. Check existing release note conventions (`gh api repos/posit-dev/shinylive/releases --jq '.[:3] | .[] | .body'`) and match the format used by recent releases.
 - [ ] Wait for release to succeed and build artifact to appear in GH Release page
+- [ ] Confirm the artifact really uploaded — `gh release view vX.Y.Z --repo posit-dev/shinylive
+      --json assets` should show `shinylive-X.Y.Z.tar.gz` with `state=uploaded` (it is ~435 MB,
+      so it appears a while after the release object does). Phases 7 and 8 pin this as
+      `SHINYLIVE_ASSETS_VERSION`, so a missing artifact blocks both.
+- [ ] **Clean up**: kill the `make serve` dev server this phase started (port 3000) and confirm
+      the port closed. See "Clean up background processes at the end of each phase" in
+      `SKILL.md`.
 
 ### Local shinylive example testing procedure
 

--- a/.claude/skills/py-shiny-release/references/release-phases.md
+++ b/.claude/skills/py-shiny-release/references/release-phases.md
@@ -384,12 +384,51 @@ Use the shinylive JS version from Phase 6 (already known at this point).
 - [ ] Check for any existing open PRs that bump `SHINYLIVE_ASSETS_VERSION` (`gh pr list --repo posit-dev/r-shinylive --state open --search "SHINYLIVE_ASSETS_VERSION"`). If found, close them.
 - [ ] Create a branch with the following changes:
   - Update `SHINYLIVE_ASSETS_VERSION` in `R/version.R` to the Phase 6 shinylive JS version
-  - Bump `Version` in `DESCRIPTION` to the next dev version (e.g., `0.4.1.9000`)
-  - Add a `NEWS.md` entry under the dev version heading (e.g., `# shinylive 0.4.1.9000`) noting the assets update
+  - Bump `Version` in `DESCRIPTION` to the next dev version (e.g., `0.4.1.9000`) — **only if
+    it is not already a dev version**. If it already ends in `.9000` there is nothing to do,
+    and the NEWS entry goes under the existing `# shinylive (development version)` heading.
+  - Add a `NEWS.md` entry noting the assets update. Match the established wording, which
+    links the release and calls out what changed for R users — usually whether the bundled
+    webR moved, since a py-shiny-only bump does not affect R apps.
 - [ ] Commit, push, open PR
 - [ ] Wait for CI to pass
 - [ ] Ask user to confirm before merging the PR
 - [ ] Merge PR (squash merge)
+
+**This does not ship to users.** r-shinylive releases through CRAN, so a dev-version assets
+bump reaches R users only at its next CRAN release. Say so when reporting the phase complete,
+or it reads as though the R side is live like the PyPI packages are.
+
+**Note the assets version may skip releases.** If a shinylive version was cut but never
+deployed to shinylive.io (see the note on v0.10.13), r-shinylive will be behind by more than
+one. Bump to the current one and mention the skip in the PR body.
+
+### A formatter bot may push to your PR branch
+
+`r-shinylive` runs an `air format` workflow that commits fixes directly to PR branches. Two
+consequences:
+
+1. Your PR can pick up an **unrelated** formatting change (a pre-existing violation elsewhere
+   in the package). Harmless, but mention it in the squash-merge body so it does not look like
+   part of the release change.
+2. Because the push is from a bot, GitHub gates the resulting workflow run as
+   `action_required` with **zero jobs**. This makes `gh pr checks` report
+   *"no checks reported on the branch"* and the PR show `mergeStateStatus: BLOCKED`, which
+   looks exactly like CI never ran — when in fact it passed on your commit.
+
+Diagnose by listing runs with their SHAs rather than trusting the PR-level view:
+
+```bash
+gh run list --repo posit-dev/r-shinylive --limit 5 \
+  --json databaseId,status,conclusion,headSha,event
+gh pr view <N> --repo posit-dev/r-shinylive --json headRefOid   # compare
+```
+
+Then approve the gated run so checks report against the new head:
+
+```bash
+gh api -X POST repos/posit-dev/r-shinylive/actions/runs/<RUN_ID>/approve
+```
 
 ---
 
@@ -409,14 +448,56 @@ Repo: `posit-dev/py-shiny`
 
 Repo: `posit-dev/py-shiny-site`
 
-- [ ] Update the py-shiny submodule to point to the release tag
-- [ ] Update py-shinylive version in `requirements.txt`
+- [ ] Update the py-shiny submodule to point to the release tag. **Check how far behind it
+      was** — if it lagged by more than one release, the PR also lands the intermediate ones,
+      which is worth saying in the PR body (a skipped security patch especially).
+- [ ] Update py-shinylive version in `requirements.txt`. Note this is an **exact** pin
+      (`shinylive==0.8.11`), not a floor.
 - [ ] Create a PR
 - [ ] Use deployment preview to verify:
-  - [ ] API docs are correct
-  - [ ] Examples run properly
+  - [ ] API docs are correct — especially pages for APIs the release added
+  - [ ] Deprecations render as deprecated
+  - [ ] Examples run properly. Embedded editors now execute the new shiny, so an example using
+        a newly deprecated API will print a deprecation warning in the browser console.
 - [ ] Ask user to confirm before merging the PR
 - [ ] Merge PR
+
+### Expect the doc-coverage test to fail when the release adds UI components
+
+`components/test_ui_api_has_page.py::test_every_ui_export_has_a_page` asserts that every
+`shiny.ui` / `shiny.express.ui` export is either documented or explicitly opted out. It
+computes `API - DOCUMENTED - KNOWN_MISSING_COMPONENTS`, so **any new UI export fails the
+`apps` job until a page exists**:
+
+```
+AssertionError: These shiny.ui / shiny.express.ui exports have no doc page:
+  ['Offcanvas', 'hide_offcanvas', 'offcanvas', 'show_offcanvas', 'toggle_offcanvas'].
+```
+
+This is predictable rather than surprising: scan the release's **New features** changelog
+section for new UI exports before opening the PR. Options are to write the `components/` page
+and list the exports in its `relevant-functions` front-matter, or add them to
+`KNOWN_MISSING_COMPONENTS` (`_TODO_NEEDS_COMPONENT_PAGE` is the bucket for "real component,
+page not written yet"). Writing docs mid-release-train is usually out of scope, so the normal
+outcome is to file an issue, get the user's sign-off, and merge with the failure — but surface
+it rather than letting it look like an unexplained red check.
+
+### The deploy preview URL is not posted as a comment
+
+Nothing comments the Netlify URL on the PR. It follows the pattern
+`https://pr-<N>--pyshiny.netlify.app`, and can be confirmed from the `deploy` job log:
+
+```bash
+gh api repos/posit-dev/py-shiny-site/actions/jobs/<JOB_ID>/logs | grep -a environment_url
+```
+
+### `main` requires an approving review
+
+`required_approving_review_count: 1`, so `mergeStateStatus: BLOCKED` here usually means
+"needs review", not "CI failed" — check which before reporting. Merging therefore needs either
+a reviewer or, with the user's explicit approval, `gh pr merge --squash --admin`. If merging
+with a known failure, record the failure and its tracking issue in the squash-merge body so
+the history explains itself.
 
 Ask user: "Ready to update the docs site? I'll help create the PR."
 
@@ -424,25 +505,130 @@ Ask user: "Ready to update the docs site? I'll help create the PR."
 
 ## Phase 11: Conda-forge
 
-- [ ] Check `conda-forge/py-htmltools-feedstock` for auto-created PR from bot (only if py-htmltools was released)
-- [ ] Check `conda-forge/py-shiny-feedstock` for auto-created PR from bot
-- [ ] If PRs exist and tests pass, they should auto-merge (look for `[bot-automerge]` prefix)
-- [ ] If auto-merge doesn't happen, create an issue with the appropriate bot command
-- [ ] Note: Only py-htmltools and py-shiny have conda-forge feedstocks. py-shinyswatch, py-shinywidgets, and py-shinylive do NOT have feedstocks as of 2026-03.
+- [ ] Check `conda-forge/py-shiny-feedstock` for an auto-created bot PR (and
+      `conda-forge/py-htmltools-feedstock`, only if py-htmltools was released)
+- [ ] **Read the existing PRs' comments before investigating anything.** Prior cycles'
+      analysis usually lives there, and re-deriving it wastes a lot of time.
+- [ ] **Sync `recipe/meta.yaml`'s `run:` section by hand** — see below. The bot does not do
+      this, and it is the usual reason a bump fails.
+- [ ] Verify `about/license_file` against the new sdist, in both directions (below)
+- [ ] If tests pass, `[bot-automerge]` lands it without help
+- [ ] Feedstocks: py-shiny and py-htmltools. py-shinyswatch and shinychat were submitted to
+      `staged-recipes` in July 2026 (#34339, #34338) — check whether they now have feedstocks
+      that also need bumping. py-shinywidgets and py-shinylive still do not.
+
+### The bot bumps the version; it does not add dependencies
+
+This is the single biggest trap in this phase. A bot PR only changes `version`, `sha256` and
+`build/number`, then re-renders. **Whenever py-shiny gains a runtime dependency, the recipe
+must be updated by hand or the build fails in the test phase**, typically with a
+`ModuleNotFoundError` for the new dep during `import shiny`.
+
+This failure mode is silent across releases: the bot keeps opening PRs, each fails the same
+way, and they get closed. In July 2026 the feedstock was found stuck on **1.4.0 since April
+2025** — every bump from 1.5.0 onward had failed because `shinychat` (new in 1.5.0) and
+`opentelemetry-api` (new in 1.6.0) were never added.
+
+Compute the gap from PyPI metadata rather than reading `pyproject.toml` by eye:
+
+```bash
+curl -s https://pypi.org/pypi/shiny/<VERSION>/json -o /tmp/shiny.json
+python - <<'EOF'
+import json, re
+d = json.load(open("/tmp/shiny.json"))
+for r in (d["info"]["requires_dist"] or []):
+    if "extra ==" not in r:
+        print(" ", r)
+EOF
+```
+
+Diff that against the recipe's `run:` list. Check for three things: **missing** deps, deps
+that were **replaced** upstream (`appdirs` → `platformdirs`), and **floors that drifted**
+behind `pyproject.toml`. py-shiny raises floors fairly often — its lowest-direct-resolution
+CI job exists precisely to catch stale minimums, so its bounds move more than most packages'.
+
+Also apply the linter's `noarch: python` hint if it appears: `run:` should use
+`python >={{ python_min }}`, not `python {{ python_min }}`.
+
+### Triggering a bot PR
+
+If no bot PR exists (or you want one for a newer version), open an **issue** on the feedstock
+titled exactly:
+
+```
+@conda-forge-admin, please update version
+```
+
+`conda-forge-webservices` replies with a link to the PR it opened. Note it works in two
+stages — first a `dummy commit for rerendering`, then the real
+`ENH: updated version to X.Y.Z & Re-rendered ...`. Between those, the PR looks like it only
+touched `README.md`; wait for the second commit before concluding anything.
+
+The bot stops issuing PRs when more than 3 of its version-bump PRs are open, so close
+superseded ones.
+
+### Pushing to a bot PR's branch
+
+Bot branches live on the **bot's fork**, not the feedstock. Check `maintainerCanModify` (it is
+normally `true`), then push to that remote explicitly:
+
+```bash
+gh pr view <N> --repo conda-forge/py-shiny-feedstock \
+  --json maintainerCanModify,headRepositoryOwner,headRefName
+git remote add bot https://github.com/conda-forge-admin/py-shiny-feedstock.git
+git fetch bot <branch> && git checkout -B <branch> bot/<branch>
+# ... edit recipe/meta.yaml ...
+git push bot HEAD:<branch>
+```
+
+The owner is `conda-forge-admin` for webservice PRs and `regro-cf-autotick-bot` for autotick
+PRs. `git fetch origin <branch>` fails with `couldn't find remote ref` — that is the giveaway
+that you are looking at the wrong repo.
+
+Current `recipe-maintainers`: `cpsievert`, `schloerke`, `wch`, `sugatoray` — so both Carson
+and Barret can push directly. (Verify with the recipe's `extra/recipe-maintainers` rather
+than trusting this list.)
 
 ### Known issue: license_file references
 
-The feedstock `recipe/meta.yaml` has an `about/license_file` section that lists bundled license files from py-shiny (e.g., `shiny/www/shared/highlight/LICENSE`, `shiny/www/shared/busy-indicators/spinners/LICENSE`, `shiny/www/shared/jqueryui/LICENSE.txt`). If py-shiny removes or renames any vendored dependency between releases, these paths become stale and the conda-forge build will fail with `ValueError: License file ... does not exist`.
+`about/license_file` lists bundled license files from py-shiny. Check it **both ways** against
+the new sdist:
 
-**If a build fails for this reason:**
-1. Identify which license files no longer exist by checking `shiny/www/shared/` in the current release
-2. Comment on the bot PR explaining which line(s) to remove from `license_file`
-3. The feedstock maintainers (currently `wch` and `sugatoray`) can push the fix to the bot's branch or request a `bot-rerun` after updating `meta.yaml` on main
-4. Note: Carson (cpsievert) is **not** a feedstock maintainer and cannot push directly — if this is needed, ask to be added or request a maintainer to act
+```bash
+curl -sL "https://pypi.org/packages/source/s/shiny/shiny-<VERSION>.tar.gz" -o /tmp/s.tar.gz
+# 1. every listed path must still exist -- a stale one fails the build with
+#    `ValueError: License file ... does not exist`
+tar tzf /tmp/s.tar.gz | grep -iE "LICENSE|COPYING" | sed 's|^shiny-<VERSION>/||'
+```
+
+- **Stale paths** (listed but gone, because a vendored dependency was removed or renamed)
+  break the build.
+- **Missing paths** (bundled in the sdist but not listed) do not break the build but are a
+  licensing-compliance gap. In July 2026 `shiny/www/shared/busy-indicators/spinners/LICENSE`
+  was bundled and unlisted.
 
 ### Bot PR timing
 
-The conda-forge bot (`regro-cf-autotick-bot`) typically creates PRs within a few hours of a PyPI release, but it can sometimes take up to a day. If no PR appears after 24 hours, check the bot's [status page](https://github.com/regro/cf-scripts) for outages.
+The conda-forge bot (`regro-cf-autotick-bot`) typically creates PRs within a few hours of a
+PyPI release, but it can sometimes take up to a day. If no PR appears after 24 hours, check
+the bot's [status page](https://github.com/regro/cf-scripts) for outages, or trigger one with
+the issue command above.
+
+### When a dependency is not on conda-forge at all
+
+A new py-shiny dependency may have no conda-forge package. Then the feedstock cannot build
+until someone submits it to
+[`conda-forge/staged-recipes`](https://github.com/conda-forge/staged-recipes), which is a
+separate review queue with its own latency. Check with:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" https://api.anaconda.org/package/conda-forge/<name>
+```
+
+A build in a personal anaconda.org channel does not count — conda-forge recipes may only
+depend on conda-forge packages. When this happens, still push the corrected recipe (it will
+fail to solve, which is expected and explainable) so that the only remaining action once the
+dependency lands is a CI rerun.
 
 Ask user: "Have the conda-forge bot PRs appeared? Any issues with auto-merge?"
 

--- a/.claude/skills/py-shiny-release/references/release-phases.md
+++ b/.claude/skills/py-shiny-release/references/release-phases.md
@@ -202,6 +202,27 @@ Repo: `posit-dev/shinylive`
 - [ ] Cross-check the built wheels: `ls build/shinylive/pyodide/*.whl` should show the
       expected versions of shiny, shinyswatch, htmltools, shinywidgets and faicons.
 - [ ] Run `npm install --package-lock-only` to sync `package-lock.json` version with `package.json`
+- [ ] **Grep the bundled examples for anything the new py-shiny deprecated** — see
+      "Deprecations break the bundled examples" below.
+
+### Deprecations break the bundled examples
+
+A py-shiny release that deprecates a renderer or UI function will make any shinylive example
+still using it print a `ShinyDeprecationWarning` on load, and `examples-smoke-test` fails on
+that: `SUSPECT_PATTERNS` in `playwright/examples-smoke-helpers.ts` matches `/Warning\b/` and
+`/Deprecat/i` in the shinylive terminal.
+
+So for every entry in the new release's **Deprecations** changelog section:
+
+```bash
+grep -rn "render\.download\|<other deprecated API>" examples/ export_template/ site_template/
+```
+
+Migrate what turns up, in the release PR. (In v1.7.0, `examples/python/file_download_core`
+used `@render.download` three times and had to move to `@render.download_button`.)
+`export_template/` and `site_template/` matter too — they ship to users. Ignore hits under
+`_shinylive/py`, `_shinylive/r`, `venv/`, `build/` and `packages/`: those are build output or
+submodules.
 
 ### The `latest` trap: PyPI pins do not update themselves
 
@@ -255,6 +276,17 @@ land on disk; only the pinned ones load. Missing `*-tests.tar` entries are likew
 - [ ] Squash merge the RC PR into `main` via GitHub
 - [ ] Tag the squash commit on main: `git checkout main && git pull && git tag vX.Y.Z && git push origin vX.Y.Z`
 - [ ] **DEPLOY GATE 1 (github.io)**: Wait for the `main` branch deploy to github.io to finish. Then bust all browser caches and verify apps work on github.io using the Playwright-based example testing procedure. **Important**: When testing, always append a cache-busting query parameter (e.g., `?v={timestamp}`) to URLs or use a fresh incognito/private browser context to ensure you're testing the newly deployed version, not a cached old version. **Do NOT push to `deploy` until github.io is verified.**
+- [ ] **Confirm the deployed bundle is actually the new one** before reading the sweep results.
+      A stale CDN response passes the sweep while proving nothing, so check the served
+      lockfile rather than assuming:
+
+      ```bash
+      curl -s "https://posit-dev.github.io/shinylive/shinylive/shinylive_lock.json?v=$(date +%s)" \
+        | python -c "import json,sys; d=json.load(sys.stdin); print(d['shiny']['version'], d['shinyswatch']['version'])"
+      ```
+
+      Tell the user which surface is live and which is not at this point — github.io is
+      staging; shinylive.io is untouched and still serving the previous release.
 - [ ] Ask user: "github.io apps have been tested — X passed, Y failed. Ready to push to `deploy` (shinylive.io)?" Get explicit confirmation.
 - [ ] Only after github.io verification passes and user confirms: push to `deploy` branch (for shinylive.io) using `git push origin main:deploy`
 - [ ] **DEPLOY GATE 2 (shinylive.io)**: Wait for the `deploy` branch deploy to shinylive.io to finish. Then bust all browser caches and verify apps work on shinylive.io using the same testing procedure with cache-busting (fresh incognito context or `?v={timestamp}` query params).
@@ -263,24 +295,43 @@ land on disk; only the pinned ones load. Missing `*-tests.tar` entries are likew
 
 ### Local shinylive example testing procedure
 
-Use the same [`references/test_shinylive_site.py`](test_shinylive_site.py) script as Phase 3,
-pointed at the local dev server.
+**Run the repo's own smoke suite — `test_shinylive_site.py` is not a substitute for it.**
 
-**The local URL layout differs from the deployed one.** `make serve` binds **port 3000**, and
-serves examples at **`/examples/`** — `/py/examples/` exists only on the deployed site and
-404s locally. Root serves `/app/`, `/editor/`, `/examples/` and `/shinylive/`.
+```bash
+make examples-smoke-test                       # everything
+npx playwright test --config playwright-examples.config.ts --project=py
+npx playwright test --config playwright-examples.config.ts --project=py -g "File download"
+```
+
+`examples-smoke.spec.ts` asserts three things per example: no suspect lines in the shinylive
+**terminal**, no `.shiny-output-error` in the app frame, and no browser console errors. The
+release skill's `test_shinylive_site.py` only covers console errors plus tracebacks in the app
+iframe — it has no notion of the terminal pane, so it will happily pass a bundle whose
+examples emit deprecation warnings on load. That exact gap let a broken bundle look clean
+during the v1.7.0 train; only `examples-smoke-test` caught it.
+
+Expect one fewer test than there are examples: the `Non-Apps` category holds entries that load
+a plain script into the editor and never start an app, and `exampleAppTitles()` filters them
+out (`NON_APP_CATEGORIES`). In v1.7.0 that was 27 tests for 28 examples.
+
+**The smoke test reads `_shinylive/`, not `build/`.** `readExamplesJson()` loads
+`_shinylive/<engine>/shinylive/examples.json` and the config serves that directory on port
+8100. So after editing an example, `make all` is not enough — run `make _shinylive`
+(`rm -rf _shinylive/py _shinylive/r` first for a clean rebuild) or the suite will keep testing
+the old copy and appear not to have fixed anything.
+
+`test_shinylive_site.py` is still useful as a quick check against a running dev server. Note
+the local URL layout differs from the deployed one: `make serve` binds **port 3000** and serves
+examples at **`/examples/`** — `/py/examples/` exists only on the deployed site and 404s
+locally. Root serves `/app/`, `/editor/`, `/examples/` and `/shinylive/`.
 
 ```bash
 python references/test_shinylive_site.py "http://localhost:3000/examples/"
 ```
 
-Present the same summary table and broken app links as in Phase 3, and ask the user to verify
-any broken apps before proceeding.
-
-Sanity checks on the build while the server is up:
+Sanity check the example counts against `examples/index.json`:
 
 ```bash
-# expect 28 python apps / 11 r apps (or whatever examples/index.json now lists)
 python -c "
 import json; d = json.load(open('build/shinylive/examples.json'))
 [print(e['engine'], sum(len(c['apps']) for c in e['examples'])) for e in d]

--- a/.claude/skills/py-shiny-release/references/release-phases.md
+++ b/.claude/skills/py-shiny-release/references/release-phases.md
@@ -2,8 +2,32 @@
 
 ## Phase 1: Prerequisites
 
-- [ ] Check if any Shiny HTML Dependencies were updated or added
+- [ ] Check if any Shiny HTML Dependencies were updated or added. A quick signal is
+      `git diff v<PREV>..origin/main -- shiny/_versions.py shiny/www/` — a bumped
+      `shiny_html_deps` plus changes under `shiny/www/shared/sass/` means the theme
+      presets moved.
 - [ ] If yes, show the user which files changed (e.g., `git diff main -- shiny/www/shared/`) and ask if py-shinyswatch and/or py-shinywidgets need to be updated before proceeding
+
+**py-shinyswatch is almost always affected, and the answer is Phase 4, not Phase 1.**
+shinyswatch *commits* pre-built CSS — `shinyswatch/bsw5/<theme>/bootswatch.min.css`, 26
+files — compiled from shiny's own theme presets by `scripts/update_themes.py`. Those files
+go stale whenever shiny's preset SCSS changes, and the staleness is invisible: apps render,
+just without the new component's styles.
+
+Because the script compiles against the *installed* shiny, it can only run once the new
+py-shiny is on PyPI. So nothing blocks Phase 3 — but plan on a shinyswatch release in
+Phase 4 whenever the presets moved.
+
+To confirm whether a regeneration is actually needed, grep the committed CSS for a selector
+that the new shiny release added, e.g.:
+
+```bash
+# 0 matches in shinyswatch => stale
+gh api repos/posit-dev/py-shinyswatch/contents/shinyswatch/bsw5/darkly/bootswatch.min.css \
+  --jq '.content' | base64 -d | grep -c "offcanvas-footer"
+```
+
+py-shinywidgets does **not** vendor shiny SCSS, so it is usually unaffected.
 - [ ] **Python version check**: Look up the current [Python release schedule](https://devguide.python.org/versions/) and check if any Python versions have reached end-of-life since the last release. If so, ask the user whether to drop them from the following packages during this release cycle:
   - py-shiny (`pyproject.toml`, CI workflow)
   - py-htmltools (`pyproject.toml`, CI workflow)
@@ -104,7 +128,41 @@ Repo: `posit-dev/py-shinyswatch`
 
 - [ ] **Confirm version**: Look up the current version (`gh api repos/posit-dev/py-shinyswatch/releases/latest --jq .tag_name`), suggest the next minor bump, and ask the user to confirm the release version
 
-Follow the general package release pattern (same as Phase 2).
+Follow the general package release pattern (same as Phase 2), plus the theme regeneration
+below when Phase 1 found that shiny's presets moved.
+
+### Regenerating the pre-built themes
+
+Must happen **after** the new py-shiny is on PyPI — the script compiles against the
+installed shiny.
+
+- [ ] Install the *released* shiny plus shinyswatch's dev extras into a venv. The extras
+      matter: `scripts/update_themes.py` imports `black` and `sass`, and
+      `scripts/get_theme_values.py` imports `tinycss2`. All are declared under
+      `[options.extras_require] dev` in `setup.cfg`, so `pip install -e ".[dev]"` is the
+      right move — a hand-rolled minimal venv will fail **partway through**, after all 26
+      CSS files are already written but before `_bsw5.py`/`theme.py` are regenerated, which
+      looks deceptively like a successful run.
+- [ ] Run `make update-bootswatch` (= `python3 scripts/update_themes.py`)
+- [ ] **Verify the regeneration actually took**, by grepping the regenerated CSS for a
+      selector the new shiny release added — do not assume the script worked:
+
+      ```bash
+      # expect this to go from 0 -> 1, in every theme
+      for f in shinyswatch/bsw5/*/bootswatch.min.css; do
+        grep -c "offcanvas-footer" "$f" | grep -q '^0$' && echo "MISSING: $f"
+      done
+      ```
+
+      `git status` should show ~26 modified `bootswatch.min.css` files. `_bsw5.py` and
+      `theme.py` change only when the theme list or Bootstrap version changed.
+- [ ] Bump `__version__` in `shinyswatch/__init__.py` (`setup.cfg` resolves the version
+      from this attribute via `version = attr:`, so this is the real bump)
+- [ ] Raise the shiny floor in `setup.cfg` (`install_requires`) to the new release
+- [ ] `CHANGELOG.md`: follow the established wording — "Update pre-built shinyswatch themes
+      for use with Shiny vX.Y.Z." — plus a line noting the new shiny floor
+
+Note: py-shinyswatch has no conda-forge feedstock, so Phase 11 does not apply to it.
 
 Ask user: "Is py-shinyswatch being released? What version? Do we need to update docs after shinylive updates?"
 
@@ -137,9 +195,49 @@ Repo: `posit-dev/shinylive`
   - `packages/py-htmltools` → latest py-htmltools tag (if released this cycle)
   - `packages/py-shinywidgets` → latest py-shinywidgets tag
   - `packages/py-faicons` → check if update needed
+- [ ] **Update the PyPI-sourced pins by hand** — see "The `latest` trap" below. At minimum
+      check `shinyswatch`, which tracks a py-shiny release of its own.
 - [ ] Run `make clean && make all`
 - [ ] **Verify `shinylive_lock.json`** — check that ALL package versions match their latest releases. The lockfile reflects what's actually bundled. Don't trust that updating one submodule will cascade to others.
+- [ ] Cross-check the built wheels: `ls build/shinylive/pyodide/*.whl` should show the
+      expected versions of shiny, shinyswatch, htmltools, shinywidgets and faicons.
 - [ ] Run `npm install --package-lock-only` to sync `package-lock.json` version with `package.json`
+
+### The `latest` trap: PyPI pins do not update themselves
+
+`shinylive_requirements.json` marks some packages `{"source": "pypi", "version": "latest"}`.
+**`make all` will not move them.** It runs `update_packages_lock_local`, which filters the
+requirements down to `source: "local"` and then merges into the existing lockfile — PyPI
+entries are carried over verbatim and never re-resolved. `"latest"` means "latest as of the
+last full regen". This is how `shinyswatch` sat at 0.8.0 (April 2023) until shinylive#235
+noticed, two and a half years later.
+
+The obvious fix is unavailable: a full `make update_packages_lock` is **broken** — see
+[shinylive#233](https://github.com/posit-dev/shinylive/issues/233). It moves ~28 packages
+and yields a lockfile that fails at runtime with
+`No known package with name 'jupyterlab_widgets'`, breaking every shinywidgets app. **Do not
+run it** as part of a release.
+
+Instead, edit the single entry, generating it with the repo's own helper so field order and
+formatting match the file (this also pulls the package's real dependency specs from PyPI, so
+e.g. a raised `shiny>=` floor comes along automatically):
+
+```bash
+python -c "
+import sys, json; sys.path.insert(0, 'scripts')
+import pyodide_packages as pp
+print(json.dumps(pp._get_pypi_package_info('shinyswatch', 'latest'), indent=2))
+"
+```
+
+Splice `version`, `filename`, `sha256`, `url` and `depends` into the existing block, keeping
+the file's compact one-line-per-dependency style. Expect a ~5-line diff. Re-verify after
+`make all` that the edit survived (it should — the local pass does not disturb it).
+
+Harmless finding, so don't chase it: `build/shinylive/pyodide` will contain a couple of
+wheels not referenced by `pyodide-lock.json` (e.g. `anyio`, `narwhals`). Those are pyodide's
+own upstream versions, which shinylive's older pins override in the merged lock. Both files
+land on disk; only the pinned ones load. Missing `*-tests.tar` entries are likewise expected.
 
 ### Local testing and PR
 
@@ -165,19 +263,29 @@ Repo: `posit-dev/shinylive`
 
 ### Local shinylive example testing procedure
 
-Same approach as the Phase 3 shinylive testing, but against the local `make serve` URL:
+Use the same [`references/test_shinylive_site.py`](test_shinylive_site.py) script as Phase 3,
+pointed at the local dev server.
 
-1. Determine the local serve URL (typically `http://localhost:8080`)
-2. List Python examples from the local repo's `examples/python/` directory
-3. The base URL for each example is:
-   `http://localhost:8080/py/examples/#EXAMPLE_NAME`
-4. For each example, use Playwright MCP tools to:
-   a. Navigate to the example URL (`browser_navigate`)
-   b. Wait for the app to load (`browser_wait_for`)
-   c. Check browser console messages (`browser_console_messages`) for Python errors/tracebacks
-   d. Record the result (pass/fail + any error text)
-5. Present the same summary table and broken app links as in Phase 3
-6. Ask user to verify any broken apps before proceeding
+**The local URL layout differs from the deployed one.** `make serve` binds **port 3000**, and
+serves examples at **`/examples/`** — `/py/examples/` exists only on the deployed site and
+404s locally. Root serves `/app/`, `/editor/`, `/examples/` and `/shinylive/`.
+
+```bash
+python references/test_shinylive_site.py "http://localhost:3000/examples/"
+```
+
+Present the same summary table and broken app links as in Phase 3, and ask the user to verify
+any broken apps before proceeding.
+
+Sanity checks on the build while the server is up:
+
+```bash
+# expect 28 python apps / 11 r apps (or whatever examples/index.json now lists)
+python -c "
+import json; d = json.load(open('build/shinylive/examples.json'))
+[print(e['engine'], sum(len(c['apps']) for c in e['examples'])) for e in d]
+"
+```
 
 If release fails, delete tag and GH Release, fix, redo.
 


### PR DESCRIPTION
> **Draft — do not merge until the v1.7.0 release train is finished.** Later phases may turn up more corrections, which I'll add to this branch.

Six things the release skill either got wrong or didn't say. Each one cost time during the v1.7.0 train, and three of them would have shipped a defect if followed literally.

## 1. py-shinyswatch's publish gate is inverted

The skill's table says every repo's publish is gated on a title prefix. py-shinyswatch isn't:

```yaml
if: ${{ !startsWith(github.event.release.name, 'TEST') }}   # prod
if: startsWith(github.event.release.name, 'TEST')            # test.pypi.org
```

So the two families have *opposite* failure modes. A prefix-gated repo (py-shiny, py-htmltools, py-shinywidgets, py-shinylive) fails **silently** — mistitle it and the publish step skips while the workflow still reports success. py-shinyswatch publishes on any non-`TEST` title, so the hazard is the reverse: an accidental `TEST` prefix quietly diverts the release to test.pypi.org.

## 2. shinylive's PyPI pins do not follow `"version": "latest"`

`shinylive_requirements.json` lists shinyswatch as `{"source": "pypi", "version": "latest"}`. I initially read that as self-updating and told Barret the shinyswatch 0.12.0 bump would come along for free. It doesn't. `make all` runs `update_packages_lock_local`:

```python
249:  required_packages = [x for x in required_packages if x["source"] == "local"]
259:  lockfile_info.update(required_package_info)
```

PyPI entries are filtered out, then existing lockfile entries are carried over verbatim. `"latest"` means "latest as of the last full regen" — which is how shinyswatch sat at 0.8.0 from April 2023 until [shinylive#235](https://github.com/posit-dev/shinylive/pull/235) caught it.

And the obvious fix is unavailable: a full `make update_packages_lock` is **broken** ([shinylive#233](https://github.com/posit-dev/shinylive/issues/233)) — it moves ~28 packages and produces a lockfile that fails at runtime with `No known package with name 'jupyterlab_widgets'`, breaking every shinywidgets app. The docs now say don't run it, and document #235's `_get_pypi_package_info()` approach instead.

## 3. Phase 6's local sweep URL was wrong twice over

Documented as `http://localhost:8080/py/examples/`. `make serve` binds **3000**, and serves **`/examples/`** — `/py/examples/` is deployed-only and 404s locally.

## 4. shinyswatch theme staleness is invisible, and Phase 1 asked about it at the wrong time

shinyswatch *commits* 26 pre-built `bsw5/<theme>/bootswatch.min.css` files compiled from shiny's theme presets. When those presets move, the committed CSS goes stale silently — apps render, just without the new component's styles. This release added `bslib/components/scss/offcanvas.scss` to every preset, and shinyswatch v0.11.0 had **0** occurrences of `.offcanvas-footer`, so `ui.offcanvas()` would have rendered unstyled under every shinyswatch theme.

Phase 1 asked whether shinyswatch needs updating "before proceeding," but `update_themes.py` compiles against the *installed* shiny, so it can only run after py-shiny is on PyPI — i.e. Phase 4. Added the grep that proves staleness, and a note that the script needs the `dev` extras (`tinycss2`, `libsass`, `black`) and otherwise fails **partway through**, after writing all 26 CSS files but before regenerating `_bsw5.py`/`theme.py` — which looks like success.

## 5. A holding PR may carry its own `TODO: release` markers

The skill said to merge the holding PR, then remove the pin. [py-shiny-templates#55](https://github.com/posit-dev/py-shiny-templates/pull/55) had pinned `shiny @ git+https://github.com/posit-dev/py-shiny.git@main` in three `requirements.txt` files as a pre-1.7.0 stopgap, each with its own `TODO: release` comment. Merging as instructed would have **shipped a git dependency in the templates repo** — the exact thing the pre-release gate screens for everywhere else.

## 6. PyPI's index lags a successful publish

`build (3.14, ubuntu-latest)` on the shinyswatch PR failed with `Could not find a version that satisfies the requirement shiny>=1.7.0` minutes after 1.7.0 published, while the other 15 matrix jobs resolved it fine. Now documented: poll PyPI itself before starting a dependent phase, and treat a one-runner resolver failure as a stale index to rerun, not a pin to weaken.

## Also

- Piping a build through `tail` (`make all 2>&1 | tail -60`) makes the reported exit status come from `tail` — a failed build looks like success. Verify from artifacts.
- Dropped the now-completed py-shiny-templates#55 holding item and replaced it with a placeholder plus instructions for maintaining that section.
- Noted the harmless unreferenced `anyio`/`narwhals` wheels in `build/shinylive/pyodide` so the next person doesn't chase them (pyodide's own dist versions, overridden by shinylive's pins).

Related: #2379 already fixed the sweep script's example enumeration. Part of the v1.7.0 release train; see #2377.