### PR TITLE
fix(tests): Load bookmark URLs with a fresh navigation instead of a reload

### DIFF
--- a/tests/playwright/ai_generated_apps/bookmark/accordion/test_accordion_bookmarking.py
+++ b/tests/playwright/ai_generated_apps/bookmark/accordion/test_accordion_bookmarking.py
@@ -1,4 +1,5 @@
 from playwright.sync_api import Page
+from utils.bookmark_utils import load_bookmark_url
 
 from shiny.playwright import controller
 from shiny.pytest import create_app_fixture
@@ -27,7 +28,7 @@ def test_accordion_bookmarking_demo(page: Page, app: ShinyAppProc) -> None:
     page.wait_for_url(lambda url: url != existing_url, timeout=5 * 1000)
 
     # reload page
-    page.reload()
+    load_bookmark_url(page)
 
     acc_single.expect_open(["Section B"])
     acc_mod.expect_open(["Section C"])
@@ -42,7 +43,7 @@ def test_accordion_bookmarking_demo(page: Page, app: ShinyAppProc) -> None:
     page.wait_for_url(lambda url: url != existing_url, timeout=5 * 1000)
 
     # reload page
-    page.reload()
+    load_bookmark_url(page)
 
     acc_single.expect_open([])
     acc_mod.expect_open([])

--- a/tests/playwright/ai_generated_apps/bookmark/bookmark_exclude/test_bookmark_exclusion.py
+++ b/tests/playwright/ai_generated_apps/bookmark/bookmark_exclude/test_bookmark_exclusion.py
@@ -1,4 +1,5 @@
 from playwright.sync_api import Page
+from utils.bookmark_utils import load_bookmark_url
 
 from shiny.playwright import controller
 from shiny.pytest import create_app_fixture
@@ -30,7 +31,7 @@ def test_bookmark_exclusion(page: Page, app: ShinyAppProc) -> None:
     mod1_excluded_txt.expect_value("Excluded text: Hello excluded")
 
     # reload page
-    page.reload()
+    load_bookmark_url(page)
 
     mod1_txt.expect_value("Included text: Hello world")
     mod1_num_txt.expect_value("Included num: 10")

--- a/tests/playwright/ai_generated_apps/bookmark/input_checkbox/test_input_checkbox_express_bookmarking.py
+++ b/tests/playwright/ai_generated_apps/bookmark/input_checkbox/test_input_checkbox_express_bookmarking.py
@@ -1,4 +1,5 @@
 from playwright.sync_api import Page
+from utils.bookmark_utils import load_bookmark_url
 
 from shiny.playwright import controller
 from shiny.pytest import create_app_fixture
@@ -40,7 +41,7 @@ def test_checkbox_demo(page: Page, app: ShinyAppProc) -> None:
     page.wait_for_url(lambda url: url != existing_url, timeout=5 * 1000)
 
     # reload the page to test bookmark
-    page.reload()
+    load_bookmark_url(page)
 
     # Check if the basic checkbox is checked
     basic_checkbox.expect_checked(True)

--- a/tests/playwright/ai_generated_apps/bookmark/input_checkbox_group/test_input_checkbox_group_express_bookmarking.py
+++ b/tests/playwright/ai_generated_apps/bookmark/input_checkbox_group/test_input_checkbox_group_express_bookmarking.py
@@ -1,4 +1,5 @@
 from playwright.sync_api import Page
+from utils.bookmark_utils import load_bookmark_url
 
 from shiny.playwright import controller
 from shiny.pytest import create_app_fixture
@@ -42,7 +43,7 @@ def test_checkbox_group_demo(page: Page, app: ShinyAppProc) -> None:
     page.wait_for_url(lambda url: url != existing_url, timeout=5 * 1000)
 
     # Reload the page to test bookmark
-    page.reload()
+    load_bookmark_url(page)
 
     # Check if selections are preserved
     basic_group.expect_selected(["Option 1", "Option 3"])

--- a/tests/playwright/ai_generated_apps/bookmark/input_dark_mode/test_input_dark_mode_express_bookmarking.py
+++ b/tests/playwright/ai_generated_apps/bookmark/input_dark_mode/test_input_dark_mode_express_bookmarking.py
@@ -1,4 +1,5 @@
 from playwright.sync_api import Page
+from utils.bookmark_utils import load_bookmark_url
 
 from shiny.playwright import controller
 from shiny.pytest import create_app_fixture
@@ -33,7 +34,7 @@ def test_dark_mode_demo(page: Page, app: ShinyAppProc) -> None:
     module_text.expect_value("Dark mode value: dark")
 
     # Reload the page to test bookmark
-    page.reload()
+    load_bookmark_url(page)
 
     basic_text.expect_value("Dark mode value: light")
     module_text.expect_value("Dark mode value: light")

--- a/tests/playwright/ai_generated_apps/bookmark/input_date/test_bookmark_input_date_express_bookmarking.py
+++ b/tests/playwright/ai_generated_apps/bookmark/input_date/test_bookmark_input_date_express_bookmarking.py
@@ -1,4 +1,5 @@
 from playwright.sync_api import Page
+from utils.bookmark_utils import load_bookmark_url
 
 from shiny.playwright import controller
 from shiny.pytest import create_app_fixture
@@ -38,7 +39,7 @@ def test_bookmark_date_inputs(page: Page, app: ShinyAppProc) -> None:
     text2.expect_value("Date value: 2024-04-04")
 
     # Reload the page to test bookmark
-    page.reload()
+    load_bookmark_url(page)
 
     date1.expect_value("2024-01-01")
     text1.expect_value("Date value: 2024-01-01")

--- a/tests/playwright/ai_generated_apps/bookmark/input_date_range/test_input_date_range_express_bookmarking.py
+++ b/tests/playwright/ai_generated_apps/bookmark/input_date_range/test_input_date_range_express_bookmarking.py
@@ -1,4 +1,5 @@
 from playwright.sync_api import Page
+from utils.bookmark_utils import load_bookmark_url
 
 from shiny.playwright import controller
 from shiny.pytest import create_app_fixture
@@ -51,7 +52,7 @@ def test_date_range_input(page: Page, app: ShinyAppProc) -> None:
     )
 
     # Reload the page to test bookmark
-    page.reload()
+    load_bookmark_url(page)
 
     basic_text.expect_value(
         "Date range values: (datetime.date(2024, 1, 1), datetime.date(2024, 1, 31))"

--- a/tests/playwright/ai_generated_apps/bookmark/input_file/test_input_file_express_bookmarking.py
+++ b/tests/playwright/ai_generated_apps/bookmark/input_file/test_input_file_express_bookmarking.py
@@ -1,4 +1,5 @@
 from playwright.sync_api import FilePayload, Page
+from utils.bookmark_utils import load_bookmark_url
 
 from shiny.playwright import controller
 from shiny.pytest import create_app_fixture
@@ -51,7 +52,7 @@ def test_file_input_bookmarking(page: Page, app: ShinyAppProc) -> None:
     bookmark_button.click()
     page.wait_for_url(lambda url: url != existing_url, timeout=5 * 1000)
 
-    page.reload()
+    load_bookmark_url(page)
 
     # Check if the values are retained after reloading the page
     file_output_txt.expect_value("File name(s): users.csv")

--- a/tests/playwright/ai_generated_apps/bookmark/input_password/test_input_password_express_bookmarking.py
+++ b/tests/playwright/ai_generated_apps/bookmark/input_password/test_input_password_express_bookmarking.py
@@ -1,4 +1,5 @@
 from playwright.sync_api import Page
+from utils.bookmark_utils import load_bookmark_url
 
 from shiny.playwright import controller
 from shiny.pytest import create_app_fixture
@@ -51,7 +52,7 @@ def test_text_input_demo(page: Page, app: ShinyAppProc) -> None:
 
     page.wait_for_url(lambda url: url != existing_url, timeout=5 * 1000)
 
-    page.reload()
+    load_bookmark_url(page)
 
     # Check if the values are retained after reloading the page
     text_output.expect_value("Text input value: Hello world")

--- a/tests/playwright/ai_generated_apps/bookmark/input_radio_buttons/test_input_radio_buttons_express_bookmarking.py
+++ b/tests/playwright/ai_generated_apps/bookmark/input_radio_buttons/test_input_radio_buttons_express_bookmarking.py
@@ -1,4 +1,5 @@
 from playwright.sync_api import Page
+from utils.bookmark_utils import load_bookmark_url
 
 from shiny.playwright import controller
 from shiny.pytest import create_app_fixture
@@ -36,7 +37,7 @@ def test_radio_buttons_demo(page: Page, app: ShinyAppProc) -> None:
     selection_output.expect_value("Radio button value: Option 3")
 
     # Reload the page to test bookmark
-    page.reload()
+    load_bookmark_url(page)
 
     radio_buttons.expect_selected("Option 2")
     selection_output.expect_value("Radio button value: Option 2")

--- a/tests/playwright/ai_generated_apps/bookmark/input_select/test_input_select_express_bookmarking.py
+++ b/tests/playwright/ai_generated_apps/bookmark/input_select/test_input_select_express_bookmarking.py
@@ -1,4 +1,5 @@
 from playwright.sync_api import Page
+from utils.bookmark_utils import load_bookmark_url
 
 from shiny.playwright import controller
 from shiny.pytest import create_app_fixture
@@ -43,7 +44,7 @@ def test_input_select_demo(page: Page, app: ShinyAppProc) -> None:
     mod_select_txt.expect_value("Select value: choiceC")
 
     # Reload the page to test bookmark
-    page.reload()
+    load_bookmark_url(page)
 
     basic_select_txt.expect_value("Select value: option2")
 

--- a/tests/playwright/ai_generated_apps/bookmark/input_slider/test_input_slider_express_bookmarking.py
+++ b/tests/playwright/ai_generated_apps/bookmark/input_slider/test_input_slider_express_bookmarking.py
@@ -1,4 +1,5 @@
 from playwright.sync_api import Page
+from utils.bookmark_utils import load_bookmark_url
 
 from shiny.playwright import controller
 from shiny.pytest import create_app_fixture
@@ -44,7 +45,7 @@ def test_slider_parameters(page: Page, app: ShinyAppProc) -> None:
     mod_value1.expect_value("Slider value: 1")
 
     # Reload the page to test bookmark
-    page.reload()
+    load_bookmark_url(page)
 
     value1.expect_value("Slider value: 0")
     mod_value1.expect_value("Slider value: 0")

--- a/tests/playwright/ai_generated_apps/bookmark/input_switch/test_input_switch_express_bookmarking.py
+++ b/tests/playwright/ai_generated_apps/bookmark/input_switch/test_input_switch_express_bookmarking.py
@@ -1,4 +1,5 @@
 from playwright.sync_api import Page
+from utils.bookmark_utils import load_bookmark_url
 
 from shiny.playwright import controller
 from shiny.pytest import create_app_fixture
@@ -40,7 +41,7 @@ def test_switch_demo(page: Page, app: ShinyAppProc) -> None:
     switch2.set(False)
     switch2.expect_checked(False)
 
-    page.reload()
+    load_bookmark_url(page)
     basic_txt.expect_value("Switch value: True")
     module_txt.expect_value("Switch value: True")
     switch1.expect_checked(True)

--- a/tests/playwright/ai_generated_apps/bookmark/input_text/test_input_text_express_bookmarking.py
+++ b/tests/playwright/ai_generated_apps/bookmark/input_text/test_input_text_express_bookmarking.py
@@ -1,4 +1,5 @@
 from playwright.sync_api import Page
+from utils.bookmark_utils import load_bookmark_url
 
 from shiny.playwright import controller
 from shiny.pytest import create_app_fixture
@@ -36,7 +37,7 @@ def test_text_input_demo(page: Page, app: ShinyAppProc) -> None:
     mod_output_txt.expect_value("Text input value: Hello again Miami")
 
     # reload pagw
-    page.reload()
+    load_bookmark_url(page)
 
     text_output.expect_value("Text input value: Hello world")
     mod_output_txt.expect_value("Text input value: Hello Miami")

--- a/tests/playwright/ai_generated_apps/bookmark/input_text_area/test_input_text_area_express_bookmarking.py
+++ b/tests/playwright/ai_generated_apps/bookmark/input_text_area/test_input_text_area_express_bookmarking.py
@@ -1,4 +1,5 @@
 from playwright.sync_api import Page
+from utils.bookmark_utils import load_bookmark_url
 
 from shiny.playwright import controller
 from shiny.pytest import create_app_fixture
@@ -36,7 +37,7 @@ def test_text_area_demo(page: Page, app: ShinyAppProc) -> None:
     mod_output_txt.expect_value("Text area value: Hello again Miami")
 
     # reload page
-    page.reload()
+    load_bookmark_url(page)
 
     text_output.expect_value("Text area value: Hello world")
     mod_output_txt.expect_value("Text area value: Hello Miami")

--- a/tests/playwright/ai_generated_apps/bookmark/navsets/test_navsets_express_bookmarking.py
+++ b/tests/playwright/ai_generated_apps/bookmark/navsets/test_navsets_express_bookmarking.py
@@ -2,6 +2,7 @@ from typing import Callable
 
 import pytest
 from playwright.sync_api import Page
+from utils.bookmark_utils import load_bookmark_url
 
 from shiny.playwright import controller
 from shiny.pytest import create_app_fixture
@@ -53,7 +54,7 @@ def test_navsets_bookmarking_demo(
     controller.InputBookmarkButton(page).click()
     page.wait_for_url(lambda url: url != existing_url, timeout=5 * 1000)
     # Reload page
-    page.reload()
+    load_bookmark_url(page)
 
     # Assert
     navset_collection.expect_value(navset_name)

--- a/tests/playwright/ai_generated_apps/bookmark/navsets/test_navsets_hidden_bookmarking.py
+++ b/tests/playwright/ai_generated_apps/bookmark/navsets/test_navsets_hidden_bookmarking.py
@@ -2,6 +2,7 @@ from typing import Callable
 
 import pytest
 from playwright.sync_api import Page
+from utils.bookmark_utils import load_bookmark_url
 
 from shiny.playwright import controller
 from shiny.pytest import create_app_fixture
@@ -56,7 +57,7 @@ def test_navset_hidden_bookmarking(
     page.wait_for_url(lambda url: url != existing_url, timeout=5 * 1000)
 
     # Reload page
-    page.reload()
+    load_bookmark_url(page)
 
     # Assert
     navset_collection.expect_value(navset_name)

--- a/tests/playwright/ai_generated_apps/bookmark/sidebar/test_sidebar_express_bookmarking.py
+++ b/tests/playwright/ai_generated_apps/bookmark/sidebar/test_sidebar_express_bookmarking.py
@@ -1,4 +1,5 @@
 from playwright.sync_api import Page
+from utils.bookmark_utils import load_bookmark_url
 
 from shiny.playwright import controller
 from shiny.pytest import create_app_fixture
@@ -31,7 +32,7 @@ def test_sidebar_bookmarking_demo(page: Page, app: ShinyAppProc) -> None:
     right_sidebar.set(True)
 
     # reload page
-    page.reload()
+    load_bookmark_url(page)
 
     left_sidebar.expect_open(False)
     right_sidebar.expect_open(False)

--- a/tests/playwright/utils/bookmark_utils.py
+++ b/tests/playwright/utils/bookmark_utils.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from playwright.sync_api import Page
+
+__all__ = ("load_bookmark_url",)
+
+
+def load_bookmark_url(page: Page) -> None:
+    """
+    Load the page's current (bookmarked) URL in a fresh page load.
+
+    Use this instead of `page.reload()` when asserting that bookmarked state is
+    restored. A reload lets the browser restore the previous form control values
+    (Firefox does this), which then overwrite the values Shiny restores from the
+    bookmark URL. Navigating anew starts from the markup the server sends, so the
+    assertions actually exercise bookmark restoration.
+    """
+    page.goto(page.url)


### PR DESCRIPTION
## Problem

The `playwright-ai` Firefox jobs started failing on **every** shard and Python version, on commits that had passed a day earlier (e.g. `67fc0f45` [passed](https://github.com/posit-dev/py-shiny/actions/runs/30618461855) on 07-31, [failed](https://github.com/posit-dev/py-shiny/actions/runs/30692474010) on 08-01). Also seen on #2404's run.

Two tests fail:

- `bookmark/input_switch/test_input_switch_express_bookmarking.py::test_switch_demo`
- `bookmark/input_select/test_input_select_express_bookmarking.py::test_input_select_demo`

Both fail after `page.reload()`, asserting the bookmarked value but seeing the value that was set *after* bookmarking.

## Root cause

The only difference between the passing and failing runs is the resolved Playwright version: `1.61.0` → `1.62.0`, which ships Firefox 153. That Firefox restores form control values across a `page.reload()`. The restored DOM values are then reported by the input bindings and overwrite the state Shiny restored from the bookmark URL.

Confirmed locally with a probe on the same app (Playwright 1.62.0 / Firefox 153) — same bookmark URL, only the navigation method differs:

```
URL BEFORE RELOAD: .../?_inputs_&basic=true&first-module_switch=false
AFTER RELOAD: checked = False  text = 'Switch value: False'   # browser-restored form state wins
AFTER GOTO  : checked = True   text = 'Switch value: True'    # bookmark restore wins
```

The other bookmark tests kept passing only because the browser-restored values happened to equal the bookmarked ones — meaning they were not actually exercising bookmark restoration on Firefox.

## Fix

Add `tests/playwright/utils/bookmark_utils.py::load_bookmark_url()`, which navigates to the page's current URL rather than reloading it, and use it in place of `page.reload()` across `tests/playwright/ai_generated_apps/bookmark/`. A fresh navigation starts from the markup the server sends, so the assertions test bookmark restoration rather than the browser's form-state restoration.

## Verification

Full `tests/playwright/ai_generated_apps/bookmark` suite, locally, Playwright 1.62.0:

- firefox — 25 passed
- chromium — 25 passed
- webkit — 25 passed

Both failing tests were reproduced locally before the change and pass after.

`uv run make format check-lint check-types` passes (pyrefly: 0 errors).