### PR TITLE
fix(render): Honor `@output(id=)` for download renderers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
-* The `ui.Theme` API reference examples now run in Shinylive. Compiling a customized theme requires `libsass`, but Shinylive only auto-loads packages it finds in an app's top-level imports and `Theme.to_css()` imports `sass` lazily, so the examples died with an `ImportError`. The example directory now declares `libsass` in a `requirements.txt`. (#2386)
+* The `ui.Theme` API reference examples now run in Shinylive. Compiling a customized theme requires `libsass`, but Shinylive only auto-loads packages it finds in an app's top-level imports and `Theme.to_css()` imports `sass` lazily, so the examples died with an `ImportError`. The example directory now declares `libsass` in a `requirements.txt`. (#2387)
 
-* Fixed the error message raised when a package required for theme compilation is missing: it interpolated the package name into the first sentence but printed a literal `pip install {pkg}` in the second. (#2386)
+* Fixed the error message raised when a package required for theme compilation is missing: it interpolated the package name into the first sentence but printed a literal `pip install {pkg}` in the second. (#2387)
 
 * Download renderers (`@render.download_button`, `@render.download_link`, and the deprecated `@render.download`) now honor `@output(id=)`. The download handler was registered under the decorated function's name, but the URL rendered by the control used the `@output(id=)` value, so clicking the control returned a 404. (#2415)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Fixed the error message raised when a package required for theme compilation is missing: it interpolated the package name into the first sentence but printed a literal `pip install {pkg}` in the second. (#2386)
 
+* Download renderers (`@render.download_button`, `@render.download_link`, and the deprecated `@render.download`) now honor `@output(id=)`. The download handler was registered under the decorated function's name, but the URL rendered by the control used the `@output(id=)` value, so clicking the control returned a 404. (#2415)
+
 * `ui.input_task_button(type=None)` no longer drops the `bslib-task-button` class. Operator precedence made the `type is not None` check apply to the whole class string rather than just the Bootstrap classes, so the button rendered with `class=""`; since that class is the selector Shiny's input binding uses, the button was never bound as an input and clicking it did nothing. (#2388)
 
 ## [1.7.0] - 2026-07-28

--- a/shiny/render/_render.py
+++ b/shiny/render/_render.py
@@ -20,7 +20,7 @@ from .. import ui as _ui
 from .._docstring import add_example
 from .._typing_extensions import Self
 from ..module import ResolvedId
-from ..session import get_current_session, require_active_session
+from ..session import require_active_session
 from ..session._session import DownloadHandler, DownloadInfo
 from ..types import MISSING, MISSING_TYPE, ImgData
 from ._try_render_plot import (
@@ -607,6 +607,9 @@ class _DownloadBase(Renderer[str]):
     control (`download_button` vs `download_link`) they auto-place in Express.
     """
 
+    _download_handler: DownloadHandler
+    """App-supplied function that produces the download's contents."""
+
     def __init__(
         self,
         fn: Optional[DownloadHandler] = None,
@@ -659,26 +662,48 @@ class _DownloadBase(Renderer[str]):
         # name from the user-supplied function.
         url.__name__ = fn.__name__
 
+        # Keep the download handler around; it is registered with the session in
+        # `._set_output_metadata()`, once the final `output_id` is known.
+        self._download_handler = fn
+
         # We invoke `super().__call__()` now, because it indirectly invokes
-        # `Outputs.__call__()`, which sets `output_id` (and `self.__name__`), which is
-        # then used below.
+        # `Outputs.__call__()`, which sets `output_id` (and `self.__name__`).
         super().__call__(url)
 
-        # Register the download handler for the session. The reason we check for session
-        # not being None or a stub session is because in Express, when the UI is
-        # rendered, this function is called once before any sessions have been started.
-        session = get_current_session()
-        if session is not None and not session.is_stub_session():
-            # All download objects are stored in the root session.
-            # They must be fully namespaced
-            session._downloads[session.ns(self.output_id)] = DownloadInfo(
-                filename=self.filename,
-                content_type=self.media_type,
-                handler=fn,
-                encoding=self.encoding,
-            )
-
         return self
+
+    def _set_output_metadata(self, *, output_id: str) -> None:
+        # Always set by `Renderer.__call__()` before it can auto-register the output.
+        prev_output_id = self.output_id
+        super()._set_output_metadata(output_id=output_id)
+
+        # The download handler is registered here rather than in `.__call__()` because
+        # `output_id` is not final until now, and the URL produced by `url()` above uses
+        # whatever `output_id` ends up being.
+        #
+        # With `@output(id=)`, this method runs twice: once for the auto-registration
+        # inside `.__call__()` (under the value function's name), then again with the
+        # explicit id. Drop the first registration so that the download isn't also
+        # served under a name the app never declared.
+        #
+        # The reason we check for session not being None or a stub session is because in
+        # Express, when the UI is rendered, this method is called once before any
+        # sessions have been started.
+        session = self._session
+        if session is None or session.is_stub_session():
+            return
+
+        if prev_output_id != output_id:
+            session._downloads.pop(session.ns(prev_output_id), None)
+
+        # All download objects are stored in the root session.
+        # They must be fully namespaced
+        session._downloads[session.ns(output_id)] = DownloadInfo(
+            filename=self.filename,
+            content_type=self.media_type,
+            handler=self._download_handler,
+            encoding=self.encoding,
+        )
 
     async def transform(self, value: str) -> Jsonifiable:
         return value

--- a/tests/playwright/shiny/components/download_button/app.py
+++ b/tests/playwright/shiny/components/download_button/app.py
@@ -23,6 +23,10 @@ app_ui = ui.page_fluid(
                 icon=faicons.icon_svg("file-csv"),
                 width="560px",
             ),
+            ui.download_button(
+                "explicit_id_csv",
+                "Explicit ID CSV",
+            ),
         ),
     ),
 )
@@ -59,6 +63,13 @@ def server(input: Inputs, output: Outputs, session: Session) -> None:
         yield "metric,value\n"
         yield f"inventory,{current_inventory}\n"
         yield f"download_number,{current_styled}\n"
+
+    # The download id comes from `@output(id=)` rather than the function name
+    @output(id="explicit_id_csv")
+    @render.download_button(filename="explicit-id.csv")
+    async def _():
+        yield "kind,inventory\n"
+        yield f"explicit,{inventory_total}\n"
 
 
 app = App(app_ui, server)

--- a/tests/playwright/shiny/components/download_button/test_download_button_kitchensink.py
+++ b/tests/playwright/shiny/components/download_button/test_download_button_kitchensink.py
@@ -47,3 +47,15 @@ def test_download_button_kitchensink(
     plain_path_2 = tmp_path / plain_download_2.suggested_filename
     plain_download_2.save_as(plain_path_2)
     assert plain_path_2.read_text() == "kind,inventory,count\nplain,2,2\n"
+
+    # A download whose id comes from `@output(id=)` resolves (used to 404)
+    explicit_id_button = controller.DownloadButton(page, "explicit_id_csv")
+    explicit_id_button.expect_label("Explicit ID CSV")
+
+    with page.expect_download() as explicit_id_info:
+        explicit_id_button.click()
+    explicit_id_download = explicit_id_info.value
+    assert explicit_id_download.suggested_filename == "explicit-id.csv"
+    explicit_id_path = tmp_path / explicit_id_download.suggested_filename
+    explicit_id_download.save_as(explicit_id_path)
+    assert explicit_id_path.read_text() == "kind,inventory\nexplicit,2\n"

--- a/tests/pytest/test_render_download.py
+++ b/tests/pytest/test_render_download.py
@@ -1,0 +1,60 @@
+"""Tests for the download renderers' handler registration."""
+
+from __future__ import annotations
+
+from typing import AsyncIterable
+
+from shiny import App, Inputs, Outputs, Session, module, render, ui
+from shiny._connection import MockConnection
+from shiny.session import session_context
+
+
+def _new_session() -> Session:
+    return App(ui.TagList(), None)._create_session(MockConnection())
+
+
+def test_download_registers_under_function_name():
+    session = _new_session()
+
+    with session_context(session):
+
+        @render.download_button(filename="file.txt")
+        async def my_download() -> AsyncIterable[str]:
+            yield "hello"
+
+    assert list(session._downloads.keys()) == ["my_download"]
+
+
+def test_download_registers_under_output_id():
+    """`@output(id=)` renames the download control; the handler must follow."""
+    session = _new_session()
+
+    with session_context(session):
+
+        @session.output(id="download4")
+        @render.download_button(filename="file.txt")
+        async def _() -> AsyncIterable[str]:
+            yield "hello"
+
+    # Exact equality matters: the renderer auto-registers under the value function's
+    # name (`_`) before `@output(id=)` re-registers it, so a lingering `_` key would
+    # mean the download is also served under a name the app never declared.
+    assert list(session._downloads.keys()) == ["download4"]
+
+
+def test_download_registers_under_namespaced_output_id():
+    session = _new_session()
+
+    @module.server
+    def mod_server(input: Inputs, output: Outputs, session: Session):
+        @output(id="download4")
+        @render.download_button(filename="file.txt")
+        async def _() -> AsyncIterable[str]:
+            yield "hello"
+
+    with session_context(session):
+        mod_server("mod1")
+
+    # Downloads are always stored fully namespaced in the root session, and the
+    # auto-registered `mod1-_` entry must not survive the rename.
+    assert list(session._downloads.keys()) == ["mod1-download4"]


### PR DESCRIPTION
Fixes #2399.

## Problem

```python
@output(id="download4")
@render.download_button(filename="failuretest.txt")
async def _():
    yield "hello"
```

Clicking the button 404s:

```
"GET /session/xxxxxxxxx/download/download4?w= HTTP/1.1" 404 Not Found
```

## Root cause

`_DownloadBase.__call__()` registered the handler in `session._downloads` under `session.ns(self.output_id)` at decoration time — and at that point `output_id` is still the decorated function's `__name__` (`_` here). The value function `url()`, by contrast, reads `self.output_id` *lazily* at render time. So once `@output(id="download4")` ran and called `Renderer._set_output_metadata(output_id="download4")`, the button rendered `…/download/download4?w=` while the handler was still keyed under `_`, and the lookup in `AppSession._handle_request()` missed.

## Fix

Defer registration until `output_id` is final. `__call__()` now just stashes the app-supplied handler on the renderer, and `_DownloadBase._set_output_metadata()` does the `session._downloads` registration (dropping the previous entry if the id changed).

`_set_output_metadata()` is the single funnel for this: `Outputs.__call__()` is its only caller, and a renderer reaches a real session exclusively through `Renderer._auto_register()` → `session.output(self)` (Core auto-registration, Express) or an explicit `@output(...)`. Whenever `self._session` is non-`None`, `_set_output_metadata()` has run. Stub sessions (the Express UI-render phase) are skipped as before.

Covers `@render.download_button`, `@render.download_link`, and the deprecated `@render.download` (a subclass), including inside modules.

## Tests

- `tests/pytest/test_render_download.py` (new): function-name registration, `@output(id=)`, and `@output(id=)` inside a module (expects `mod1-download4`). The latter two fail on `main`.
- Extended the download-button kitchen sink app/test with an `@output(id="explicit_id_csv")` button that actually downloads its contents — end-to-end proof the 404 is gone. Verified it fails with the fix reverted.
- Also re-ran the download-link kitchen sink, the `0696-resolve-id` module test (module-namespaced downloads), and an ad-hoc Express download app to confirm the deferred registration doesn't regress those paths.

`uv run make format check-lint check-types check-pyright` is clean; full `tests/pytest` suite passes.