### PR TITLE
fix(render): register download handlers with explicit output IDs

### DIFF
--- a/shiny/render/_render.py
+++ b/shiny/render/_render.py
@@ -624,6 +624,7 @@ class _DownloadBase(Renderer[str]):
         self.encoding = encoding
         self.label = label
         self.width = width
+        self._download_handler: DownloadHandler | None = None
 
         if fn is not None:
             self(fn)
@@ -658,27 +659,49 @@ class _DownloadBase(Renderer[str]):
         # Unlike most value functions, this one's name is `url`. But we want to get the
         # name from the user-supplied function.
         url.__name__ = fn.__name__
+        self._download_handler = fn
 
         # We invoke `super().__call__()` now, because it indirectly invokes
         # `Outputs.__call__()`, which sets `output_id` (and `self.__name__`), which is
         # then used below.
         super().__call__(url)
 
+        self._register_download()
+
+        return self
+
+    def _register_download(self) -> None:
         # Register the download handler for the session. The reason we check for session
         # not being None or a stub session is because in Express, when the UI is
         # rendered, this function is called once before any sessions have been started.
         session = get_current_session()
-        if session is not None and not session.is_stub_session():
+        if (
+            session is not None
+            and not session.is_stub_session()
+            and self._download_handler is not None
+        ):
             # All download objects are stored in the root session.
             # They must be fully namespaced
             session._downloads[session.ns(self.output_id)] = DownloadInfo(
                 filename=self.filename,
                 content_type=self.media_type,
-                handler=fn,
+                handler=self._download_handler,
                 encoding=self.encoding,
             )
 
-        return self
+    def _on_register(self) -> None:
+        if self._auto_registered:
+            session = require_active_session(None)
+            download_id = session.ns(self.__name__)
+            download_info = session._downloads.get(download_id)
+            if (
+                download_info is not None
+                and download_info.handler is self._download_handler
+            ):
+                del session._downloads[download_id]
+
+        super()._on_register()
+        self._register_download()
 
     async def transform(self, value: str) -> Jsonifiable:
         return value

--- a/tests/pytest/test_renderer.py
+++ b/tests/pytest/test_renderer.py
@@ -4,9 +4,10 @@ from typing import Optional
 
 import pytest
 
-from shiny import reactive, render
+from shiny import App, reactive, render, ui
+from shiny._connection import MockConnection
 from shiny.render.renderer import Renderer, ValueFn
-from shiny.session import Session, get_current_session
+from shiny.session import Session, get_current_session, session_context
 
 
 class RendererWithSession(Renderer[str]):
@@ -175,3 +176,17 @@ def test_render_download_is_deprecated():
         @render.download
         def dl():
             yield "data"
+
+
+def test_download_button_output_id_registers_download_handler():
+    session = App(ui.TagList(), None)._create_session(MockConnection())
+
+    with session_context(session):
+
+        @session.output(id="download4")
+        @render.download_button(filename="failuretest.txt")
+        async def _():
+            yield "hello"
+
+    assert "download4" in session._downloads
+    assert "_" not in session._downloads


### PR DESCRIPTION
Fixes #2399.

`_DownloadBase.__call__()` registered the download handler in `session._downloads` immediately after `super().__call__(url)`, while `self.output_id` was still the decorated function name. With an explicit `@output(id="download4")` decorator above it, `Outputs.__call__()` later updated the renderer metadata so the rendered URL pointed at `/download/download4`, but the handler remained stored under the old function-name key. The session download route only serves IDs present in `_downloads`, so the explicit output ID URL missed the registered handler and returned 404.

This stores the user download handler on `_DownloadBase` and centralizes `DownloadInfo` registration under `session.ns(self.output_id)`. `_DownloadBase._on_register()` now handles the explicit `@output(id=...)` path by removing the stale function-name entry and re-registering the handler under the explicit output ID.

The no-`@output` path remains registered after the initial `super().__call__(url)`, using the same shared helper.

Modified files:
- `shiny/render/_render.py`
- `tests/pytest/test_renderer.py`

`ruff check shiny/render/_render.py tests/pytest/test_renderer.py` reports no new findings on the changed files.
Ran `pytest -x` locally with no new failures.
