### PR TITLE
test(otel): Make span assertions independent of the global tracer provider

### DIFF
--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -8,6 +8,9 @@ import pytest
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
+from shiny.otel import _core
+from shiny.otel._constants import TRACER_NAME
+
 from .otel_helpers import otel_tracer_provider_impl
 
 
@@ -35,7 +38,7 @@ def _otel_tracer_provider_session() -> (
 @pytest.fixture
 def otel_tracer_provider(
     _otel_tracer_provider_session: Tuple[TracerProvider, InMemorySpanExporter],
-) -> Tuple[TracerProvider, InMemorySpanExporter]:
+) -> Iterator[Tuple[TracerProvider, InMemorySpanExporter]]:
     """
     Function-scoped pytest fixture for OpenTelemetry TracerProvider.
 
@@ -52,6 +55,16 @@ def otel_tracer_provider(
 
     This two-fixture pattern separates the one-time global setup (session)
     from the per-test cleanup (function), working correctly with pytest-xdist.
+
+    Why force `_core._tracer`?
+    --------------------------
+    `trace.set_tracer_provider()` is silently rejected when a provider was
+    already installed in this worker process (e.g. by `test_otel_logfire.py`
+    configuring logfire). In that case the session fixture's provider is not
+    the global one, spans go somewhere else, and the in-memory exporter stays
+    empty. Pointing Shiny's cached tracer at the test provider makes span
+    assertions independent of which tests happen to share the worker. This
+    mirrors what `test_otel_value_logging.py` does for `_core._logger`.
 
     Yields
     ------
@@ -80,4 +93,10 @@ def otel_tracer_provider(
     provider, exporter = _otel_tracer_provider_session
     # Clear spans from previous tests to ensure isolation
     exporter.clear()
-    return provider, exporter
+    # Force Shiny's cached tracer to come from the test provider, even if
+    # `trace.set_tracer_provider()` was rejected because another test already
+    # owned the global provider.
+    _core._tracer = provider.get_tracer(TRACER_NAME)
+    yield provider, exporter
+    # Reset so subsequent callers re-fetch from the global provider
+    _core._tracer = None


### PR DESCRIPTION
Fixes #2389

## Root cause

`tests/pytest/conftest.py`'s session-scoped fixture takes ownership of spans via `trace.set_tracer_provider(provider)`. OTel **silently rejects** that call when a provider is already installed in the process (logging `Overriding of current TracerProvider is not allowed`).

`test_otel_logfire.py` installs one — both via `logfire.configure(...)` and via `trace.set_tracer_provider()` in `test_direct_sdk_provider_still_detected`. When xdist happens to place a logfire test before the span-asserting tests in the same worker, Shiny's spans go to logfire's provider (visible as logfire console output in the captured stdout of the failure) and the in-memory exporter stays empty → `assert 0 >= 2`.

Reproduced on clean `main`:

```
$ pytest test_otel_logfire.py test_otel_reactive_flush.py test_otel_reactive_execution.py -n 3
1 failed, 69 passed, 2 skipped
WARNING opentelemetry.trace: Overriding of current TracerProvider is not allowed
```

## Fix

The function-scoped `otel_tracer_provider` fixture now points Shiny's cached tracer at the test provider, and resets it afterward:

```python
_core._tracer = provider.get_tracer(TRACER_NAME)
yield provider, exporter
_core._tracer = None
```

Every span in `shiny/` is created through `get_otel_tracer()` → `_core._tracer`, so this makes span assertions independent of who owns the process-global provider — option (3) from the issue, without restructuring the fixtures. It follows the existing precedent in `test_otel_value_logging.py`, whose log fixture already forces `_core._logger` for exactly this reason.

## Verification

- The 3-file repro passes at `-n 1,2,3,4,5` (previously failed at `-n 3` and `-n 4`).
- Full `tests/pytest` suite passes at `-n auto, 2, 3, 5, 7`: 984 passed, 2 skipped.
- `uv run make format check-lint check-types` clean.

## Not addressed

The logfire tests still skip-or-run depending on the xdist partition (`_check_provider_not_already_set()` skips once any real provider is installed). Making that deterministic would require running `logfire.configure()` in its own process, since those tests genuinely need to own the global provider in order to test detection of it. That variance only affects which branch of the logfire tests runs — it no longer causes failures.