### PR TITLE
docs: Register input_bookmark_button in the Express API reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `ui.input_task_button(type=None)` no longer drops the `bslib-task-button` class. Operator precedence made the `type is not None` check apply to the whole class string rather than just the Bootstrap classes, so the button rendered with `class=""`; since that class is the selector Shiny's input binding uses, the button was never bound as an input and clicking it did nothing. (#2388)
 
-* `ui.input_bookmark_button()` now appears in the Express API reference. It was the only `ui.input_*` function missing from `docs/_quartodoc-express.yml`, so its Express docs page was never generated even though `shiny.express.ui.input_bookmark_button()` is supported. Its docstring also carried a Shiny for R leftover (`[input_action_button()]`), which is now a working cross-reference. (#2418)
+* `ui.input_bookmark_button()` was added to the Express API reference. (#2418)
 
 ## [1.7.0] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `ui.input_task_button(type=None)` no longer drops the `bslib-task-button` class. Operator precedence made the `type is not None` check apply to the whole class string rather than just the Bootstrap classes, so the button rendered with `class=""`; since that class is the selector Shiny's input binding uses, the button was never bound as an input and clicking it did nothing. (#2388)
 
+* `ui.input_bookmark_button()` now appears in the Express API reference. It was the only `ui.input_*` function missing from `docs/_quartodoc-express.yml`, so its Express docs page was never generated even though `shiny.express.ui.input_bookmark_button()` is supported. Its docstring also carried a Shiny for R leftover (`[input_action_button()]`), which is now a working cross-reference. (#2418)
+
 ## [1.7.0] - 2026-07-28
 
 ### New features

--- a/docs/_quartodoc-express.yml
+++ b/docs/_quartodoc-express.yml
@@ -195,6 +195,19 @@ quartodoc:
       desc: Saving and restoring app state
       contents:
         - express.ui.input_bookmark_button
+        - bookmark.restore_input
+        - bookmark.Bookmark
+        - bookmark.BookmarkState
+        - bookmark.RestoreState
+        - kind: page
+          path: bookmark_integration
+          summary:
+            name: "Integration"
+            desc: "Decorators to set save and restore directories."
+          flatten: true
+          contents:
+            - bookmark.set_global_save_dir_fn
+            - bookmark.set_global_restore_dir_fn
     - title: Dynamic UI
       desc: Dynamically show/hide UI elements.
       contents:

--- a/docs/_quartodoc-express.yml
+++ b/docs/_quartodoc-express.yml
@@ -94,6 +94,23 @@ quartodoc:
         - express.ui.insert_nav_panel
         - express.ui.remove_nav_panel
         - express.ui.update_nav_panel
+    - title: Bookmarking
+      desc: Saving and restoring app state
+      contents:
+        - express.ui.input_bookmark_button
+        - bookmark.restore_input
+        - bookmark.Bookmark
+        - bookmark.BookmarkState
+        - bookmark.RestoreState
+        - kind: page
+          path: bookmark_integration
+          summary:
+            name: "Integration"
+            desc: "Decorators to set save and restore directories."
+          flatten: true
+          contents:
+            - bookmark.set_global_save_dir_fn
+            - bookmark.set_global_restore_dir_fn
     - title: Chat interface
       desc: Build a chatbot interface
       contents:
@@ -191,23 +208,6 @@ quartodoc:
         - express.ui.input_file
         - express.render.download_button
         - express.render.download_link
-    - title: Bookmarking
-      desc: Saving and restoring app state
-      contents:
-        - express.ui.input_bookmark_button
-        - bookmark.restore_input
-        - bookmark.Bookmark
-        - bookmark.BookmarkState
-        - bookmark.RestoreState
-        - kind: page
-          path: bookmark_integration
-          summary:
-            name: "Integration"
-            desc: "Decorators to set save and restore directories."
-          flatten: true
-          contents:
-            - bookmark.set_global_save_dir_fn
-            - bookmark.set_global_restore_dir_fn
     - title: Dynamic UI
       desc: Dynamically show/hide UI elements.
       contents:

--- a/docs/_quartodoc-express.yml
+++ b/docs/_quartodoc-express.yml
@@ -191,6 +191,10 @@ quartodoc:
         - express.ui.input_file
         - express.render.download_button
         - express.render.download_link
+    - title: Bookmarking
+      desc: Saving and restoring app state
+      contents:
+        - express.ui.input_bookmark_button
     - title: Dynamic UI
       desc: Dynamically show/hide UI elements.
       contents:

--- a/shiny/bookmark/_bookmark.py
+++ b/shiny/bookmark/_bookmark.py
@@ -30,6 +30,21 @@ else:
 
 
 class Bookmark(ABC):
+    """
+    A session's bookmarking interface.
+
+    Every session exposes one of these as `session.bookmark`. It controls whether
+    bookmarking is enabled (`store`), which inputs are left out of a bookmark
+    (`exclude`), and when state is saved and restored (the `on_bookmark`,
+    `on_bookmarked`, `on_restore` and `on_restored` callback registrations).
+
+    Calling the object (`await session.bookmark()`) is equivalent to
+    `do_bookmark()`: it saves the current state and, depending on `store`, updates
+    the query string or shows a modal containing the bookmark URL.
+
+    App authors do not construct this class directly. Shiny creates the appropriate
+    subclass for the session.
+    """
 
     _on_get_exclude: list[Callable[[], list[str]]]
     """Callbacks that BookmarkProxy classes utilize to help determine the list of inputs to exclude from bookmarking."""
@@ -70,7 +85,7 @@ class Bookmark(ABC):
         Possible values:
         * `"url"`: Save / reload the bookmark state in the URL.
         * `"server"`: Save / reload the bookmark state on the server.
-        * `"disable"` (default): Bookmarking is diabled.
+        * `"disable"` (default): Bookmarking is disabled.
         """
         ...
 
@@ -114,7 +129,7 @@ class Bookmark(ABC):
         callback
             The callback function to call when the session is bookmarked.
             This method should accept a single argument, which is a
-            :class:`~shiny.bookmark._bookmark.ShinySaveState` object.
+            :class:`~shiny.bookmark.BookmarkState` object.
         """
         return self._on_bookmark_callbacks.register(wrap_async(callback))
 

--- a/shiny/bookmark/_bookmark.py
+++ b/shiny/bookmark/_bookmark.py
@@ -39,7 +39,7 @@ class Bookmark(ABC):
     `on_bookmarked`, `on_restore` and `on_restored` callback registrations).
 
     Calling the object (`await session.bookmark()`) is equivalent to
-    `do_bookmark()`: it saves the current state and, depending on `store`, updates
+    `await session.bookmark.do_bookmark()`: it saves the current state and, depending on `store`, updates
     the query string or shows a modal containing the bookmark URL.
 
     App authors do not construct this class directly. Shiny creates the appropriate

--- a/shiny/bookmark/_button.py
+++ b/shiny/bookmark/_button.py
@@ -26,7 +26,9 @@ def input_bookmark_button(
     """
     Button for bookmarking/sharing.
 
-    A `bookmarkButton` is a [input_action_button()] with a default label that consists of a link icon and the text "Bookmark...". It is meant to be used for bookmarking state.
+    A bookmark button is an :func:`~shiny.ui.input_action_button` with a default label
+    that consists of a link icon and the text ``"Bookmark..."``. It is meant to be used
+    for bookmarking state.
 
     Parameters
     ----------

--- a/shiny/bookmark/_restore_state.py
+++ b/shiny/bookmark/_restore_state.py
@@ -28,7 +28,7 @@ class RestoreState:
     `session.bookmark.on_restore()` callback. Within a module, the state is scoped to
     that module, so names are unprefixed.
 
-    Input values are usually restored for you — :func:`~shiny.bookmark.restore_input`
+    Input values are restored using :func:`~shiny.bookmark.restore_input` which
     reads from the active restore context — so this class is mainly of interest for
     reading back `values` or files written during saving.
 

--- a/shiny/bookmark/_restore_state.py
+++ b/shiny/bookmark/_restore_state.py
@@ -21,9 +21,38 @@ _logger = logging.getLogger(__name__)
 
 
 class RestoreState:
+    """
+    The state read back when a session is restored from a bookmark.
+
+    Shiny creates one of these while a bookmarked session starts up and passes it to any
+    `session.bookmark.on_restore()` callback. Within a module, the state is scoped to
+    that module, so names are unprefixed.
+
+    Input values are usually restored for you — :func:`~shiny.bookmark.restore_input`
+    reads from the active restore context — so this class is mainly of interest for
+    reading back `values` or files written during saving.
+
+    App authors do not construct this class directly.
+    """
+
     input: dict[str, Any]
+    """The saved input values, keyed by input name."""
+
     values: dict[str, Any]
+    """
+    The extra values recorded during saving.
+
+    Whatever an `on_bookmark()` callback put into
+    `BookmarkState.values` appears here.
+    """
+
     dir: Path | None
+    """
+    Directory holding the files saved with this bookmark, or `None`.
+
+    Set only for bookmarks saved server-side (`store="server"`); it is `None` for
+    `store="url"` bookmarks, which keep their state in the query string.
+    """
 
     def __init__(
         self,

--- a/shiny/bookmark/_save_state.py
+++ b/shiny/bookmark/_save_state.py
@@ -20,9 +20,9 @@ class BookmarkState:
     """
     The state being written while a bookmark is saved.
 
-    Shiny creates one of these each time a bookmark is taken and passes it to any
-    `session.bookmark.on_bookmark()` callback, which may add entries to
-    `values` or write files into `dir` before the state is persisted.
+    Shiny creates a `BookmarkState` instance each time a bookmark is taken and passes the instance to every
+    `session.bookmark.on_bookmark()` callback. The registered callbacks may add entries to
+    the state's `values` or write files into `dir` (if available) before the state is persisted.
 
     App authors do not construct this class directly.
     """

--- a/shiny/bookmark/_save_state.py
+++ b/shiny/bookmark/_save_state.py
@@ -17,12 +17,33 @@ if TYPE_CHECKING:
 
 
 class BookmarkState:
+    """
+    The state being written while a bookmark is saved.
+
+    Shiny creates one of these each time a bookmark is taken and passes it to any
+    `session.bookmark.on_bookmark()` callback, which may add entries to
+    `values` or write files into `dir` before the state is persisted.
+
+    App authors do not construct this class directly.
+    """
+
     # session: ?
     # * Would get us access to inputs, possibly app dir, registered on save / load classes (?), exclude
     #
     input: Inputs
+    """The session's inputs. Every value except those named in `exclude` is saved."""
+
     values: dict[str, Any]
+    """
+    Arbitrary extra values to save alongside the inputs.
+
+    Starts empty. Add to it from an `on_bookmark()` callback to store state that is
+    not held in an input, and read it back from
+    `RestoreState.values` when restoring.
+    """
+
     exclude: list[str]
+    """Scoped input names to leave out of the bookmark."""
 
     _on_save: (
         Callable[["BookmarkState"], Awaitable[None]] | None
@@ -31,6 +52,14 @@ class BookmarkState:
     # These are set not in initialize(), but by external functions that modify
     # the ShinySaveState object.
     dir: Path | None
+    """
+    Directory to write bookmark files into, or `None`.
+
+    Only set when the bookmark is saved server-side (`store="server"`), in which case
+    Shiny creates the directory and sets this before invoking `on_bookmark()`. It stays
+    `None` for `store="url"`, which encodes the state into a query string and never
+    touches disk.
+    """
 
     def __init__(
         self,


### PR DESCRIPTION
Fixes #2034: `[Bug]: input_bookmark_button documentation not available for core or express syntax`

## Current state of the bug

The core docs (`docs/_quartodoc-core.yml`) already had `ui.input_bookmark_button` (added by #1870), but the express docs (`docs/_quartodoc-express.yml`) are missing it. It is the *only* `input_*` symbol exported from `shiny.express.ui` with no Express config entry, and the only `ui.input_*` present in core but absent from Express.

Documenting `dir` turned up a behavioural detail worth stating in the docs: it is populated only for `store="server"`. The `"url"` store encodes state into the query string and never touches disk, so `dir` stays `None` there.

The rest of core's Bookmarking section was missing from Express too: `bookmark.restore_input`, `Bookmark`, `BookmarkState`, `RestoreState`, `set_global_save_dir_fn`, `set_global_restore_dir_fn`. Those are mode-agnostic symbols Express users need, so this PR mirrors the whole section rather than adding a single-entry section.

## History of bookmark docs changes

#1870 (`feat: Add support for bookmarking via shiny.bookmark`) added the Bookmarking section to `_quartodoc-core.yml` and the `shiny.express.ui` export, but never touched `_quartodoc-express.yml`. That same commit shipped `api-examples/input_bookmark_button/app-express.py`, so this appears to have been an unintentional omission

## Changes

- `docs/_quartodoc-express.yml`: add a "Bookmarking" section mirroring core's — `express.ui.input_bookmark_button`, then `bookmark.restore_input`, `bookmark.Bookmark`, `bookmark.BookmarkState`, `bookmark.RestoreState`, and core's `kind: page` "Integration" group wrapping `set_global_save_dir_fn` / `set_global_restore_dir_fn`. Placed immediately before "Chat interface" to match core, reusing its title/description.
- `shiny/bookmark/_button.py`: replace the roxygen link `[input_action_button()]` with `` :func:`~shiny.ui.input_action_button` `` per `.claude/references/documentation-style.md`. Also dropped the R name `bookmarkButton` from the same sentence and wrapped the long line.
- `shiny/bookmark/_bookmark.py`, `_save_state.py`, `_restore_state.py`: add the missing docstrings for `Bookmark`, `BookmarkState` and `RestoreState`. All three were registered in the reference with *no* docstring, so their rows in the Bookmarking index rendered with an empty summary column and their pages showed nothing but a signature. `BookmarkState` / `RestoreState` also had bare attribute annotations, leaving the fields app authors touch from `on_bookmark()` / `on_restore()` callbacks undocumented. Also fixes two stale references found in the same area: `on_bookmark()` pointed at `ShinySaveState` (renamed to `BookmarkState`), and `store` said "diabled".
- `CHANGELOG.md`: entry under `## [Unreleased]`, following the precedent of existing docs-only entries (#2386).

Note for review: this is the first `kind: page` group in the Express config, though core has used the pattern for a while. It builds and flattens correctly (below), but it is a new shape for this file.

Here's what it looks like built locally:

<img width="2470" height="984" alt="image" src="https://github.com/user-attachments/assets/df979c4b-42fe-4ad6-86f5-24e5c16d92bc" />

For comparison, the core doc page:

<img width="2436" height="1162" alt="image" src="https://github.com/user-attachments/assets/b17c2923-ce96-4aff-8714-993ae561f719" />


## Verification

Built the docs manually and verified they render correctly, as in the above screenshots.
