### PR TITLE
docs: Reference ui.js_eval() in input_selectize options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `ui.input_task_button(type=None)` no longer drops the `bslib-task-button` class. Operator precedence made the `type is not None` check apply to the whole class string rather than just the Bootstrap classes, so the button rendered with `class=""`; since that class is the selector Shiny's input binding uses, the button was never bound as an input and clicking it did nothing. (#2388)
 
+* `ui.input_selectize()`'s `options` docstring now points at `ui.js_eval()` for marking a string as a JavaScript function. It referred to `ui.JS`, which has never existed. (#XXXX)
+
 ## [1.7.0] - 2026-07-28
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `ui.input_task_button(type=None)` no longer drops the `bslib-task-button` class. Operator precedence made the `type is not None` check apply to the whole class string rather than just the Bootstrap classes, so the button rendered with `class=""`; since that class is the selector Shiny's input binding uses, the button was never bound as an input and clicking it did nothing. (#2388)
 
-* `ui.input_selectize()`'s `options` docstring now points at `ui.js_eval()` for marking a string as a JavaScript function. It referred to `ui.JS`, which has never existed. (#2416)
+* `ui.input_selectize()`'s `options` docstring now correctly points at `ui.js_eval()` for marking a string as a JavaScript function. (#2416)
 
 ## [1.7.0] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `ui.input_task_button(type=None)` no longer drops the `bslib-task-button` class. Operator precedence made the `type is not None` check apply to the whole class string rather than just the Bootstrap classes, so the button rendered with `class=""`; since that class is the selector Shiny's input binding uses, the button was never bound as an input and clicking it did nothing. (#2388)
 
-* `ui.input_selectize()`'s `options` docstring now points at `ui.js_eval()` for marking a string as a JavaScript function. It referred to `ui.JS`, which has never existed. (#XXXX)
+* `ui.input_selectize()`'s `options` docstring now points at `ui.js_eval()` for marking a string as a JavaScript function. It referred to `ui.JS`, which has never existed. (#2416)
 
 ## [1.7.0] - 2026-07-28
 

--- a/shiny/ui/_input_select.py
+++ b/shiny/ui/_input_select.py
@@ -88,7 +88,8 @@ def input_selectize(
         remove button to multiple selections, but not single selections.
     options
         A dictionary of options. See the documentation of selectize.js for possible options.
-        If you want to pass a JavaScript function, wrap the string in `ui.JS`.
+        If you want to pass a JavaScript function, wrap the string in
+        :func:`~shiny.ui.js_eval`.
 
     Returns
     -------


### PR DESCRIPTION
Fixes #2106

## Problem

`ui.input_selectize()`'s `options` parameter docstring said:

> If you want to pass a JavaScript function, wrap the string in `ui.JS`.

`ui.JS` does not exist. The public helper is `ui.js_eval()` (defined in `shiny/ui/_utils.py`, exported from both `shiny.ui` and `shiny.express.ui`), which returns a `JSEval` string subclass.

This is not a stale name after a rename: `git log -S` shows the docstring text and `js_eval()` were both introduced in the same commit (9f0e753, "feat: Pass options to input_selectize", #745), so the docstring never matched the API.

## Change

- `shiny/ui/_input_select.py`: point the docstring at `:func:`~shiny.ui.js_eval``, using the repo's Sphinx cross-reference role convention instead of a plain backtick literal.
- `CHANGELOG.md`: bug-fix entry under `## [Unreleased]`, following the precedent of the `value_box()` `id` docstring fix in 1.7.0.

Repo-wide grep confirms this was the only stale `ui.JS` reference — the api examples (`shiny/api-examples/input_selectize/app-{core,express}.py`), the Playwright test app, and the unit tests all already use `js_eval`, and the bundled Agent Skills under `shiny/.agents/skills/` don't mention it at all.

## Verification

`uv run --extra dev --extra test make format check-lint check-types` passes (black: 1188 files unchanged; isort clean; flake8 clean; pyrefly 0 errors). Docs-only change, no executable code touched.

