### PR TITLE
chore: Quote $(MAKE) in recursive make invocations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ update-testing-docs: docs update-testing-docs-repomix update-testing-docs-proces
 
 ci-install-ai-deps: FORCE
 	uv pip install -e ".[dev,test,add-test]"
-	$(MAKE) install-playwright
+	"$(MAKE)" install-playwright
 
 run-test-ai-evaluation: FORCE ## Run the AI evaluation script for tests
 	@echo "-------- Running AI evaluation for tests --------"
@@ -253,19 +253,19 @@ playwright-show-trace: ## Show trace of failed tests
 
 # end-to-end tests with playwright; (SUB_FILE="" within tests/playwright/shiny/)
 playwright-shiny: FORCE
-	$(MAKE) playwright TEST_FILE="$(SHINY_TEST_FILE)"
+	"$(MAKE)" playwright TEST_FILE="$(SHINY_TEST_FILE)"
 
 # end-to-end tests on deployed apps with playwright; (SUB_FILE="" within tests/playwright/deploys/)
 playwright-deploys: FORCE
-	$(MAKE) playwright PYTEST_BROWSERS="$(PYTEST_DEPLOYS_BROWSERS)" TEST_FILE="$(DEPLOYS_TEST_FILE)"
+	"$(MAKE)" playwright PYTEST_BROWSERS="$(PYTEST_DEPLOYS_BROWSERS)" TEST_FILE="$(DEPLOYS_TEST_FILE)"
 
 # end-to-end tests on all py-shiny examples with playwright; (SUB_FILE="" within tests/playwright/examples/)
 playwright-examples: FORCE
-	$(MAKE) playwright TEST_FILE="$(EXAMPLES_TEST_FILE)"
+	"$(MAKE)" playwright TEST_FILE="$(EXAMPLES_TEST_FILE)"
 
 # end-to-end tests for all AI generated apps
 playwright-ai: FORCE
-	$(MAKE) playwright TEST_FILE="$(AI_TEST_FILE)"
+	"$(MAKE)" playwright TEST_FILE="$(AI_TEST_FILE)"
 
 coverage: FORCE ## check combined code coverage (must run e2e last)
 	pytest --cov-report term-missing --cov=shiny tests/pytest/ $(SHINY_TEST_FILE) $(PYTEST_BROWSERS)
@@ -337,10 +337,10 @@ upgrade-html-deps: FORCE ## Upgrade Shiny's HTMLDependencies
 
 narwhals-install-shiny: FORCE
 	@echo "-------- Install py-shiny ----------"
-	$(MAKE) ci-install-deps
-	$(MAKE) install-playwright PLAYWRIGHT_BROWSERS=chromium
+	"$(MAKE)" ci-install-deps
+	"$(MAKE)" install-playwright PLAYWRIGHT_BROWSERS=chromium
 narwhals-test-integration: FORCE
 	@echo "-------- Running py-shiny typing and unit tests ----------"
-	$(MAKE) check-types check-tests
+	"$(MAKE)" check-types check-tests
 	@echo "-------- Running py-shiny playwright tests ----------"
-	$(MAKE) playwright TEST_FILE="tests/playwright/shiny/components/data_frame/data_type/" PYTEST_BROWSERS="--browser chromium"
+	"$(MAKE)" playwright TEST_FILE="tests/playwright/shiny/components/data_frame/data_type/" PYTEST_BROWSERS="--browser chromium"


### PR DESCRIPTION
Fixes #1946

## The bug

`$(MAKE)` expands to the path `make` was invoked with. When that path contains spaces, an unquoted `$(MAKE) ...` recipe line is word-split by the shell and the recursion dies before the sub-make starts:

```
$ make MAKE=".../Program Files (x86)/bin/make" playwright-shiny
/bin/sh: -c: line 0: syntax error near unexpected token `('
make: *** [playwright-shiny] Error 2
```

Quoting fixes it. I verified this manually with a real (non-dry-run) recursion through a wrapper `make` at such a path that reproduces the failure on `main` and shows it fixed with the quoting change.

## The change

All **9** recursive invocations are now `"$(MAKE)"` — in `ci-install-ai-deps`, `playwright-shiny`, `playwright-deploys`, `playwright-examples`, `playwright-ai`, `narwhals-install-shiny` (×2), `narwhals-test-integration` (×2). No target was added, removed, or restructured.

Quoting is safe here: the literal `$(MAKE)` reference is preserved, so make still propagates `-n`/`-t`/`-q` and the jobserver (`MAKE` holds only the program path — flags travel in `MAKEFLAGS`).

## Should other path variables be quoted too?

**No, quoting `$(TEST_FILE)` would break CI.** Despite the name it is not a single path but a bag of whitespace-separated pytest arguments:

- `.github/workflows/pytest.yaml:242` — `SUB_FILE=". --numprocesses 3 --num-shards 4 --shard-id N"`
- `.github/workflows/deploy-tests.yaml:101` — `TEST_FILE="<base_test_dir> -vv"`
- `tests/playwright/README.md:31` — `SUB_FILE="--headed e2e/async"`

Quoting would collapse each into a single argument. Same reasoning leaves `$(SHINY_TEST_FILE)`, `$(PYTEST_BROWSERS)`, `$(PLAYWRIGHT_BROWSERS)`, `$(PLAYWRIGHT_VERBOSE)` (also empty outside CI, where `""` would pass a bogus empty arg), `$(BROWSER)` (an entire `python -c` command) and `$(MAKEFILE_LIST)` unquoted. `$(SUB_FILE)` never reaches a shell directly.

So the rule is now consistent: single paths are quoted, argument lists are not. A checkout path with spaces would still trip the test-path variables, but that needs the path and the arg list split into separate variables — a larger change than quoting.

Also left alone: `docs`, `docs-preview`, `docs-quartodoc` use a literal `make` in `cd docs && make ...`. Those resolve via `PATH` so they don't have this bug, and switching them to `$(MAKE)` would change flag propagation.

## Verification

- Spaces-in-path recursion fails before / succeeds after, using a wrapper `make` at `.../Program Files (x86)/bin/make`.
- `make -n` on the 7 touched targets — expansions unchanged apart from the quotes.
- CI-style multi-argument `SUB_FILE`/`TEST_FILE` still word-split correctly.
- `uv run make check-lint` passes, confirming the repo's own checks still run through the `Makefile`.
- The Playwright suite itself was **not** run (slow); those targets were only dry-run.

No `CHANGELOG.md` entry — dev-only build tooling, matching precedent (#2363, #2334, #2303, #2301, #2218, #2203, #2082, #2067 all touch the `Makefile` without one).
