### PR TITLE
fix(express): match decorated functions by code object name

### DIFF
--- a/shiny/express/expressify_decorator/_helpers.py
+++ b/shiny/express/expressify_decorator/_helpers.py
@@ -42,4 +42,4 @@ def ast_matches_func(node: ast.AST, func: FunctionType) -> bool:
     if not isinstance(node, ast.FunctionDef):
         return False
     linenos = [*[dec.lineno for dec in node.decorator_list], node.lineno]
-    return func.__code__.co_firstlineno in linenos and func.__name__ == node.name
+    return func.__code__.co_firstlineno in linenos and func.__code__.co_name == node.name

--- a/tests/pytest/test_display_decorator.py
+++ b/tests/pytest/test_display_decorator.py
@@ -12,6 +12,7 @@ from htmltools import Tagifiable
 
 from shiny import render, ui
 from shiny.express import expressify
+from shiny.express.expressify_decorator._expressify import expressify_unwrap_inplace
 
 
 @contextlib.contextmanager
@@ -160,6 +161,21 @@ def test_annotations():
     assert annotated.__doc__ == "Here's a docstring"
 
     assert inspect.getsource(annotated) == inspect.getsource(annotated.__wrapped__)  # type: ignore
+
+
+def test_name_mutating_decorator_matches_original_ast_name():
+    def append_name(fn):
+        fn.__name__ = f"{fn.__name__}_modified"
+        return fn
+
+    @expressify_unwrap_inplace()
+    @append_name
+    def name_mutated():
+        "value"
+
+    with capture_display() as d:
+        name_mutated()
+        assert d == ["value"]
 
 
 def test_implicit_output():


### PR DESCRIPTION
Fixes #1994.

`update_action_button()` had no effect on a download button because expressification could fail before finding the function AST node. The Express `expressify` lookup matched an `ast.FunctionDef` using the function object's current `__name__` plus the decorator/definition line check. Decorators such as `extend_name` can mutate `fn.__name__` after the function is created, while the source AST node still uses the lexical `def` name and the code object retains that original `co_name`.

When `@render.express` calls `expressify_unwrap_inplace` on the decorated function, `ast_matches_func` compared the mutated runtime name, such as `docs_label_human_animal`, with the AST name, such as `docs_label`, failed to find the function node, and raised the internal `RuntimeError`.

This changes `ast_matches_func` to compare the AST function name with `func.__code__.co_name` instead of mutable `func.__name__`, while preserving the existing decorator-line/def-line check. That keeps duplicate-name disambiguation based on line numbers intact and uses the immutable lexical function name recorded in the code object.

Adds a regression test covering a decorator that mutates `__name__` before expressification through `expressify_unwrap_inplace`, mirroring the `@render.express` path.

`ruff check shiny/express/expressify_decorator/_helpers.py tests/pytest/test_display_decorator.py` reports no new findings on the changed files.
Ran `pytest -x` locally with no new failures.
