### PR TITLE
fix: Keep `.bslib-task-button` class when `input_task_button(type=None)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Fixed the error message raised when a package required for theme compilation is missing: it interpolated the package name into the first sentence but printed a literal `pip install {pkg}` in the second. (#2386)
 
+* `ui.input_task_button(type=None)` no longer drops the `bslib-task-button` class. Operator precedence made the `type is not None` check apply to the whole class string rather than just the Bootstrap classes, so the button rendered with `class=""`; since that class is the selector Shiny's input binding uses, the button was never bound as an input and clicking it did nothing. (#2388)
+
 ## [1.7.0] - 2026-07-28
 
 ### New features

--- a/shiny/ui/_input_task_button.py
+++ b/shiny/ui/_input_task_button.py
@@ -125,8 +125,6 @@ def input_task_button(
     if icon_busy is MISSING:
         icon_busy = HTML(spinner_icon)
 
-    # `.bslib-task-button` is how bslib's input binding finds the button, so it must be
-    # present even when `type=None` drops the Bootstrap-specific classes.
     css_class = "bslib-task-button"
     if type is not None:
         css_class += f" btn btn-{type}"

--- a/shiny/ui/_input_task_button.py
+++ b/shiny/ui/_input_task_button.py
@@ -125,7 +125,11 @@ def input_task_button(
     if icon_busy is MISSING:
         icon_busy = HTML(spinner_icon)
 
-    css_class = "bslib-task-button" + f" btn btn-{type}" if type is not None else ""
+    # `.bslib-task-button` is how bslib's input binding finds the button, so it must be
+    # present even when `type=None` drops the Bootstrap-specific classes.
+    css_class = "bslib-task-button"
+    if type is not None:
+        css_class += f" btn btn-{type}"
 
     return tags.button(
         {"class": css_class, "style": css(width=width), "data-auto-reset": auto_reset},

--- a/tests/pytest/test_input_task_button.py
+++ b/tests/pytest/test_input_task_button.py
@@ -1,0 +1,19 @@
+from shiny.ui import input_task_button
+
+
+def test_input_task_button_class_default_type():
+    btn = input_task_button("go", "Go")
+    assert btn.attrs["class"] == "bslib-task-button btn btn-primary"
+
+
+def test_input_task_button_class_explicit_type():
+    btn = input_task_button("go", "Go", type="danger")
+    assert btn.attrs["class"] == "bslib-task-button btn btn-danger"
+
+
+def test_input_task_button_keeps_binding_class_when_type_is_none():
+    # `type=None` documents "leave off the Bootstrap-specific button CSS classes",
+    # but `.bslib-task-button` is the selector bslib's input binding uses to find
+    # the button, so dropping it would leave the button unbound.
+    btn = input_task_button("go", "Go", type=None)
+    assert btn.attrs["class"] == "bslib-task-button"


### PR DESCRIPTION
## Problem

`ui.input_task_button(type=None)` renders a button with `class=""`, which means it is **never bound as a Shiny input**: clicking it does nothing and `input.<id>()` stays at `0`.

The class list was built as:

```python
css_class = "bslib-task-button" + f" btn btn-{type}" if type is not None else ""
```

`+` binds tighter than the conditional expression, so this parses as `("bslib-task-button" + f" btn btn-{type}") if type is not None else ""`. When `type=None` the whole string collapses to `""`, taking `bslib-task-button` with it — and that class is the selector Shiny's client-side input binding uses to find the button:

```js
find(t) { return $(t).find(".bslib-task-button") }
```

`shiny.playwright.controller.InputTaskButton` also locates the button via `button#{id}.bslib-task-button.shiny-bound-input`, so it cannot find such a button either.

## Why this is a bug and not intended behavior

`type=None` is a documented, supported option. Both py-shiny's and bslib's docs for `type` say the same thing: *"or `None`/`NULL` to leave off the **Bootstrap-specific** button CSS classes."* Only the Bootstrap classes are meant to go away.

Confirmed against upstream — bslib does **not** squash the class value. It passes two separate `class` arguments and lets htmltools drop the `NULL` one (`rstudio/bslib`, `R/buttons.R`):

```r
  tags$button(
    id = id,
    class = if (!is.null(type)) paste0("btn btn-", type),
    class = "bslib-task-button",
```

Verified by running it:

| `type` | bslib (R) | py-shiny before | py-shiny after |
| --- | --- | --- | --- |
| `"primary"` | `btn btn-primary bslib-task-button` | `bslib-task-button btn btn-primary` | unchanged |
| `NULL` / `None` | `bslib-task-button` | `""` :x: | `bslib-task-button` :white_check_mark: |

So this was a genuine divergence from bslib, and py-shiny's docstring was correct while the code disagreed with it. bslib's formulation is also immune to this bug class by construction: with two separate `class` arguments there is no conditional spanning a concatenation, hence no operator-precedence hazard.

## Fix

Always emit `bslib-task-button`, then append the Bootstrap classes only when `type` is not `None`. This lands on the same class *set* as bslib.

I deliberately did **not** restructure this into bslib's two-dict form (which Python htmltools would also support, since `TagAttrDict.update` concatenates duplicate `class` keys). It is more convoluted for no functional gain, and it would flip py-shiny's class ordering to bslib's — churn in the rendered output of every existing task button, for a difference that is semantically irrelevant to CSS and selectors. The `type="primary"` path stays byte-identical.

I also grepped `shiny/` for the same precedence pattern elsewhere and found no other instances.

## Tests

`tests/pytest/test_input_task_button.py` covers the default, an explicit `type`, and `type=None`. The `type=None` test is red on `main`:

```
assert '' == 'bslib-task-button'
```

and green with this change. The other two pass both before and after, confirming the common paths are untouched.

`uv run make format check-lint check-types` and `uv run pytest tests/pytest` pass.