### PR TITLE
fix(tests): resolve flaky test_input_action_task_button (#2380)

### DIFF
--- a/tests/playwright/shiny/inputs/input_task_button/test_input_task_button.py
+++ b/tests/playwright/shiny/inputs/input_task_button/test_input_task_button.py
@@ -25,11 +25,17 @@ def test_input_action_task_button(page: Page, local_app: ShinyAppProc) -> None:
     page.goto(local_app.url)
     result = controller.OutputCode(page, "show_result")
     current_time = controller.OutputCode(page, "current_time")
+    renders_during_block = controller.OutputCode(page, "renders_during_block")
 
-    # Wait until shiny is stable
+    # Wait for the startup extended task to finish.
     result.expect_value("3", timeout=10 * 1000)
 
-    # Make sure the time has content
+    # The ignore_none=False blocking handler also runs during startup. This
+    # output is only updated after that handler completes, so use it as the
+    # explicit synchronization point before checking the ticking output.
+    renders_during_block.expect_value("0", timeout=10 * 1000)
+
+    # Make sure the time has content after startup has completed.
     current_time.expect.not_to_be_empty(timeout=10 * 1000)
 
     y = controller.InputNumeric(page, "y")
@@ -62,14 +68,6 @@ def test_input_action_task_button(page: Page, local_app: ShinyAppProc) -> None:
     # set up Blocking test
     y.set("15")
     result.expect_value("5")
-
-    # Blocking verification. The server records how many current_time renders
-    # occur inside each blocking window; this avoids sampling the display on a
-    # timer from the client, which races against in-flight output updates.
-    renders_during_block = controller.OutputCode(page, "renders_during_block")
-    # The `ignore_none=False` handler already ran one blocking window at
-    # startup; it must not have allowed any renders either.
-    renders_during_block.expect_value("0")
 
     button_block = controller.InputTaskButton(page, "btn_block")
     button_block.expect_label_busy("\n  \n Blocking...")

--- a/tests/playwright/shiny/inputs/input_task_button/test_input_task_button.py
+++ b/tests/playwright/shiny/inputs/input_task_button/test_input_task_button.py
@@ -23,15 +23,17 @@ def click_extended_task_button(
 
 def test_input_action_task_button(page: Page, local_app: ShinyAppProc) -> None:
     page.goto(local_app.url)
-    y = controller.InputNumeric(page, "y")
-    y.set("4")
     result = controller.OutputCode(page, "show_result")
     current_time = controller.OutputCode(page, "current_time")
-    # Make sure the time has content
-    current_time.expect.not_to_be_empty()
 
     # Wait until shiny is stable
-    result.expect_value("3")
+    result.expect_value("3", timeout=10 * 1000)
+
+    # Make sure the time has content
+    current_time.expect.not_to_be_empty(timeout=10 * 1000)
+
+    y = controller.InputNumeric(page, "y")
+    y.set("4")
 
     # Extended task
     button_task = controller.InputTaskButton(page, "btn_task")


### PR DESCRIPTION
Fixes #2380

### Cause

Both task handlers in `app.py` use `ignore_none=False`, so they run during the initial session flush. The blocking handler awaits `slow_input_compute()` for approximately 1.5 seconds and prevents output flushes during that time.

The test previously changed `y` and immediately checked `current_time`. Under Firefox and CI load, browser startup, the WebSocket connection, the initial blocking handler, and input re-invalidation could keep `current_time` empty and marked as `recalculating` beyond Playwright’s default 5-second timeout.

### Solution

Synchronize explicitly with the server-side blocking-window output:

1. Wait for the initial extended task result (`show_result == "3"`).
2. Wait for `renders_during_block == "0"`, which confirms the initial blocking handler has completed.
3. Assert that `current_time` contains a value.
4. Set `y` to `4` only after startup processing is complete.

This removes the race without changing the application behavior or weakening the test’s blocking/non-blocking assertions.
