### PR TITLE
fix(typing): Avoid lambda functions to comply with latest pyrefly

### DIFF
--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -716,6 +716,15 @@ def _new_destroy_callbacks() -> _utils.AsyncCallbacks:
     return _utils.AsyncCallbacks(on_error=_print_exception)
 
 
+def _ns_depth(ns_key: str) -> int:
+    """
+    Nesting depth of a namespace key, measured by its dash count.
+
+    Used as a sort key so that deeper (more nested) namespaces sort first.
+    """
+    return ns_key.count("-")
+
+
 async def _invoke_destroy_callbacks(
     callbacks_by_ns: dict[str, _utils.AsyncCallbacks],
     ns: str,
@@ -747,7 +756,7 @@ async def _invoke_destroy_callbacks(
     # Sort deepest namespaces first (most dashes → most nested) so that
     # children are destroyed before parents, mirroring the reverse of
     # construction order.
-    matching_keys.sort(key=lambda k: k.count("-"), reverse=True)
+    matching_keys.sort(key=_ns_depth, reverse=True)
 
     for ns_key in matching_keys:
         callbacks = callbacks_by_ns.pop(ns_key, None)

--- a/shiny/ui/_utils.py
+++ b/shiny/ui/_utils.py
@@ -62,7 +62,7 @@ def _find_child_strings(x: TagList | TagNode) -> str:
         x = x.children
     if isinstance(x, TagList):
         strings = [_find_child_strings(y) for y in x]
-        return " ".join(filter(lambda x: x != "", strings))
+        return " ".join(string for string in strings if string != "")
     if isinstance(x, str):
         return x
     return ""

--- a/tests/inspect-ai/utils/scripts/average_results.py
+++ b/tests/inspect-ai/utils/scripts/average_results.py
@@ -13,6 +13,11 @@ from pathlib import Path
 from typing import Any, Dict, List, Union
 
 
+def _attempt_number(attempt_dir: Path) -> int:
+    """Sort key: the numeric suffix of an ``attempt_<n>`` directory name."""
+    return int(attempt_dir.name.split("_")[1])
+
+
 def process_inspect_ai_results(attempts_dir: Path) -> Dict[str, Any]:
     """
     Process and average inspect-ai results across multiple attempts.
@@ -28,7 +33,7 @@ def process_inspect_ai_results(attempts_dir: Path) -> Dict[str, Any]:
         for d in attempts_dir.iterdir()
         if d.is_dir() and d.name.startswith("attempt_")
     ]
-    attempt_dirs.sort(key=lambda x: int(x.name.split("_")[1]))
+    attempt_dirs.sort(key=_attempt_number)
 
     if not attempt_dirs:
         print("No attempt directories found")
@@ -148,7 +153,7 @@ def process_pytest_results(attempts_dir: Path) -> Dict[str, Any]:
         for d in attempts_dir.iterdir()
         if d.is_dir() and d.name.startswith("attempt_")
     ]
-    attempt_dirs.sort(key=lambda x: int(x.name.split("_")[1]))
+    attempt_dirs.sort(key=_attempt_number)
 
     if not attempt_dirs:
         print("No attempt directories found for pytest results")

--- a/tests/inspect-ai/utils/scripts/process_docs.py
+++ b/tests/inspect-ai/utils/scripts/process_docs.py
@@ -171,6 +171,12 @@ def parse_qmd_content(content: str) -> Optional[Dict[str, Any]]:
     return data
 
 
+def _controller_name(controller: Dict[str, Any]) -> str:
+    """Sort key: the controller's name, or ``""`` when it is missing."""
+    name = controller.get("controller_name", "")
+    return name if isinstance(name, str) else ""
+
+
 def convert_xml_to_json(xml_file_path: Path) -> str:
     """
     Parses an XML file containing multiple .qmd docs and converts it to a
@@ -217,7 +223,7 @@ def convert_xml_to_json(xml_file_path: Path) -> str:
                 if controller_data and controller_data.get("methods"):
                     all_controllers_data.append(controller_data)
 
-    all_controllers_data.sort(key=lambda x: x.get("controller_name", ""))
+    all_controllers_data.sort(key=_controller_name)
 
     return json.dumps(all_controllers_data, indent=2)
 

--- a/tests/playwright/conftest.py
+++ b/tests/playwright/conftest.py
@@ -33,6 +33,10 @@ here_root = here.parent.parent
 _NAVIGATION_WEDGED_ATTR = "_shiny_navigation_wedged"
 
 
+def _mark_navigation_wedged(crashed_page: Page) -> None:
+    setattr(crashed_page, _NAVIGATION_WEDGED_ATTR, True)
+
+
 def _new_session_page(browser: BrowserContext) -> Page:
     """
     Create a shared page whose `goto()` verifies the navigation committed.
@@ -42,7 +46,7 @@ def _new_session_page(browser: BrowserContext) -> Page:
         Page: The newly created page.
     """
     page = browser.new_page()
-    page.on("crash", lambda page: setattr(page, _NAVIGATION_WEDGED_ATTR, True))
+    page.on("crash", _mark_navigation_wedged)
     original_goto = page.goto
 
     def goto_and_verify_commit(url: str, **kwargs: typing.Any) -> Response | None:


### PR DESCRIPTION
Spotted in narwhals downstream tests (see [failed job](https://github.com/narwhals-dev/narwhals/actions/runs/30701344185/job/91372774436?pr=3827)).

One alternative is to add a `# pyrefly: ignore[...]`