### PR TITLE
fix(docs): remove duplicate page_sidebar core API link

### DIFF
--- a/docs/_quartodoc-core.yml
+++ b/docs/_quartodoc-core.yml
@@ -16,7 +16,6 @@ quartodoc:
       contents:
         - ui.page_sidebar
         - ui.page_navbar
-        - ui.page_sidebar
         - ui.page_fillable
         - ui.page_fluid
         - ui.page_fixed

--- a/docs/_quartodoc-express.yml
+++ b/docs/_quartodoc-express.yml
@@ -51,7 +51,6 @@ quartodoc:
         - express.render.DataGrid
         - express.render.text
         - express.render.ui
-        - express.render.download
         - express.render.download_button
         - express.render.download_link
         - express.render.image
@@ -190,7 +189,6 @@ quartodoc:
       desc: Allow users to upload and download files.
       contents:
         - express.ui.input_file
-        - express.render.download
         - express.render.download_button
         - express.render.download_link
     - title: Dynamic UI
@@ -235,3 +233,7 @@ quartodoc:
       contents:
         - express.is_express_app
         - express.wrap_express_app
+    - title: Deprecated
+      desc: ""
+      contents:
+        - express.render.download

--- a/tests/pytest/_quartodoc_utils.py
+++ b/tests/pytest/_quartodoc_utils.py
@@ -19,4 +19,7 @@ def load_quartodoc_sections(config_path: Path) -> list[dict[str, Any]]:
     except Exception as e:
         pytest.fail(f"Failed to load or parse {config_path}: {e}")
 
-    return config.get("quartodoc", {}).get("sections", [])
+    # An empty or comments-only config parses to `None`, and a key with nothing
+    # under it (`sections:`) parses to `None` rather than an empty list.
+    quartodoc = (config or {}).get("quartodoc") or {}
+    return quartodoc.get("sections") or []

--- a/tests/pytest/_quartodoc_utils.py
+++ b/tests/pytest/_quartodoc_utils.py
@@ -13,10 +13,17 @@ QUARTODOC_CONFIGS = tuple(sorted(DOCS_DIR.glob("_quartodoc-*.yml")))
 
 
 def load_quartodoc_sections(config_path: Path) -> list[dict[str, Any]]:
-    """Return the `quartodoc.sections` entries of a Quartodoc config file."""
+    """
+    Return the `quartodoc.sections` entries of a Quartodoc config file.
+
+    Raises
+    ------
+    Fails the calling test if the file cannot be read (`OSError`) or is not
+    valid YAML (`yaml.YAMLError`).
+    """
     try:
         config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
-    except Exception as e:
+    except (OSError, yaml.YAMLError) as e:
         pytest.fail(f"Failed to load or parse {config_path}: {e}")
 
     # An empty or comments-only config parses to `None`, and a key with nothing

--- a/tests/pytest/_quartodoc_utils.py
+++ b/tests/pytest/_quartodoc_utils.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+DOCS_DIR = Path(__file__).parent.parent.parent / "docs"
+
+QUARTODOC_CONFIGS = tuple(sorted(DOCS_DIR.glob("_quartodoc-*.yml")))
+"""Every Quartodoc config that drives a generated API reference page."""
+
+
+def load_quartodoc_sections(config_path: Path) -> list[dict[str, Any]]:
+    """Return the `quartodoc.sections` entries of a Quartodoc config file."""
+    try:
+        config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except Exception as e:
+        pytest.fail(f"Failed to load or parse {config_path}: {e}")
+
+    return config.get("quartodoc", {}).get("sections", [])

--- a/tests/pytest/_quartodoc_utils.py
+++ b/tests/pytest/_quartodoc_utils.py
@@ -11,6 +11,9 @@ DOCS_DIR = Path(__file__).parent.parent.parent / "docs"
 QUARTODOC_CONFIGS = tuple(sorted(DOCS_DIR.glob("_quartodoc-*.yml")))
 """Every Quartodoc config that drives a generated API reference page."""
 
+QuartodocContent = str | dict[str, Any]
+"""A `contents` entry: a bare symbol name, or a mapping with a `name`/`path`."""
+
 
 def load_quartodoc_sections(config_path: Path) -> list[dict[str, Any]]:
     """
@@ -22,11 +25,19 @@ def load_quartodoc_sections(config_path: Path) -> list[dict[str, Any]]:
     valid YAML (`yaml.YAMLError`).
     """
     try:
-        config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        parsed: Any = yaml.safe_load(config_path.read_text(encoding="utf-8"))
     except (OSError, yaml.YAMLError) as e:
         pytest.fail(f"Failed to load or parse {config_path}: {e}")
 
     # An empty or comments-only config parses to `None`, and a key with nothing
     # under it (`sections:`) parses to `None` rather than an empty list.
-    quartodoc = (config or {}).get("quartodoc") or {}
-    return quartodoc.get("sections") or []
+    config: dict[str, Any] = parsed or {}
+    quartodoc: dict[str, Any] = config.get("quartodoc") or {}
+    sections: list[dict[str, Any]] = quartodoc.get("sections") or []
+    return sections
+
+
+def section_contents(section: dict[str, Any]) -> list[QuartodocContent]:
+    """Return a section's `contents`, treating a missing or empty key as empty."""
+    contents: list[QuartodocContent] = section.get("contents") or []
+    return contents

--- a/tests/pytest/test_controller_documentation.py
+++ b/tests/pytest/test_controller_documentation.py
@@ -30,7 +30,7 @@ def get_documented_controllers() -> Set[str]:
     return {
         content.split(".")[-1]
         for section in load_quartodoc_sections(DOCS_CONFIG)
-        for content in section.get("contents", [])
+        for content in section.get("contents") or []
         if isinstance(content, str) and content.startswith("playwright.controller.")
     }
 

--- a/tests/pytest/test_controller_documentation.py
+++ b/tests/pytest/test_controller_documentation.py
@@ -11,6 +11,7 @@ root = Path(__file__).parent.parent.parent
 
 CONTROLLER_DIR = root / "shiny/playwright/controller"
 DOCS_CONFIG = root / "docs/_quartodoc-testing.yml"
+QUARTODOC_CONFIGS = tuple(sorted((root / "docs").glob("_quartodoc-*.yml")))
 
 
 def get_controller_classes() -> Set[str]:
@@ -66,3 +67,47 @@ def test_all_controllers_are_documented():
 
     assert controller_classes, "No controller classes were found."
     assert documented_controllers, "No documented controllers were found."
+
+
+def _quartodoc_content_name(content: object) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, dict):
+        name = content.get("name") or content.get("path")
+        if isinstance(name, str):
+            return name
+        return yaml.safe_dump(content, sort_keys=True)
+    return repr(content)
+
+
+def test_quartodoc_configs_have_unique_contents():
+    error_messages: list[str] = []
+
+    for config_path in QUARTODOC_CONFIGS:
+        try:
+            config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        except Exception as e:
+            pytest.fail(f"Failed to load or parse {config_path}: {e}")
+
+        for section in config.get("quartodoc", {}).get("sections", []):
+            seen: set[str] = set()
+            duplicates: list[str] = []
+
+            for content in section.get("contents", []):
+                content_name = _quartodoc_content_name(content)
+                if content_name in seen:
+                    duplicates.append(content_name)
+                else:
+                    seen.add(content_name)
+
+            if duplicates:
+                duplicate_list = "\n".join(sorted(f"  - {x}" for x in duplicates))
+                error_messages.append(
+                    f"Duplicate contents in {config_path}, "
+                    f"section {section.get('title')!r}:\n{duplicate_list}"
+                )
+
+    if error_messages:
+        pytest.fail("\n\n".join(error_messages), pytrace=False)
+
+    assert QUARTODOC_CONFIGS, "No Quartodoc configs were found."

--- a/tests/pytest/test_controller_documentation.py
+++ b/tests/pytest/test_controller_documentation.py
@@ -5,13 +5,13 @@ from pathlib import Path
 from typing import Set
 
 import pytest
-import yaml
+
+from ._quartodoc_utils import load_quartodoc_sections
 
 root = Path(__file__).parent.parent.parent
 
 CONTROLLER_DIR = root / "shiny/playwright/controller"
 DOCS_CONFIG = root / "docs/_quartodoc-testing.yml"
-QUARTODOC_CONFIGS = tuple(sorted((root / "docs").glob("_quartodoc-*.yml")))
 
 
 def get_controller_classes() -> Set[str]:
@@ -27,14 +27,9 @@ def get_controller_classes() -> Set[str]:
 
 
 def get_documented_controllers() -> Set[str]:
-    try:
-        config = yaml.safe_load(DOCS_CONFIG.read_text(encoding="utf-8"))
-    except Exception as e:
-        pytest.fail(f"Failed to load or parse {DOCS_CONFIG}: {e}")
-
     return {
         content.split(".")[-1]
-        for section in config.get("quartodoc", {}).get("sections", [])
+        for section in load_quartodoc_sections(DOCS_CONFIG)
         for content in section.get("contents", [])
         if isinstance(content, str) and content.startswith("playwright.controller.")
     }
@@ -67,47 +62,3 @@ def test_all_controllers_are_documented():
 
     assert controller_classes, "No controller classes were found."
     assert documented_controllers, "No documented controllers were found."
-
-
-def _quartodoc_content_name(content: object) -> str:
-    if isinstance(content, str):
-        return content
-    if isinstance(content, dict):
-        name = content.get("name") or content.get("path")
-        if isinstance(name, str):
-            return name
-        return yaml.safe_dump(content, sort_keys=True)
-    return repr(content)
-
-
-def test_quartodoc_configs_have_unique_contents():
-    error_messages: list[str] = []
-
-    for config_path in QUARTODOC_CONFIGS:
-        try:
-            config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
-        except Exception as e:
-            pytest.fail(f"Failed to load or parse {config_path}: {e}")
-
-        for section in config.get("quartodoc", {}).get("sections", []):
-            seen: set[str] = set()
-            duplicates: list[str] = []
-
-            for content in section.get("contents", []):
-                content_name = _quartodoc_content_name(content)
-                if content_name in seen:
-                    duplicates.append(content_name)
-                else:
-                    seen.add(content_name)
-
-            if duplicates:
-                duplicate_list = "\n".join(sorted(f"  - {x}" for x in duplicates))
-                error_messages.append(
-                    f"Duplicate contents in {config_path}, "
-                    f"section {section.get('title')!r}:\n{duplicate_list}"
-                )
-
-    if error_messages:
-        pytest.fail("\n\n".join(error_messages), pytrace=False)
-
-    assert QUARTODOC_CONFIGS, "No Quartodoc configs were found."

--- a/tests/pytest/test_controller_documentation.py
+++ b/tests/pytest/test_controller_documentation.py
@@ -6,7 +6,7 @@ from typing import Set
 
 import pytest
 
-from ._quartodoc_utils import load_quartodoc_sections
+from ._quartodoc_utils import load_quartodoc_sections, section_contents
 
 root = Path(__file__).parent.parent.parent
 
@@ -30,7 +30,7 @@ def get_documented_controllers() -> Set[str]:
     return {
         content.split(".")[-1]
         for section in load_quartodoc_sections(DOCS_CONFIG)
-        for content in section.get("contents") or []
+        for content in section_contents(section)
         if isinstance(content, str) and content.startswith("playwright.controller.")
     }
 

--- a/tests/pytest/test_quartodoc_configs.py
+++ b/tests/pytest/test_quartodoc_configs.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Iterator
 
 import pytest
 
@@ -19,26 +19,45 @@ def _quartodoc_content_name(content: str | dict[str, Any]) -> str:
     return str(content.get("name") or content["path"])
 
 
+def _iter_rendered_links(
+    contents: list[Any] | None, location: str
+) -> Iterator[tuple[str, str]]:
+    """
+    Yield `(name, location)` for every link a `contents` list renders.
+
+    `kind: page` groups render a link of their own and are then walked, because a
+    duplicate nested inside a group renders twice just like one at section level.
+    """
+    for content in contents or []:
+        name = _quartodoc_content_name(content)
+        yield name, location
+
+        nested = content.get("contents") if isinstance(content, dict) else None
+        if nested:
+            yield from _iter_rendered_links(nested, f"{location} > page {name!r}")
+
+
 def test_quartodoc_configs_have_unique_contents():
     error_messages: list[str] = []
 
     for config_path in QUARTODOC_CONFIGS:
         for section in load_quartodoc_sections(config_path):
+            section_location = f"section {section.get('title')!r}"
             seen: set[str] = set()
             duplicates: list[str] = []
 
-            for content in section.get("contents") or []:
-                content_name = _quartodoc_content_name(content)
-                if content_name in seen:
-                    duplicates.append(content_name)
+            for name, location in _iter_rendered_links(
+                section.get("contents"), section_location
+            ):
+                if name in seen:
+                    duplicates.append(f"{name} (in {location})")
                 else:
-                    seen.add(content_name)
+                    seen.add(name)
 
             if duplicates:
                 duplicate_list = "\n".join(sorted(f"  - {x}" for x in duplicates))
                 error_messages.append(
-                    f"Duplicate contents in {config_path}, "
-                    f"section {section.get('title')!r}:\n{duplicate_list}"
+                    f"Duplicate contents in {config_path}:\n{duplicate_list}"
                 )
 
     if error_messages:

--- a/tests/pytest/test_quartodoc_configs.py
+++ b/tests/pytest/test_quartodoc_configs.py
@@ -49,7 +49,6 @@ CROSS_SECTION_ALLOWLIST: dict[str, frozenset[str]] = {
     # "Uploads & downloads".
     "_quartodoc-express.yml": frozenset(
         {
-            "express.render.download",
             "express.render.download_button",
             "express.render.download_link",
         }

--- a/tests/pytest/test_quartodoc_configs.py
+++ b/tests/pytest/test_quartodoc_configs.py
@@ -25,7 +25,7 @@ def test_quartodoc_configs_have_unique_contents():
             seen: set[str] = set()
             duplicates: list[str] = []
 
-            for content in section.get("contents", []):
+            for content in section.get("contents") or []:
                 content_name = _quartodoc_content_name(content)
                 if content_name in seen:
                     duplicates.append(content_name)

--- a/tests/pytest/test_quartodoc_configs.py
+++ b/tests/pytest/test_quartodoc_configs.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Any, Iterator
+from typing import Iterator
 
 import pytest
 
-from ._quartodoc_utils import QUARTODOC_CONFIGS, load_quartodoc_sections
+from ._quartodoc_utils import (
+    QUARTODOC_CONFIGS,
+    QuartodocContent,
+    load_quartodoc_sections,
+    section_contents,
+)
 
 
-def _quartodoc_content_name(content: str | dict[str, Any]) -> str:
+def _quartodoc_content_name(content: QuartodocContent) -> str:
     """
     Return the symbol or page name a `contents` entry renders a link for.
 
@@ -21,7 +26,7 @@ def _quartodoc_content_name(content: str | dict[str, Any]) -> str:
 
 
 def _iter_rendered_links(
-    contents: list[Any] | None, location: str
+    contents: list[QuartodocContent], location: str
 ) -> Iterator[tuple[str, str]]:
     """
     Yield `(label, location)` for every link a `contents` list renders.
@@ -32,9 +37,11 @@ def _iter_rendered_links(
     different namespaces, and a page deliberately named after a class it extends
     (e.g. the `Session` page) is not a duplicate of that class.
     """
-    for content in contents or []:
+    for content in contents:
         name = _quartodoc_content_name(content)
-        nested = content.get("contents") if isinstance(content, dict) else None
+        nested: list[QuartodocContent] = (
+            content.get("contents") or [] if isinstance(content, dict) else []
+        )
 
         yield (f"page {name!r}" if nested else name), location
 
@@ -69,7 +76,7 @@ def test_quartodoc_configs_have_unique_contents():
         locations: dict[str, list[str]] = defaultdict(list)
         for section in load_quartodoc_sections(config_path):
             for name, location in _iter_rendered_links(
-                section.get("contents"), f"section {section.get('title')!r}"
+                section_contents(section), f"section {section.get('title')!r}"
             ):
                 locations[name].append(location)
 

--- a/tests/pytest/test_quartodoc_configs.py
+++ b/tests/pytest/test_quartodoc_configs.py
@@ -1,20 +1,22 @@
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
-import yaml
 
 from ._quartodoc_utils import QUARTODOC_CONFIGS, load_quartodoc_sections
 
 
-def _quartodoc_content_name(content: object) -> str:
+def _quartodoc_content_name(content: str | dict[str, Any]) -> str:
+    """
+    Return the symbol or page name a `contents` entry renders a link for.
+
+    A `contents` entry is either a bare symbol name or a mapping carrying a
+    `name` (a symbol with options) or a `path` (a `kind: page` group).
+    """
     if isinstance(content, str):
         return content
-    if isinstance(content, dict):
-        name = content.get("name") or content.get("path")
-        if isinstance(name, str):
-            return name
-        return yaml.safe_dump(content, sort_keys=True)
-    return repr(content)
+    return str(content.get("name") or content["path"])
 
 
 def test_quartodoc_configs_have_unique_contents():

--- a/tests/pytest/test_quartodoc_configs.py
+++ b/tests/pytest/test_quartodoc_configs.py
@@ -24,48 +24,77 @@ def _iter_rendered_links(
     contents: list[Any] | None, location: str
 ) -> Iterator[tuple[str, str]]:
     """
-    Yield `(name, location)` for every link a `contents` list renders.
+    Yield `(label, location)` for every link a `contents` list renders.
 
     `kind: page` groups render a link of their own and are then walked, because a
     duplicate nested inside a group renders twice just like one at section level.
+    A page `path` is labelled separately from a symbol `name`: the two live in
+    different namespaces, and a page deliberately named after a class it extends
+    (e.g. the `Session` page) is not a duplicate of that class.
     """
     for content in contents or []:
         name = _quartodoc_content_name(content)
-        yield name, location
-
         nested = content.get("contents") if isinstance(content, dict) else None
+
+        yield (f"page {name!r}" if nested else name), location
+
         if nested:
             yield from _iter_rendered_links(nested, f"{location} > page {name!r}")
+
+
+CROSS_SECTION_ALLOWLIST: dict[str, frozenset[str]] = {
+    # `shiny.express.ui` has no `download_button` / `download_link` counterpart
+    # to core's `ui.download_button` / `ui.download_link`, so the Express
+    # renderers are deliberately listed under both "Output components" and
+    # "Uploads & downloads".
+    "_quartodoc-express.yml": frozenset(
+        {
+            "express.render.download",
+            "express.render.download_button",
+            "express.render.download_link",
+        }
+    ),
+}
+"""Symbols intentionally listed under more than one section, keyed by config."""
 
 
 def test_quartodoc_configs_have_unique_contents():
     error_messages: list[str] = []
 
     for config_path in QUARTODOC_CONFIGS:
-        for section in load_quartodoc_sections(config_path):
-            section_location = f"section {section.get('title')!r}"
-            locations: dict[str, list[str]] = defaultdict(list)
+        allowed = CROSS_SECTION_ALLOWLIST.get(config_path.name, frozenset())
 
+        # Every section of a config renders onto one API reference page, so a
+        # symbol repeated across sections produces duplicate links just like one
+        # repeated within a section.
+        locations: dict[str, list[str]] = defaultdict(list)
+        for section in load_quartodoc_sections(config_path):
             for name, location in _iter_rendered_links(
-                section.get("contents"), section_location
+                section.get("contents"), f"section {section.get('title')!r}"
             ):
                 locations[name].append(location)
 
-            duplicates = {
-                name: where for name, where in locations.items() if len(where) > 1
-            }
+        duplicates: dict[str, list[str]] = {}
+        for name, where in locations.items():
+            if len(where) == 1:
+                continue
+            # An allow-listed symbol may appear in several sections, but still
+            # never twice within one section.
+            if name in allowed and len(set(where)) == len(where):
+                continue
+            duplicates[name] = where
 
-            if duplicates:
-                duplicate_list = "\n".join(
-                    sorted(
-                        f"  - {name} rendered {len(where)} times"
-                        f" (in {', '.join(dict.fromkeys(where))})"
-                        for name, where in duplicates.items()
-                    )
+        if duplicates:
+            duplicate_list = "\n".join(
+                sorted(
+                    f"  - {name} rendered {len(where)} times"
+                    f" (in {', '.join(dict.fromkeys(where))})"
+                    for name, where in duplicates.items()
                 )
-                error_messages.append(
-                    f"Duplicate contents in {config_path}:\n{duplicate_list}"
-                )
+            )
+            error_messages.append(
+                f"Duplicate contents in {config_path}:\n{duplicate_list}"
+            )
 
     if error_messages:
         pytest.fail("\n\n".join(error_messages), pytrace=False)

--- a/tests/pytest/test_quartodoc_configs.py
+++ b/tests/pytest/test_quartodoc_configs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from typing import Any, Iterator
 
 import pytest
@@ -43,19 +44,25 @@ def test_quartodoc_configs_have_unique_contents():
     for config_path in QUARTODOC_CONFIGS:
         for section in load_quartodoc_sections(config_path):
             section_location = f"section {section.get('title')!r}"
-            seen: set[str] = set()
-            duplicates: list[str] = []
+            locations: dict[str, list[str]] = defaultdict(list)
 
             for name, location in _iter_rendered_links(
                 section.get("contents"), section_location
             ):
-                if name in seen:
-                    duplicates.append(f"{name} (in {location})")
-                else:
-                    seen.add(name)
+                locations[name].append(location)
+
+            duplicates = {
+                name: where for name, where in locations.items() if len(where) > 1
+            }
 
             if duplicates:
-                duplicate_list = "\n".join(sorted(f"  - {x}" for x in duplicates))
+                duplicate_list = "\n".join(
+                    sorted(
+                        f"  - {name} rendered {len(where)} times"
+                        f" (in {', '.join(dict.fromkeys(where))})"
+                        for name, where in duplicates.items()
+                    )
+                )
                 error_messages.append(
                     f"Duplicate contents in {config_path}:\n{duplicate_list}"
                 )

--- a/tests/pytest/test_quartodoc_configs.py
+++ b/tests/pytest/test_quartodoc_configs.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from ._quartodoc_utils import QUARTODOC_CONFIGS, load_quartodoc_sections
+
+
+def _quartodoc_content_name(content: object) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, dict):
+        name = content.get("name") or content.get("path")
+        if isinstance(name, str):
+            return name
+        return yaml.safe_dump(content, sort_keys=True)
+    return repr(content)
+
+
+def test_quartodoc_configs_have_unique_contents():
+    error_messages: list[str] = []
+
+    for config_path in QUARTODOC_CONFIGS:
+        for section in load_quartodoc_sections(config_path):
+            seen: set[str] = set()
+            duplicates: list[str] = []
+
+            for content in section.get("contents", []):
+                content_name = _quartodoc_content_name(content)
+                if content_name in seen:
+                    duplicates.append(content_name)
+                else:
+                    seen.add(content_name)
+
+            if duplicates:
+                duplicate_list = "\n".join(sorted(f"  - {x}" for x in duplicates))
+                error_messages.append(
+                    f"Duplicate contents in {config_path}, "
+                    f"section {section.get('title')!r}:\n{duplicate_list}"
+                )
+
+    if error_messages:
+        pytest.fail("\n\n".join(error_messages), pytrace=False)
+
+    assert QUARTODOC_CONFIGS, "No Quartodoc configs were found."


### PR DESCRIPTION
Fixes #2397.

The generated core API reference page is driven by `docs/_quartodoc-core.yml`. In the `Page containers` section, `ui.page_sidebar` appeared twice in the `contents` array. Quartodoc renders each `contents` entry as a link/card, so the duplicate YAML item produced the duplicate `page_sidebar` link on `https://shiny.posit.co/py/api/core/#page-containers`.

This removes the second `ui.page_sidebar` entry and adds a small pytest regression check that loads the Quartodoc YAML configs and fails when any section contains duplicate `contents` entries, catching this class of docs navigation typo without building the full site.

`ruff check docs/_quartodoc-core.yml tests/pytest/test_controller_documentation.py` reports no new findings on the changed files.
Ran `pytest -x` locally with no new failures.
