### PR TITLE
chore(docs): Bump shinylive to >=0.8.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,7 @@ doc = [
     "jupyter",
     "jupyter_client < 8.0.0",
     "tabulate",
-    "shinylive>=0.8.10",
+    "shinylive>=0.8.11",
     "pydantic>=2.7.4",
     "quartodoc>=0.8.1",
     "griffe>=1.3.2,<2.0.0",


### PR DESCRIPTION
Post-release step for the py-shiny v1.7.0 train (Phase 9).

`pyproject.toml` `[doc]` extras: `shinylive>=0.8.10` → **`shinylive>=0.8.11`**.

[py-shinylive 0.8.11](https://github.com/posit-dev/py-shinylive/releases/tag/v0.8.11) is on PyPI and pins the [v0.10.14](https://github.com/posit-dev/shinylive/releases/tag/v0.10.14) web assets, which bundle shiny 1.7.0 and shinyswatch 0.12.0. Without this floor the docs build could resolve an older shinylive whose bundle predates this release, so the embedded examples would run 1.6.x.

Verified before opening: `shinylive 0.8.11` resolves from PyPI, and an app exported with it produces a bundle containing shiny 1.7.0 / shinyswatch 0.12.0.

See #2377 for the originating release.