### PR TITLE
docs: clarify panel_conditional module IDs

### DIFF
--- a/shiny/ui/_bootstrap.py
+++ b/shiny/ui/_bootstrap.py
@@ -160,10 +160,8 @@ def panel_conditional(
     (Be sure not to modify the input/output objects, as this may cause unpredictable
     behavior.)
 
-    You are not recommended to use special JavaScript characters such as a period . in
-    the input id's, but if you do use them anyway, for example, `id = "foo.bar"`, you
-    will have to use `input["foo.bar"]` instead of ``input.foo.bar`` to read the input
-    value.
+    Within a module, refer to inputs by their unprefixed, module-local IDs (for example,
+    ``input.foo``). Shiny applies the module namespace prefix automatically.
 
     Tip
     ---


### PR DESCRIPTION
Fixes #2394

## Summary

- remove advice for period-containing input IDs, which Shiny rejects during ID validation
- clarify that module conditions use unprefixed, module-local input IDs because Shiny applies the namespace automatically

## Testing

- `PYTHONPATH=. python -m pytest -o addopts= tests/pytest/test_ui.py -q` (5 passed)
- Black, isort, Flake8, compileall, and `git diff --check` on the changed file
