### PR TITLE
fix(express): match AST function nodes by lexical code name

### DIFF
--- a/shiny/express/expressify_decorator/_helpers.py
+++ b/shiny/express/expressify_decorator/_helpers.py
@@ -42,4 +42,4 @@ def ast_matches_func(node: ast.AST, func: FunctionType) -> bool:
     if not isinstance(node, ast.FunctionDef):
         return False
     linenos = [*[dec.lineno for dec in node.decorator_list], node.lineno]
-    return func.__code__.co_firstlineno in linenos and func.__name__ == node.name
+    return func.__code__.co_firstlineno in linenos and func.__code__.co_name == node.name

--- a/tests/pytest/test_display_decorator.py
+++ b/tests/pytest/test_display_decorator.py
@@ -12,6 +12,7 @@ from htmltools import Tagifiable
 
 from shiny import render, ui
 from shiny.express import expressify
+from shiny.express.expressify_decorator._expressify import expressify_unwrap_inplace
 
 
 @contextlib.contextmanager
@@ -205,3 +206,23 @@ def test_no_nested_transform_unless_explicit():
     with capture_display() as d:
         inner1()
         assert d == [1, 2, 5, 6]
+
+
+def test_name_mutating_decorator_matches_original_ast_name():
+    def append_to_name(suffix: str):
+        def decorator(fn):
+            fn.__name__ = fn.__name__ + suffix
+            return fn
+
+        return decorator
+
+    @expressify_unwrap_inplace()
+    @append_to_name("_changed")
+    def displays_value():
+        "value"
+
+    assert displays_value.__name__ == "displays_value_changed"
+
+    with capture_display() as d:
+        displays_value()
+        assert d == ["value"]


### PR DESCRIPTION
Fixes #2016.

The Express expressify AST lookup previously matched an `ast.FunctionDef` by the function object's current `__name__` and first line number. Decorators can mutate `fn.__name__` after the original function is created, while the source AST node keeps the lexical `def` name and the function code object keeps that original name in `co_name`. With a decorator such as `extend_name`, `@render.express` could call `expressify_unwrap_inplace` on a function whose runtime name had changed, causing `ast_matches_func` to compare a mutated name like `docs_label_human_animal` against the AST name `docs_label` and fail with the internal `RuntimeError`.

This changes `ast_matches_func` to compare the AST function name with `func.__code__.co_name` instead of mutable `func.__name__`, while preserving the existing decorator-line/def-line check so duplicate-name disambiguation still uses line numbers.

A regression test was added for a decorator that mutates `__name__` before expressification through `expressify_unwrap_inplace`, matching the `@render.express` failure path.

`ruff check shiny/express/expressify_decorator/_helpers.py tests/pytest/test_display_decorator.py` reports no new findings on the changed files.
Ran `pytest -x` locally with no new failures.
