### PR TITLE
feat: Use app author's navset id for data-tabsetid instead of random …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
-* Navsets created with an `id` (e.g. `ui.navset_tab(id="tabs")`) now use that `id` as their `data-tabsetid`, so their tab panes get stable `tab-tabs-0` style DOM ids instead of ones built from a random integer. This makes the rendered markup reproducible across renders and easier to target from custom CSS and JavaScript. Navsets without an `id`, and `ui.nav_menu()` dropdowns, keep the random ID. (#2410)
+* Navsets created with an `id` (e.g. `ui.navset_tab(id="tabs")`) now use that `id` as their `data-tabsetid`, so their tab panes get stable `tab-tabs-0` style DOM ids instead of ones built from a random integer. This makes the rendered markup reproducible across renders and easier to target from custom CSS and JavaScript. Navsets without an `id`, and `ui.nav_menu()` dropdowns, keep the random ID. (Thanks, @pevolution-ahmed!) (#2410)
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `playwright.controller.OutputTextVerbatim` is deprecated alongside `ui.output_text_verbatim()` and now emits a `ShinyDeprecationWarning` when constructed. Please use `playwright.controller.OutputCode` instead. (#2097)
 
+### Improvements
+
+* Navsets created with an `id` (e.g. `ui.navset_tab(id="tabs")`) now use that `id` as their `data-tabsetid`, so their tab panes get stable `tab-tabs-0` style DOM ids instead of ones built from a random integer. This makes the rendered markup reproducible across renders and easier to target from custom CSS and JavaScript. Navsets without an `id`, and `ui.nav_menu()` dropdowns, keep the random ID. (#2410)
+
 ### Bug fixes
 
 * The `ui.Theme` API reference examples now run in Shinylive. Compiling a customized theme requires `libsass`, but Shinylive only auto-loads packages it finds in an app's top-level imports and `Theme.to_css()` imports `sass` lazily, so the examples died with an `ImportError`. The example directory now declares `libsass` in a `requirements.txt`. (#2386)

--- a/shiny/ui/_navs.py
+++ b/shiny/ui/_navs.py
@@ -1626,7 +1626,9 @@ def render_navset(
     selected: Optional[str],
     context: dict[str, Any],
 ) -> tuple[Tag, Tag]:
-    tabsetid = nav_random_int()
+    # Derive the tabset ID from the user-supplied (already module-resolved)
+    # input id when available; fall back to a random ID for anonymous navsets.
+    tabsetid = id if id is not None else nav_random_int()
 
     # Separate MetadataNodes from NavSetArgs.
     metadata_args: list[MetadataNode] = []

--- a/tests/pytest/test_navs.py
+++ b/tests/pytest/test_navs.py
@@ -2,14 +2,16 @@
 
 import contextlib
 import random
+import re
 import textwrap
 from typing import Generator
 
 import pytest
-from htmltools import TagList
+from htmltools import TagChild, TagList
 
 from shiny import ui
 from shiny._deprecated import ShinyDeprecationWarning
+from shiny._namespaces import namespace_context
 from shiny._utils import private_seed
 from shiny.ui._navs import (
     NavbarOptions,
@@ -176,6 +178,60 @@ def test_navset_bar_markup():
           </div>
           Page footer
         </div>""")
+
+
+# tabset IDs ---------------------------------------------------------------------------
+
+
+def tabset_ids(x: TagChild) -> list[str]:
+    """All `data-tabsetid` values in `x`, in document order."""
+    return re.findall(r'data-tabsetid="([^"]*)"', TagList(x).render()["html"])
+
+
+def test_navset_tabsetid_uses_the_input_id():
+    x = ui.navset_tab(a, b, id="my_tabs")
+    html = TagList(x).render()["html"]
+
+    assert tabset_ids(x) == ["my_tabs", "my_tabs"]
+    assert 'id="tab-my_tabs-0"' in html
+    assert 'href="#tab-my_tabs-0"' in html
+
+
+def test_navset_tabsetid_is_stable_across_renders():
+    # The point of deriving the tabset ID from the input id: two independent
+    # renders of the same navset produce byte-identical markup.
+    first = TagList(ui.navset_tab(a, b, id="my_tabs")).render()["html"]
+    second = TagList(ui.navset_tab(a, b, id="my_tabs")).render()["html"]
+
+    assert first == second
+
+
+def test_navset_tabsetid_is_module_namespaced():
+    with namespace_context("mod"):
+        x = ui.navset_tab(a, b, id="my_tabs")
+
+    assert tabset_ids(x) == ["mod-my_tabs", "mod-my_tabs"]
+    assert 'id="tab-mod-my_tabs-0"' in TagList(x).render()["html"]
+
+
+def test_navset_tabsetid_is_random_when_anonymous():
+    first = tabset_ids(ui.navset_tab(a, b))
+    second = tabset_ids(ui.navset_tab(a, b))
+
+    # Both the <ul> and the <div class="tab-content"> share one ID...
+    assert len(first) == 2 and first[0] == first[1]
+    assert re.fullmatch(r"\d{13}", first[0])
+    # ...but separate renders do not, since there is no id to key off.
+    assert first[0] != second[0]
+
+
+def test_nav_menu_tabsetid_stays_random_inside_an_identified_navset():
+    # `nav_menu()` dropdowns are nested tabsets with no id of their own, so they
+    # must keep the random fallback rather than inherit the parent's ID.
+    outer, dropdown, _content = tabset_ids(ui.navset_tab(a, menu, id="my_tabs"))
+
+    assert outer == "my_tabs"
+    assert re.fullmatch(r"\d{13}", dropdown)
 
 
 # navbar_options() -------------------------------------------------------------------

--- a/tests/pytest/test_navs.py
+++ b/tests/pytest/test_navs.py
@@ -44,7 +44,8 @@ def test_navset_tab_markup():
     with private_seed_n():
         x = ui.navset_tab(a, b, ui.nav_control("Some item"), menu)
 
-    assert TagList(x).render()["html"] == textwrap.dedent("""\
+    assert TagList(x).render()["html"] == textwrap.dedent(
+        """\
         <ul class="nav nav-tabs" data-tabsetid="7776790190029">
           <li class="nav-item">
             <a data-bs-toggle="tab" data-toggle="tab" data-value="a" role="tab" class="nav-link active" href="#tab-7776790190029-0">a</a>
@@ -70,14 +71,16 @@ def test_navset_tab_markup():
           <div class="tab-pane active" role="tabpanel" data-value="a" id="tab-7776790190029-0">a</div>
           <div class="tab-pane" role="tabpanel" data-value="b" id="tab-7776790190029-1">b</div>
           <div class="tab-pane" role="tabpanel" data-value="c" id="tab-1710475945045-0">c</div>
-        </div>""")
+        </div>"""
+    )
 
 
 def test_navset_pill_markup():
     with private_seed_n():
         x = ui.navset_pill(menu, a, id="navset_pill_id")
 
-    assert TagList(x).render()["html"] == textwrap.dedent("""\
+    assert TagList(x).render()["html"] == textwrap.dedent(
+        """\
         <ul class="nav nav-pills shiny-tab-input" id="navset_pill_id" data-tabsetid="navset_pill_id">
           <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle active" data-bs-toggle="dropdown" data-value="Menu" href="#" role="button">Menu</a>
@@ -98,7 +101,8 @@ def test_navset_pill_markup():
         <div class="tab-content" data-tabsetid="navset_pill_id">
           <div class="tab-pane active" role="tabpanel" data-value="c" id="tab-7776790190029-0">c</div>
           <div class="tab-pane" role="tabpanel" data-value="a" id="tab-navset_pill_id-1">a</div>
-        </div>""")
+        </div>"""
+    )
 
 
 def test_navset_card_pill_markup():
@@ -110,7 +114,8 @@ def test_navset_card_pill_markup():
             selected="c",
         )
 
-    assert TagList(x).render()["html"] == textwrap.dedent("""\
+    assert TagList(x).render()["html"] == textwrap.dedent(
+        """\
         <div class="card bslib-card bslib-mb-spacing html-fill-item html-fill-container" data-bslib-card-init="">
           <div class="card-header">
             <ul class="nav nav-pills card-header-pills" data-tabsetid="7776790190029">
@@ -138,7 +143,8 @@ def test_navset_card_pill_markup():
             </div>
           </div>
           <script data-bslib-card-init="">window.bslib.Card.initializeAllCards();</script>
-        </div>""")
+        </div>"""
+    )
 
 
 def test_navset_bar_markup():
@@ -150,7 +156,8 @@ def test_navset_bar_markup():
             header="Page header",
         )
 
-    assert TagList(x).render()["html"] == textwrap.dedent("""\
+    assert TagList(x).render()["html"] == textwrap.dedent(
+        """\
         <nav class="navbar navbar-expand-md navbar-default" data-bs-theme="auto">
           <div class="container-fluid">
             <span class="navbar-brand">Page title</span><button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar-collapse-9549180827234" aria-controls="navbar-collapse-9549180827234" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
@@ -175,7 +182,8 @@ def test_navset_bar_markup():
             <div class="tab-pane active html-fill-item html-fill-container bslib-gap-spacing" role="tabpanel" data-value="c" id="tab-1710475945045-1" style="--bslib-navbar-margin:0;;">c</div>
           </div>
           Page footer
-        </div>""")
+        </div>"""
+    )
 
 
 # navbar_options() -------------------------------------------------------------------

--- a/tests/pytest/test_navs.py
+++ b/tests/pytest/test_navs.py
@@ -44,8 +44,7 @@ def test_navset_tab_markup():
     with private_seed_n():
         x = ui.navset_tab(a, b, ui.nav_control("Some item"), menu)
 
-    assert TagList(x).render()["html"] == textwrap.dedent(
-        """\
+    assert TagList(x).render()["html"] == textwrap.dedent("""\
         <ul class="nav nav-tabs" data-tabsetid="7776790190029">
           <li class="nav-item">
             <a data-bs-toggle="tab" data-toggle="tab" data-value="a" role="tab" class="nav-link active" href="#tab-7776790190029-0">a</a>
@@ -71,16 +70,14 @@ def test_navset_tab_markup():
           <div class="tab-pane active" role="tabpanel" data-value="a" id="tab-7776790190029-0">a</div>
           <div class="tab-pane" role="tabpanel" data-value="b" id="tab-7776790190029-1">b</div>
           <div class="tab-pane" role="tabpanel" data-value="c" id="tab-1710475945045-0">c</div>
-        </div>"""
-    )
+        </div>""")
 
 
 def test_navset_pill_markup():
     with private_seed_n():
         x = ui.navset_pill(menu, a, id="navset_pill_id")
 
-    assert TagList(x).render()["html"] == textwrap.dedent(
-        """\
+    assert TagList(x).render()["html"] == textwrap.dedent("""\
         <ul class="nav nav-pills shiny-tab-input" id="navset_pill_id" data-tabsetid="navset_pill_id">
           <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle active" data-bs-toggle="dropdown" data-value="Menu" href="#" role="button">Menu</a>
@@ -101,8 +98,7 @@ def test_navset_pill_markup():
         <div class="tab-content" data-tabsetid="navset_pill_id">
           <div class="tab-pane active" role="tabpanel" data-value="c" id="tab-7776790190029-0">c</div>
           <div class="tab-pane" role="tabpanel" data-value="a" id="tab-navset_pill_id-1">a</div>
-        </div>"""
-    )
+        </div>""")
 
 
 def test_navset_card_pill_markup():
@@ -114,8 +110,7 @@ def test_navset_card_pill_markup():
             selected="c",
         )
 
-    assert TagList(x).render()["html"] == textwrap.dedent(
-        """\
+    assert TagList(x).render()["html"] == textwrap.dedent("""\
         <div class="card bslib-card bslib-mb-spacing html-fill-item html-fill-container" data-bslib-card-init="">
           <div class="card-header">
             <ul class="nav nav-pills card-header-pills" data-tabsetid="7776790190029">
@@ -143,8 +138,7 @@ def test_navset_card_pill_markup():
             </div>
           </div>
           <script data-bslib-card-init="">window.bslib.Card.initializeAllCards();</script>
-        </div>"""
-    )
+        </div>""")
 
 
 def test_navset_bar_markup():
@@ -156,8 +150,7 @@ def test_navset_bar_markup():
             header="Page header",
         )
 
-    assert TagList(x).render()["html"] == textwrap.dedent(
-        """\
+    assert TagList(x).render()["html"] == textwrap.dedent("""\
         <nav class="navbar navbar-expand-md navbar-default" data-bs-theme="auto">
           <div class="container-fluid">
             <span class="navbar-brand">Page title</span><button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar-collapse-9549180827234" aria-controls="navbar-collapse-9549180827234" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
@@ -182,8 +175,7 @@ def test_navset_bar_markup():
             <div class="tab-pane active html-fill-item html-fill-container bslib-gap-spacing" role="tabpanel" data-value="c" id="tab-1710475945045-1" style="--bslib-navbar-margin:0;;">c</div>
           </div>
           Page footer
-        </div>"""
-    )
+        </div>""")
 
 
 # navbar_options() -------------------------------------------------------------------

--- a/tests/pytest/test_navs.py
+++ b/tests/pytest/test_navs.py
@@ -78,12 +78,12 @@ def test_navset_pill_markup():
         x = ui.navset_pill(menu, a, id="navset_pill_id")
 
     assert TagList(x).render()["html"] == textwrap.dedent("""\
-        <ul class="nav nav-pills shiny-tab-input" id="navset_pill_id" data-tabsetid="7776790190029">
+        <ul class="nav nav-pills shiny-tab-input" id="navset_pill_id" data-tabsetid="navset_pill_id">
           <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle active" data-bs-toggle="dropdown" data-value="Menu" href="#" role="button">Menu</a>
-            <ul class="dropdown-menu" data-tabsetid="1710475945045">
+            <ul class="dropdown-menu" data-tabsetid="7776790190029">
               <li>
-                <a data-bs-toggle="tab" data-toggle="tab" data-value="c" role="tab" class="dropdown-item active" href="#tab-1710475945045-0">c</a>
+                <a data-bs-toggle="tab" data-toggle="tab" data-value="c" role="tab" class="dropdown-item active" href="#tab-7776790190029-0">c</a>
               </li>
               <li class="dropdown-divider"></li>
               <li class="dropdown-header">Plain text</li>
@@ -92,12 +92,12 @@ def test_navset_pill_markup():
             </ul>
           </li>
           <li class="nav-item">
-            <a data-bs-toggle="tab" data-toggle="tab" data-value="a" role="tab" class="nav-link" href="#tab-7776790190029-1">a</a>
+            <a data-bs-toggle="tab" data-toggle="tab" data-value="a" role="tab" class="nav-link" href="#tab-navset_pill_id-1">a</a>
           </li>
         </ul>
-        <div class="tab-content" data-tabsetid="7776790190029">
-          <div class="tab-pane active" role="tabpanel" data-value="c" id="tab-1710475945045-0">c</div>
-          <div class="tab-pane" role="tabpanel" data-value="a" id="tab-7776790190029-1">a</div>
+        <div class="tab-content" data-tabsetid="navset_pill_id">
+          <div class="tab-pane active" role="tabpanel" data-value="c" id="tab-7776790190029-0">c</div>
+          <div class="tab-pane" role="tabpanel" data-value="a" id="tab-navset_pill_id-1">a</div>
         </div>""")
 
 


### PR DESCRIPTION
Closes #2298

## Summary

When a navset has a user-supplied `id=`, use it as the `data-tabsetid` (and the derived `tab-<tabsetid>-<index>` pane IDs) instead of minting a random integer.

**Before:** `data-tabsetid="7776790190029"` / `id="tab-7776790190029-0"`
**After:** `data-tabsetid="my_tabs"` / `id="tab-my_tabs-0"`

Anonymous navsets (`id=None`) and `nav_menu()` dropdowns keep the random fallback.

## Changes

- **`shiny/ui/_navs.py`** One-line change in `render_navset()`: `tabsetid = id if id is not None else nav_random_int()`
- **`tests/pytest/test_navs.py`** Updated the `test_navset_pill_markup` snapshot to expect the deterministic IDs


