### PR TITLE
docs: explain that download buttons can't be updated like action buttons

### DIFF
--- a/shiny/render/_render.py
+++ b/shiny/render/_render.py
@@ -717,6 +717,15 @@ class download_button(_DownloadBase):
     In Shiny Core, pair this with :func:`~shiny.ui.download_button` in the UI (the
     decorated function's name should match the ``id``).
 
+    Note
+    ----
+    A download button is an *output*, not an input, so it can't be enabled or disabled
+    with :func:`~shiny.ui.update_action_button`. To only offer the download once some
+    condition is met, render the button conditionally -- e.g., place this renderer
+    inside :func:`~shiny.ui.panel_conditional` (Express), or (Core) use
+    :class:`~shiny.render.ui` with :func:`~shiny.ui.download_button` and swap in a
+    disabled :func:`~shiny.ui.input_action_button` as a placeholder.
+
     See Also
     --------
     * :class:`~shiny.render.download_link`
@@ -763,6 +772,14 @@ class download_link(_DownloadBase):
     ----
     In Shiny Core, pair this with :func:`~shiny.ui.download_link` in the UI (the
     decorated function's name should match the ``id``).
+
+    Note
+    ----
+    A download link is an *output*, not an input, so it can't be enabled or disabled
+    with :func:`~shiny.ui.update_action_link`. To only offer the download once some
+    condition is met, render the link conditionally -- e.g., place this renderer inside
+    :func:`~shiny.ui.panel_conditional` (Express), or (Core) use
+    :class:`~shiny.render.ui` with :func:`~shiny.ui.download_link`.
 
     See Also
     --------

--- a/shiny/render/_render.py
+++ b/shiny/render/_render.py
@@ -721,10 +721,11 @@ class download_button(_DownloadBase):
     ----
     A download button is an *output*, not an input, so it can't be enabled or disabled
     with :func:`~shiny.ui.update_action_button`. To only offer the download once some
-    condition is met, render the button conditionally -- e.g., place this renderer
-    inside :func:`~shiny.ui.panel_conditional` (Express), or (Core) use
-    :class:`~shiny.render.ui` with :func:`~shiny.ui.download_button` and swap in a
-    disabled :func:`~shiny.ui.input_action_button` as a placeholder.
+    condition is met, render the button conditionally with :class:`~shiny.render.ui`,
+    swapping in a disabled :func:`~shiny.ui.input_action_button` as a placeholder. In
+    Express, wrap this renderer in :func:`~shiny.express.ui.hold` so the button isn't
+    auto-placed, then place :func:`~shiny.ui.download_button` from inside the
+    :class:`~shiny.render.ui` function.
 
     See Also
     --------
@@ -777,9 +778,10 @@ class download_link(_DownloadBase):
     ----
     A download link is an *output*, not an input, so it can't be enabled or disabled
     with :func:`~shiny.ui.update_action_link`. To only offer the download once some
-    condition is met, render the link conditionally -- e.g., place this renderer inside
-    :func:`~shiny.ui.panel_conditional` (Express), or (Core) use
-    :class:`~shiny.render.ui` with :func:`~shiny.ui.download_link`.
+    condition is met, render the link conditionally with :class:`~shiny.render.ui`. In
+    Express, wrap this renderer in :func:`~shiny.express.ui.hold` so the link isn't
+    auto-placed, then place :func:`~shiny.ui.download_link` from inside the
+    :class:`~shiny.render.ui` function.
 
     See Also
     --------

--- a/shiny/ui/_download_button.py
+++ b/shiny/ui/_download_button.py
@@ -46,10 +46,11 @@ def download_button(
     enabled by Shiny once the server has supplied the download URL (this prevents the
     browser from downloading the app's own HTML if the button is clicked before the
     session is ready). To only offer the download once some condition is met, render
-    the button conditionally instead -- for example, with
-    :class:`~shiny.render.ui` (swapping in a disabled
-    :func:`~shiny.ui.input_action_button` as a placeholder), or by wrapping it in
-    :func:`~shiny.ui.panel_conditional`.
+    the button conditionally with :class:`~shiny.render.ui`, swapping in a disabled
+    :func:`~shiny.ui.input_action_button` as a placeholder until the download is
+    available. :func:`~shiny.ui.panel_conditional` also works, but only for conditions
+    that the browser can evaluate: its condition sees client-side input values, and some
+    inputs (notably :func:`~shiny.ui.input_file`) have no client-side value at all.
 
     See Also
     --------
@@ -115,8 +116,10 @@ def download_link(
     enabled by Shiny once the server has supplied the download URL (this prevents the
     browser from downloading the app's own HTML if the link is clicked before the
     session is ready). To only offer the download once some condition is met, render
-    the link conditionally instead -- for example, with :class:`~shiny.render.ui`, or by
-    wrapping it in :func:`~shiny.ui.panel_conditional`.
+    the link conditionally with :class:`~shiny.render.ui`.
+    :func:`~shiny.ui.panel_conditional` also works, but only for conditions that the
+    browser can evaluate: its condition sees client-side input values, and some inputs
+    (notably :func:`~shiny.ui.input_file`) have no client-side value at all.
 
     See Also
     --------

--- a/shiny/ui/_download_button.py
+++ b/shiny/ui/_download_button.py
@@ -39,6 +39,18 @@ def download_button(
     :
         A UI element
 
+    Note
+    ----
+    A download button is an *output*, not an input, so it can't be updated with
+    :func:`~shiny.ui.update_action_button`. It is rendered in a disabled state and is
+    enabled by Shiny once the server has supplied the download URL (this prevents the
+    browser from downloading the app's own HTML if the button is clicked before the
+    session is ready). To only offer the download once some condition is met, render
+    the button conditionally instead -- for example, with
+    :class:`~shiny.render.ui` (swapping in a disabled
+    :func:`~shiny.ui.input_action_button` as a placeholder), or by wrapping it in
+    :func:`~shiny.ui.panel_conditional`.
+
     See Also
     --------
     * :class:`~shiny.render.download_button`
@@ -95,6 +107,16 @@ def download_link(
     -------
     :
         A UI element
+
+    Note
+    ----
+    A download link is an *output*, not an input, so it can't be updated with
+    :func:`~shiny.ui.update_action_link`. It is rendered in a disabled state and is
+    enabled by Shiny once the server has supplied the download URL (this prevents the
+    browser from downloading the app's own HTML if the link is clicked before the
+    session is ready). To only offer the download once some condition is met, render
+    the link conditionally instead -- for example, with :class:`~shiny.render.ui`, or by
+    wrapping it in :func:`~shiny.ui.panel_conditional`.
 
     See Also
     --------

--- a/shiny/ui/_input_update.py
+++ b/shiny/ui/_input_update.py
@@ -91,7 +91,9 @@ def update_action_button(
         An icon to appear inline with the button/link.
     disabled
         If `True`, disable the button making it unclickable; if `False`, the button will
-        become enabled and clickable.
+        become enabled and clickable. This has no effect on a
+        :func:`~shiny.ui.download_button`, which is an output rather than an input; see
+        that function's docs for how to conditionally offer a download.
     session
         A :class:`~shiny.Session` instance. If not provided, it is inferred via
         :func:`~shiny.session.get_current_session`.


### PR DESCRIPTION
Closes #1994

## Problem

In #1994, `ui.update_action_button("download_csv", disabled=...)` silently does nothing on a download button.

That's expected, but not discoverable. `update_action_button()` sends an `inputMessages` message, and the client dispatches those only to `.shiny-bound-input#<id>` elements. A download button/link is an **output** — `<a class="btn shiny-download-link">`, handled by `DownloadLinkOutputBinding` — so it is `.shiny-bound-output` and the message is dropped with no warning. Even if the message did arrive, `ActionButtonInputBinding.receiveMessage()` toggles the `disabled` *attribute*, which has no effect on an `<a>`, and `DownloadLinkOutputBinding.renderValue()` re-enables the link on every flush.

The upstream discussion in rstudio/shiny#4119 (filed by a py-shiny user hitting this same thing) concluded that Shiny will **not** add `disabled=` to `downloadButton()`/`downloadLink()` or an `updateDownloadButton()`: the load-time disabling exists so browsers don't download the app's own HTML before the session is ready, disabling controls is poor a11y/UX, and conditional/dynamic UI is the recommended pattern. So this PR documents the intended approach rather than adding API.

## Changes

Docs only, no behavior change.

- `shiny/ui/_download_button.py` — Notes on `download_button()` and `download_link()`: they're outputs, so `update_action_button()`/`update_action_link()` don't apply; why they render disabled; and how to conditionally offer a download.
- `shiny/render/_render.py` — matching Notes on `render.download_button` and `render.download_link` (the Express entry points, which is where the reporter was looking).
- `shiny/ui/_input_update.py` — one sentence on `update_action_button(disabled=)` noting it has no effect on download buttons.

## Recommended pattern (verified in a browser)

Express, gating on an upload as in the issue. `ui.hold()` suppresses the auto-placed button so the renderer only registers the output:

```python
from shiny import ui as core_ui
from shiny.express import input, render, ui

ui.input_file("csv_file", "Upload CSV file:", accept=".csv")

@render.ui
def dl_ui():
    if not input.csv_file():
        return ui.input_action_button(
            "dl_placeholder", "Upload a CSV to enable download", disabled=True
        )
    return core_ui.download_button("download_csv", "Download CSV")

with ui.hold():
    @render.download_button(filename="download.csv")
    def download_csv():
        yield "a,b\n1,2\n"
```

Before upload only the disabled placeholder renders; after upload the real button appears and fetching its href returns `200` with `content-disposition: attachment; filename="download.csv"` and the expected body.

Note that `panel_conditional()` is *not* a general substitute: its condition is evaluated in the browser, and `input_file()` has no client-side value (always `null`), so `panel_conditional("input.csv_file")` can never become true. The docstrings say so explicitly.

Two small things surfaced while verifying: `shiny.express.ui` does not re-export `download_button`/`download_link` (hence `core_ui` above), and file inputs are invisible to client-side conditions. Neither is changed here.

## Verification

`uv run make format check-lint check-types` passes (pyrefly: 0 errors).
