### PR TITLE
fix(data-frame): handle numeric column names in DataGrid serialization

### DIFF
--- a/shiny/render/_data_frame_utils/_tbl_data.py
+++ b/shiny/render/_data_frame_utils/_tbl_data.py
@@ -237,7 +237,9 @@ def serialize_frame(into_data: IntoDataFrame) -> FrameJson:
 
     data = as_data_frame(into_data)
 
-    type_hints = [serialize_dtype(data[col_name]) for col_name in data.columns]
+    type_hints = [
+        serialize_dtype(data.get_column(col_name)) for col_name in data.columns
+    ]
 
     # TODO-future-barret; Swich serialization to "by column", rather than "by row"
     # * This would allow for a single column to be serialized in a single operation

--- a/tests/pytest/test_render_data_frame_tbl_data.py
+++ b/tests/pytest/test_render_data_frame_tbl_data.py
@@ -313,6 +313,19 @@ def test_serialize_frame(df_f: IntoDataFrame):
     }
 
 
+def test_serialize_frame_with_numeric_pandas_column_names():
+    df = pd.DataFrame([["a", 1], ["b", 2]], columns=[0, 1])
+
+    res = serialize_frame(df)
+
+    assert res == {
+        "columns": [0, 1],
+        "data": [["a", 1], ["b", 2]],
+        "typeHints": [{"type": "string"}, {"type": "numeric"}],
+        "htmlDeps": [],
+    }
+
+
 def test_subset_frame(df_f: IntoDataFrame):
     # TODO: this assumes subset_frame doesn't reset index
     res = subset_frame(as_data_frame(df_f), rows=[1], cols=["chr", "num"])


### PR DESCRIPTION
Fixes #2115.

`serialize_frame()` built type hints by iterating over `data.columns` and reading each column with `data[col_name]`. For pandas DataFrames with integer column labels, Narwhals treats integer DataFrame indexing as positional row selection, so `data[0]` returns a DataFrame instead of a Series. That DataFrame was passed into `serialize_dtype()`, which then failed while reading `.dtype` before the DataGrid payload could be built.

This changes type hint construction to retrieve columns with Narwhals `DataFrame.get_column(col_name)`, leaving the rest of payload serialization unchanged.

Adds a serializer-level regression test with pandas integer column labels `[0, 1]` that asserts `serialize_frame()` succeeds and returns the expected columns, rows, and type hints. The test stays at the serializer layer because the failure happens before DataGrid-specific options are added.

`ruff check shiny/render/_data_frame_utils/_tbl_data.py tests/pytest/test_render_data_frame_tbl_data.py` reports no new findings on the changed files.
Ran `pytest -x` locally with no new failures.
