### PR TITLE
fix: Honor --app-dir when resolving Shiny Express apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `ui.input_task_button(type=None)` no longer drops the `bslib-task-button` class. Operator precedence made the `type is not None` check apply to the whole class string rather than just the Bootstrap classes, so the button rendered with `class=""`; since that class is the selector Shiny's input binding uses, the button was never bound as an input and clicking it did nothing. (#2388)
 
-* `shiny run --app-dir <dir> <app>` now honors `--app-dir` for Shiny Express apps. Express detection looked for the app file relative to `--app-dir`, but the entrypoint that gets handed to uvicorn was then built by resolving the app path against the current working directory instead, so running an Express app from outside its directory failed with a `FileNotFoundError` for a path that never existed. (#1991)
+* `shiny run --app-dir <dir> <app>` now honors `--app-dir` for Shiny Express apps. Express detection looked for the app file relative to `--app-dir`, but the entrypoint that gets handed to uvicorn was then built by resolving the app path against the current working directory instead, so running an Express app from outside its directory failed with a `FileNotFoundError` for a path that never existed. (#2419)
 
 ## [1.7.0] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `ui.input_task_button(type=None)` no longer drops the `bslib-task-button` class. Operator precedence made the `type is not None` check apply to the whole class string rather than just the Bootstrap classes, so the button rendered with `class=""`; since that class is the selector Shiny's input binding uses, the button was never bound as an input and clicking it did nothing. (#2388)
 
+* `shiny run --app-dir <dir> <app>` now honors `--app-dir` for Shiny Express apps. Express detection looked for the app file relative to `--app-dir`, but the entrypoint that gets handed to uvicorn was then built by resolving the app path against the current working directory instead, so running an Express app from outside its directory failed with a `FileNotFoundError` for a path that never existed. (#1991)
+
 ## [1.7.0] - 2026-07-28
 
 ### New features

--- a/shiny/_main/_run.py
+++ b/shiny/_main/_run.py
@@ -313,11 +313,6 @@ def run_app(
         # default value for `shiny run` is "app.py:app", so we need to handle it.
         app_no_suffix = re.sub(r":app$", "", app)
         if is_express_app(app_no_suffix, app_dir):
-            # Resolve the app path the same way is_express_app() found the file: relative
-            # to app_dir, if one was given. (If app_no_suffix is absolute, joining it to
-            # app_dir is a no-op.) Resolving it relative to the current working directory
-            # instead would point the express entrypoint at a nonexistent file.
-            # https://github.com/posit-dev/py-shiny/issues/1991
             if app_dir is None:
                 app_path = Path(app_no_suffix).resolve()
             else:

--- a/shiny/_main/_run.py
+++ b/shiny/_main/_run.py
@@ -313,7 +313,15 @@ def run_app(
         # default value for `shiny run` is "app.py:app", so we need to handle it.
         app_no_suffix = re.sub(r":app$", "", app)
         if is_express_app(app_no_suffix, app_dir):
-            app_path = Path(app_no_suffix).resolve()
+            # Resolve the app path the same way is_express_app() found the file: relative
+            # to app_dir, if one was given. (If app_no_suffix is absolute, joining it to
+            # app_dir is a no-op.) Resolving it relative to the current working directory
+            # instead would point the express entrypoint at a nonexistent file.
+            # https://github.com/posit-dev/py-shiny/issues/1991
+            if app_dir is None:
+                app_path = Path(app_no_suffix).resolve()
+            else:
+                app_path = (Path(app_dir) / app_no_suffix).resolve()
             # If the file is "/path/to/app.py", our entrypoint with the escaped filename
             # is "shiny.express.app:_2f_path_2f_to_2f_app_2e_py".
             app = "shiny.express.app:" + escape_to_var_name(str(app_path))

--- a/tests/pytest/test_main_run.py
+++ b/tests/pytest/test_main_run.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Any
 
@@ -7,6 +8,7 @@ import pytest
 from click.testing import CliRunner
 
 from shiny._main import _run, main
+from shiny.express._utils import escape_to_var_name
 
 
 @pytest.fixture
@@ -19,6 +21,19 @@ def captured_run_app(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
         captured.update(kwargs)
 
     monkeypatch.setattr(_run, "run_app", fake_run_app)
+    return captured
+
+
+@pytest.fixture
+def captured_uvicorn(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Replace _run_uvicorn with a recorder so `run_app` never starts a server."""
+    captured: dict[str, Any] = {}
+
+    def fake_run_uvicorn(app: Any, **kwargs: Any) -> None:
+        captured["app"] = app
+        captured.update(kwargs)
+
+    monkeypatch.setattr(_run, "_run_uvicorn", fake_run_uvicorn)
     return captured
 
 
@@ -136,9 +151,80 @@ def test_resolve_app_empty_module_raises() -> None:
         _run.resolve_app(":app", None)
 
 
-def test_try_import_module() -> None:
-    import os
+def write_express_app(app_dir: Path, filename: str = "app.py") -> Path:
+    app_dir.mkdir(parents=True, exist_ok=True)
+    app_file = app_dir / filename
+    app_file.write_text("from shiny.express import ui\n\nui.h1('hello')\n")
+    return app_file
 
+
+def express_entrypoint(app_file: Path) -> str:
+    return "shiny.express.app:" + escape_to_var_name(str(app_file.resolve()))
+
+
+def test_run_app_express_resolves_relative_to_app_dir(
+    captured_uvicorn: dict[str, Any], tmp_path: Path
+) -> None:
+    # https://github.com/posit-dev/py-shiny/issues/1991
+    app_file = write_express_app(tmp_path / "subdir")
+
+    _run.run_app("app.py", app_dir=str(tmp_path / "subdir"), dev_mode=False)
+
+    assert captured_uvicorn["app"] == express_entrypoint(app_file)
+    assert captured_uvicorn["app_dir"] == os.path.realpath(tmp_path / "subdir")
+
+
+def test_run_app_express_relative_app_dir(
+    captured_uvicorn: dict[str, Any],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The reported reproduction: `shiny run --app-dir subdir app.py`
+    app_file = write_express_app(tmp_path / "subdir")
+    monkeypatch.chdir(tmp_path)
+
+    _run.run_app("app.py", app_dir="subdir", dev_mode=False)
+
+    assert captured_uvicorn["app"] == express_entrypoint(app_file)
+    assert captured_uvicorn["app_dir"] == os.path.realpath(tmp_path / "subdir")
+
+
+def test_run_app_express_default_app_suffix_with_app_dir(
+    captured_uvicorn: dict[str, Any], tmp_path: Path
+) -> None:
+    # `shiny run -d subdir` uses the default APP value of "app.py:app"
+    app_file = write_express_app(tmp_path / "subdir")
+
+    _run.run_app("app.py:app", app_dir=str(tmp_path / "subdir"), dev_mode=False)
+
+    assert captured_uvicorn["app"] == express_entrypoint(app_file)
+    assert captured_uvicorn["app_dir"] == os.path.realpath(tmp_path / "subdir")
+
+
+def test_run_app_express_absolute_app_path_ignores_app_dir(
+    captured_uvicorn: dict[str, Any], tmp_path: Path
+) -> None:
+    # An absolute APP path wins over app_dir (as documented for `--app-dir`)
+    app_file = write_express_app(tmp_path / "subdir")
+
+    _run.run_app(str(app_file), app_dir=str(tmp_path / "other"), dev_mode=False)
+
+    assert captured_uvicorn["app"] == express_entrypoint(app_file)
+    assert captured_uvicorn["app_dir"] == os.path.realpath(tmp_path / "subdir")
+
+
+def test_run_app_express_no_app_dir(
+    captured_uvicorn: dict[str, Any], tmp_path: Path
+) -> None:
+    app_file = write_express_app(tmp_path / "subdir")
+
+    _run.run_app(str(app_file), app_dir=None, dev_mode=False)
+
+    assert captured_uvicorn["app"] == express_entrypoint(app_file)
+    assert captured_uvicorn["app_dir"] == os.path.realpath(tmp_path / "subdir")
+
+
+def test_try_import_module() -> None:
     assert _run.try_import_module("os") is os
     assert _run.try_import_module("definitely_not_a_module_abc123") is None
     # '/' and '.' together make find_spec throw ModuleNotFoundError


### PR DESCRIPTION
Fixes #1991

## Problem

`run_app()` passes `app_dir` to `is_express_app()`, which correctly looks for the app file at `app_dir / app`. But the very next line resolved the app path against the *current working directory* instead:

```python
if is_express_app(app_no_suffix, app_dir):
    app_path = Path(app_no_suffix).resolve()   # app_dir dropped here
```

The escaped `shiny.express.app:<escaped-path>` entrypoint that is then handed to uvicorn therefore pointed at a path that does not exist, so the app failed at import time with a `FileNotFoundError`.

Core apps were never affected: `resolve_app()` already does `os.path.join(app_dir, module)`.

## Reproduction

```
repro/
└── subdir/
    ├── app.py     # from shiny.express import ui; ui.h1("Hello express from subdir")
    └── core.py    # app = App(ui.page_fluid(...), None)
```

<details>
<summary>Script to create the reproduction</summary>

```bash
#!/usr/bin/env bash
set -euo pipefail

mkdir -p repro/subdir

cat > repro/subdir/app.py <<'PY'
from shiny.express import ui

ui.h1("Hello express from subdir")
PY

cat > repro/subdir/core.py <<'PY'
from shiny import App, ui

app = App(ui.page_fluid(ui.h1("Hello core from subdir")), None)
PY

echo "Created $(pwd)/repro/subdir/{app.py,core.py}"
```

</details>

Before, run from the directory containing `repro/`:

```
$ shiny run --app-dir repro/subdir app.py
...
  File ".../shiny/express/_run.py", line 194, in run_express
    with open(file, encoding="utf-8") as f:
FileNotFoundError: [Errno 2] No such file or directory: '.../app.py'

$ shiny run --app-dir repro/subdir core.py     # works
INFO:     Application startup complete.
```

Note the missing `repro/subdir` in the path Express tried to open: it was resolved against the current working directory rather than `--app-dir`.

After:

```
$ shiny run --app-dir repro/subdir app.py
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:8000
$ curl -s http://127.0.0.1:8000/ | grep -o "Hello express from subdir"
Hello express from subdir
```

`shiny run -d repro/subdir --reload` (default `app.py:app` APP value) also works and watches `repro/subdir`.

## Fix

Resolve the Express app path relative to `app_dir` when one is given, matching what `is_express_app()` did to find the file. Joining an absolute app path to `app_dir` is a no-op with `pathlib`, so passing an absolute path still ignores `--app-dir`, as documented.

## Tests

Five tests in `tests/pytest/test_main_run.py` exercise `run_app()` with `_run_uvicorn` stubbed out, asserting on the entrypoint string and the final `app_dir`:

- `test_run_app_express_resolves_relative_to_app_dir` (absolute `app_dir`) — failed before
- `test_run_app_express_relative_app_dir` (the reported repro, relative `app_dir`) — failed before
- `test_run_app_express_default_app_suffix_with_app_dir` (`app.py:app`) — failed before
- `test_run_app_express_absolute_app_path_ignores_app_dir` — regression guard, passed before
- `test_run_app_express_no_app_dir` — regression guard, passed before

`uv run make check-tests` (994 passed, 1 skipped) and `uv run make format check-lint check-types` both pass.
