### PR TITLE
fix(docs): Load libsass in the `ui.Theme` Shinylive examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to Shiny for Python will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+### Bug fixes
+
+* The `ui.Theme` API reference examples now run in Shinylive. Compiling a customized theme requires `libsass`, but Shinylive only auto-loads packages it finds in an app's top-level imports and `Theme.to_css()` imports `sass` lazily, so the examples died with an `ImportError`. The example directory now declares `libsass` in a `requirements.txt`. (#2386)
+
+* Fixed the error message raised when a package required for theme compilation is missing: it interpolated the package name into the first sentence but printed a literal `pip install {pkg}` in the second. (#2386)
+
 ## [1.7.0] - 2026-07-28
 
 ### New features

--- a/shiny/api-examples/theme/requirements.txt
+++ b/shiny/api-examples/theme/requirements.txt
@@ -1,0 +1,1 @@
+libsass

--- a/shiny/ui/_theme.py
+++ b/shiny/ui/_theme.py
@@ -730,7 +730,7 @@ def check_theme_pkg_installed(pkg: str, spec: str | None = None) -> None:
     if importlib.util.find_spec(spec or pkg) is None:
         raise ImportError(
             f"The '{pkg}' package is required to compile custom themes. "
-            'Please install it with `pip install {pkg}` or `pip install "shiny[theme]"`.',
+            f'Please install it with `pip install {pkg}` or `pip install "shiny[theme]"`.',
         )
 
 


### PR DESCRIPTION
Fixes #2386.

## Problem

The `ui.Theme` / `express.ui.Theme` API reference examples are broken in Shinylive on the docs site — the app never renders, it just reports:

```
ImportError: The 'libsass' package is required to compile custom themes.
Please install it with `pip install {pkg}` or `pip install "shiny[theme]"`.
```

`shared.py` builds a customized theme, so rendering the page calls `Theme.to_css()` → `check_theme_pkg_installed("libsass", "sass")`.

Shinylive picks which pyodide packages to load by scanning the app's **top-level** imports. `Theme.to_css()` imports `sass` lazily *inside* the method (`shiny/ui/_theme.py:518`), so `libsass` is never detected — even though Shinylive bundles a `libsass` wasm wheel precisely to support `ui.Theme()` (posit-dev/shinylive#160).

## Fix

Declare `libsass` in `shiny/api-examples/theme/requirements.txt`.

`@add_example()` already collects every non-`app-*.py`, non-`__*` file in the example dir as a support file (`shiny/_docstring.py:188-204`), so the file reaches the Shinylive payload with **no py-shiny-site change**. Existing precedent: `shiny/api-examples/todo_list/requirements.txt`. One `requirements.txt` covers all eight app variants in the dir, since support files are shared.

Also fixes a missing `f` prefix in `check_theme_pkg_installed()` — the second sentence printed a literal `{pkg}` (visible in the traceback above).

## Why bare `libsass` and not `shiny[theme]`

`shiny[theme]` reads better and matches the docstring, and it *does* work at install time — Shinylive's `_install_requirements_from_dir()` resolves extras against the already-installed dist's metadata. But it does **not** work end to end, and I only found this by testing both:

py-shinylive decides which wheels to copy into the published site assets via `find_package_deps()` → `_find_packages_in_requirements()`, whose regex strips the extras:

```python
>>> _find_packages_in_requirements("shiny[theme]")
['shiny']          # libsass never copied  -> 404 at runtime
>>> _find_packages_in_requirements("libsass")
['libsass']        # wheel copied          -> works
```

So with `shiny[theme]` the browser tries to micropip-install `libsass` (plus the `brand_yml` → `pydantic` → `pydantic_core` chain, since `theme = ["libsass>=0.23.0", "brand_yml>=0.2.0"]`) and every fetch 404s, because those wheels were never published alongside the app. Confirmed against the live site:

```
site_libs/quarto-contrib/shinylive-0.10.14/shinylive/pyodide/shinyswatch-0.12.0-py3-none-any.whl  -> 200
site_libs/quarto-contrib/shinylive-0.10.14/shinylive/pyodide/libsass-…-wasm32.whl                 -> 404
```

Bare `libsass` sidesteps the extras-parsing gap *and* avoids pulling the `brand_yml`/pydantic chain into an example that doesn't use brand.yml. Making `shiny[theme]` work would need a py-shinylive fix to `_find_packages_in_requirements()` — worth filing separately, but it shouldn't block unbreaking the example.

## Verification

Exported the example with the pinned toolchain (`shinylive` 0.8.11 / assets 0.10.14) and loaded it in a real browser:

- **Before** (no `requirements.txt`): 13 console errors, the `ImportError` above, no UI.
- **With `shiny[theme]`**: extras resolution fires, but `libsass`, `ruamel.yaml`, `pydantic`, `annotated-types`, `pydantic_core` all fail with `Failed to fetch`; same `ImportError`, no UI.
- **With `libsass`** (this PR): `libsass-0.23.0-…-wasm32.whl` is copied into the export, **0 console errors**, and the app renders with the custom theme applied — sidebar, "Theme Example" heading, reactive output (`n*2 is 40`), and all three inputs. A missing libsass raises during UI construction, so a rendered page is proof the Sass actually compiled.

## Notes

- `make format check-lint` clean on the changed file.
- `pyright shiny/ui/_theme.py` reports 19 errors here, but **identical** on the unmodified tree (`git stash`) — they're all `brand_yml` typing cascades from the missing `typings/` stubs in my env, unrelated to this change.
- The example dir is lowercase `theme/` (issue #2386 says `Theme/`); the `Theme` class reaches it via `@add_example(example_name="theme")`.
