### PR TITLE
fix: Soft teardown of reactives when a session closes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* Closing a session no longer destroys the reactive values and calcs created in it, so async work that outlives the connection does not error. Since v1.6.1, refreshing the page while an `@reactive.extended_task` (or any `asyncio` task) was in flight could raise `DestroyedReactiveError: Reactive value '<name>' has been destroyed.` once it settled, leaving the task in neither `"success"` nor `"error"`. Values and calcs are now left readable at their last value on close and reclaimed by garbage collection, while an explicit `session.destroy(id)` on a live session still tears them down. Effects are still destroyed on close. (#2427)
+
 * The `ui.Theme` API reference examples now run in Shinylive. Compiling a customized theme requires `libsass`, but Shinylive only auto-loads packages it finds in an app's top-level imports and `Theme.to_css()` imports `sass` lazily, so the examples died with an `ImportError`. The example directory now declares `libsass` in a `requirements.txt`. (#2387)
 
 * Fixed the error message raised when a package required for theme compilation is missing: it interpolated the package name into the first sentence but printed a literal `pip install {pkg}` in the second. (#2387)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
-* Closing a session no longer destroys the reactive values and calcs created in it, so async work that outlives the connection does not error. Since v1.6.1, refreshing the page while an `@reactive.extended_task` (or any `asyncio` task) was in flight could raise `DestroyedReactiveError: Reactive value '<name>' has been destroyed.` once it settled, leaving the task in neither `"success"` nor `"error"`. Values and calcs are now left readable at their last value on close and reclaimed by garbage collection, while an explicit `session.destroy(id)` on a live session still tears them down. Effects are still destroyed on close. (#2427)
+* Closing a session no longer destroys the reactive values and calcs created in it, so async work that outlives the connection does not error. Since v1.6.1, refreshing the page while an `@reactive.extended_task` (or any `asyncio` task) was in flight could raise `DestroyedReactiveError: Reactive value '<name>' has been destroyed.` once it settled, leaving the task in neither `"success"` nor `"error"`. Values and calcs are now left readable at their last value on close and reclaimed by garbage collection, while an explicit `session.destroy(id)` on a live session still tears them down. Effects are still destroyed on close. (#2428)
 
 * The `ui.Theme` API reference examples now run in Shinylive. Compiling a customized theme requires `libsass`, but Shinylive only auto-loads packages it finds in an app's top-level imports and `Theme.to_css()` imports `sass` lazily, so the examples died with an `ImportError`. The example directory now declares `libsass` in a `requirements.txt`. (#2387)
 

--- a/shiny/.agents/skills/shiny-for-python/references/session-lifecycle.md
+++ b/shiny/.agents/skills/shiny-for-python/references/session-lifecycle.md
@@ -44,6 +44,15 @@ def server(input, output, session):
 module instance's reactive graph (not the entire session), use
 `session.destroy(id)` — see `references/modules-core.md`.
 
+Closing a session is not the same as destroying a scope. On close, reactive
+values and calcs stay readable at their last value (they are just reclaimed by
+garbage collection), so async work that outlives the connection — an
+`@reactive.extended_task` that settles after the user refreshes the page, a
+stray `asyncio` task — can still touch them without erroring. Effects are
+destroyed, so writes after close are inert. An explicit `session.destroy(id)`
+on a live session does hard-destroy: reading a value from that scope afterwards
+raises `DestroyedReactiveError`.
+
 ## Read the incoming request: `http_conn` and `clientdata`
 
 `session.http_conn` is the Starlette

--- a/shiny/express/_stub_session.py
+++ b/shiny/express/_stub_session.py
@@ -54,6 +54,9 @@ class ExpressStubSession(Session):
     async def close(self, code: int = 1001) -> None:
         return
 
+    def _is_closed(self) -> bool:
+        return False
+
     # This is needed so that Outputs don't throw an error.
     def _is_hidden(self, name: str) -> bool:
         return False

--- a/shiny/reactive/_reactives.py
+++ b/shiny/reactive/_reactives.py
@@ -58,15 +58,31 @@ from ._core import Context, Dependents, ReactiveWarning, isolate
 from ._utils import is_user_code_frame
 
 
-def _weak_callback(method: Callable[[], None]) -> Callable[[], None]:
+def _weak_destroy_callback(
+    method: Callable[[], None],
+    session: Session,
+) -> Callable[[], None]:
     """
-    Wrap a bound method in a ``weakref.WeakMethod`` so the callback does not
-    prevent the owning object from being garbage collected. If the object has
-    been collected, the wrapper silently no-ops.
+    Build the ``on_destroy`` callback that a reactive registers with its session.
+
+    The bound method is wrapped in a ``weakref.WeakMethod`` so the callback does
+    not prevent the owning reactive from being garbage collected. If the reactive
+    has already been collected, the wrapper silently no-ops.
+
+    The wrapper also no-ops when the session is closed. A whole-session close is
+    not a destroy: every consumer in the session is already gone (effects are
+    destroyed via ``on_ended``, and the session can no longer flush), so the
+    reactive is left intact and reclaimed by ordinary garbage collection.
+    Tearing it down here would instead poison async work that outlives the
+    connection -- an :class:`~shiny.reactive.ExtendedTask` settling after a page
+    refresh, an ``asyncio`` task, a ``loop.call_later()`` callback -- with an
+    unavoidable, racy :class:`DestroyedReactiveError`.
     """
     ref = weakref.WeakMethod(method)
 
     def wrapper() -> None:
+        if session._is_closed():
+            return
         fn = ref()
         if fn is not None:
             fn()
@@ -208,8 +224,9 @@ class Value(Generic[T]):
 
         if session is not None:
             # Unset the value on session/module destroy so dependents are
-            # invalidated and the stored value is freed.
-            session.on_destroy(_weak_callback(self.destroy))
+            # invalidated and the stored value is freed. (Not on session close --
+            # see `_weak_destroy_callback`.)
+            session.on_destroy(_weak_destroy_callback(self.destroy, session))
 
     def _try_infer_name(self) -> str | None:
         """
@@ -702,8 +719,11 @@ class Calc_(Generic[T]):
 
         if self._session is not None:
             # Invalidate context and dependents on session/module destroy so
-            # the calc is permanently destroyed and references are freed.
-            self._session.on_destroy(_weak_callback(self.destroy))
+            # the calc is permanently destroyed and references are freed. (Not on
+            # session close -- see `_weak_destroy_callback`.)
+            self._session.on_destroy(
+                _weak_destroy_callback(self.destroy, self._session)
+            )
 
     def destroy(self) -> None:
         """
@@ -1000,11 +1020,15 @@ class Effect_:
         self._session = session
 
         if self._session is not None:
-            # TODO-future: Investigate using _weak_callback for on_ended too.
+            # TODO-future: Investigate using a weak reference for on_ended too.
             # Currently kept as a strong reference to preserve existing behavior
-            # where effects are guaranteed to be destroyed at session end.
+            # where effects are guaranteed to be destroyed at session end. That
+            # `on_ended` registration is also what destroys effects on session
+            # close, since the `on_destroy` one no-ops there.
             self._session.on_ended(self.destroy)
-            self._session.on_destroy(_weak_callback(self.destroy))
+            self._session.on_destroy(
+                _weak_destroy_callback(self.destroy, self._session)
+            )
 
         # Extract OpenTelemetry attributes at initialization time
         self._otel_attrs: dict[str, Any] = {

--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -343,7 +343,9 @@ class Session(ABC):
             await session.destroy("editor")
         ```
 
-        The following categories of state are cleaned up:
+        An explicit ``destroy()`` call cleans up the following categories of
+        state. (Session *close* is deliberately gentler with reactives — see
+        "Close is not destroy" below.)
 
         - **Reactive objects** — Effects are stopped, calcs and values are
           invalidated. After destruction, ``get()``/``set()`` on a destroyed
@@ -358,7 +360,8 @@ class Session(ABC):
 
         For ``SessionProxy``, this must be called explicitly (typically after
         removing dynamic module UI). For ``AppSession``, this is called
-        automatically at session end, after all ``on_ended`` callbacks.
+        automatically at session end, after all ``on_ended`` callbacks — but
+        that path skips the reactive teardown above, per "Close is not destroy".
 
         Idempotent: calling destroy() more than once has no effect.
 
@@ -1774,7 +1777,10 @@ class SessionProxy(Session):
         Register a callback to run when this module scope is destroyed.
 
         Destroy callbacks fire when ``destroy()`` is explicitly called, or
-        automatically at session end (after ``on_ended`` callbacks).
+        automatically at session end (after ``on_ended`` callbacks). Note that
+        the session-end path leaves the scope's reactive values and calcs
+        readable; only an explicit ``destroy()`` tears them down. See
+        :meth:`~shiny.Session.destroy`.
 
         Parameters
         ----------

--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -255,6 +255,18 @@ class Session(ABC):
         """
 
     @abstractmethod
+    def _is_closed(self) -> bool:
+        """
+        Whether the session is being (or has been) torn down because its client
+        went away.
+
+        Distinguishes a whole-session close from an explicit
+        :meth:`~shiny.Session.destroy` call on a still-running session: on close
+        the reactives in the session are left intact, while an explicit
+        ``destroy()`` tears them down.
+        """
+
+    @abstractmethod
     def _is_hidden(self, name: str) -> bool: ...
 
     @add_example(example_name="session_on_ended")
@@ -288,6 +300,14 @@ class Session(ABC):
         ``session.destroy()`` is explicitly called. For ``AppSession`` (root
         sessions), destroy callbacks fire automatically at session end, after
         all ``on_ended`` callbacks have run.
+
+        Note that closing a session is not the same as destroying a scope. An
+        explicit ``destroy()`` tears down the scope's reactive values, calcs,
+        and effects, so reading one afterwards raises
+        ``DestroyedReactiveError``. When the session closes, values and calcs
+        are instead left readable at their last value and reclaimed by ordinary
+        garbage collection, so async work that outlives the connection does not
+        error.
 
         Parameters
         ----------
@@ -341,6 +361,22 @@ class Session(ABC):
         automatically at session end, after all ``on_ended`` callbacks.
 
         Idempotent: calling destroy() more than once has no effect.
+
+        Close is not destroy
+        --------------------
+        The teardown above describes an explicit ``destroy()`` call on a running
+        session. When the session itself closes (the browser tab is closed or
+        refreshed), reactive values and calcs are **not** destroyed: they are
+        left readable at their last value and reclaimed by ordinary garbage
+        collection. Effects are still destroyed, since the session can no longer
+        flush.
+
+        Without this, any async work that outlives the connection — an
+        :class:`~shiny.reactive.ExtendedTask` that settles after the user
+        refreshes the page, an ``asyncio`` task, a callback scheduled with
+        ``loop.call_later()`` — would raise ``DestroyedReactiveError`` on its
+        first reactive access. Writes after close are already inert: the
+        session's effects are gone and outbound messages are dropped.
 
         Composability
         -------------
@@ -877,9 +913,17 @@ class AppSession(Session):
         # Clear file upload directories, if present
         self.on_ended(self._file_upload_manager.rm_upload_dir)
 
+    def _is_closed(self) -> bool:
+        # `_has_run_session_ended_tasks` is set before any teardown callback
+        # runs, so teardown itself can tell a close from an explicit destroy().
+        return self._has_run_session_ended_tasks
+
     async def _run_session_ended_tasks(self) -> None:
         if self._has_run_session_ended_tasks:
             return
+        # Mark the session closed before running any teardown, so that the
+        # destroy callbacks registered by reactive values and calcs can skip
+        # tearing themselves down (see `_weak_destroy_callback`).
         self._has_run_session_ended_tasks = True
 
         # Wrap session cleanup in session_end span (or no-op if not collecting)
@@ -1719,6 +1763,9 @@ class SessionProxy(Session):
         self._downloads = root_session._downloads
 
         self.bookmark = BookmarkProxy(self)
+
+    def _is_closed(self) -> bool:
+        return self._root_session._is_closed()
 
     def on_destroy(
         self, fn: Callable[[], None] | Callable[[], Awaitable[None]]

--- a/tests/pytest/test_destroy.py
+++ b/tests/pytest/test_destroy.py
@@ -14,7 +14,15 @@ from shiny._app import App
 from shiny._connection import MockConnection
 from shiny._namespaces import ResolvedId
 from shiny.express._stub_session import ExpressStubSession
-from shiny.reactive import Value, calc, effect, flush, invalidate_later, isolate
+from shiny.reactive import (
+    Value,
+    calc,
+    effect,
+    extended_task,
+    flush,
+    invalidate_later,
+    isolate,
+)
 from shiny.reactive._reactives import DestroyedReactiveError, Effect_
 from shiny.render.renderer import Renderer
 from shiny.session._session import (
@@ -553,6 +561,9 @@ def _make_mock_root_session() -> Session:
             self._destroy_callbacks_by_ns: dict[str, _utils.AsyncCallbacks] = {}
 
         def _is_hidden(self, name: str) -> bool:
+            return False
+
+        def _is_closed(self) -> bool:
             return False
 
         def is_stub_session(self) -> bool:
@@ -1699,3 +1710,248 @@ async def test_destroy_by_id_does_not_leak_bookmark_exclude():
     root.make_scope("mod1")
     await root.destroy("mod1")
     assert len(root.bookmark._on_get_exclude) == before
+
+
+# ---- Soft teardown on whole-session close ---------------------------------
+#
+# Closing a session is not the same as destroying a module scope. When the
+# client goes away, every consumer in the session is already gone and the whole
+# object graph is about to be garbage collected, so reactive values and calcs are
+# left intact: async work that outlives the connection (an ExtendedTask settling
+# after a page refresh, a stray asyncio task) must not be poisoned by a
+# DestroyedReactiveError. An explicit `session.destroy(ns)` on a live session
+# still tears down for real.
+
+
+@pytest.mark.asyncio
+async def test_session_close_leaves_value_readable():
+    root = _make_real_app_session()
+    with session_context(root):
+        v = Value(10)
+        v.set(42)
+
+    await root._run_session_ended_tasks()
+
+    assert root._is_closed()
+    with isolate():
+        assert v.get() == 42
+
+
+@pytest.mark.asyncio
+async def test_session_close_leaves_value_writable():
+    root = _make_real_app_session()
+    with session_context(root):
+        v = Value(10)
+
+    await root._run_session_ended_tasks()
+
+    with isolate():
+        v.set(99)
+        assert v.get() == 99
+
+
+@pytest.mark.asyncio
+async def test_session_close_leaves_calc_usable():
+    root = _make_real_app_session()
+    with session_context(root):
+        v = Value(10)
+
+        @calc
+        def double():
+            return v.get() * 2
+
+        with isolate():
+            assert double() == 20
+
+    await root._run_session_ended_tasks()
+
+    with isolate():
+        assert double() == 20
+        v.set(3)
+        assert double() == 6
+
+
+@pytest.mark.asyncio
+async def test_session_close_leaves_module_reactives_usable():
+    """A root close does not tear down reactives owned by module scopes."""
+    root = _make_real_app_session()
+    proxy = root.make_scope("mod1")
+    with session_context(proxy):
+        v = Value(10)
+
+    await root._run_session_ended_tasks()
+
+    with isolate():
+        assert v.get() == 10
+
+
+@pytest.mark.asyncio
+async def test_session_close_still_destroys_effects():
+    """Effects are destroyed on close (via on_ended), so writes stay inert."""
+    root = _make_real_app_session()
+    ran = 0
+
+    with session_context(root):
+        v = Value(0)
+
+        @effect
+        def _():
+            v.get()
+            nonlocal ran
+            ran += 1
+
+        await flush()
+    assert ran == 1
+
+    await root._run_session_ended_tasks()
+
+    with isolate():
+        v.set(1)
+    await flush()
+
+    assert ran == 1
+
+
+@pytest.mark.asyncio
+async def test_session_close_does_not_destroy_inputs():
+    """Input values are readable after close, like any other reactive value."""
+    root = _make_real_app_session()
+    with session_context(root):
+        root.input["n"]._set(7)
+
+    await root._run_session_ended_tasks()
+
+    with isolate():
+        assert root.input["n"].get() == 7
+
+
+@pytest.mark.asyncio
+async def test_module_destroy_after_close_leaves_reactives_intact():
+    """A destroy() that lands during or after teardown is a no-op, not an error."""
+    root = _make_real_app_session()
+    proxy = root.make_scope("mod1")
+    with session_context(proxy):
+        v = Value(10)
+
+    await root._run_session_ended_tasks()
+    await proxy.destroy()
+
+    with isolate():
+        assert v.get() == 10
+
+
+@pytest.mark.asyncio
+async def test_explicit_module_destroy_still_hard_destroys():
+    """Contrast with close: a later access after destroy() is a genuine bug."""
+    root = _make_real_app_session()
+    proxy = root.make_scope("mod1")
+    with session_context(proxy):
+        v = Value(10)
+
+        @calc
+        def double():
+            return v.get() * 2
+
+    await root.destroy("mod1")
+
+    with isolate():
+        with pytest.raises(DestroyedReactiveError):
+            v.get()
+        with pytest.raises(DestroyedReactiveError):
+            double()
+
+
+@pytest.mark.asyncio
+async def test_session_close_still_runs_on_destroy_callbacks():
+    """User-registered destroy callbacks still fire on close."""
+    root = _make_real_app_session()
+    calls: list[str] = []
+    root.on_destroy(lambda: calls.append("root"))
+    root.make_scope("mod1").on_destroy(lambda: calls.append("mod1"))
+
+    await root._run_session_ended_tasks()
+
+    assert sorted(calls) == ["mod1", "root"]
+
+
+@pytest.mark.asyncio
+async def test_session_close_lets_values_be_garbage_collected():
+    """Soft teardown must not keep reactives alive: GC still reclaims them."""
+    root = _make_real_app_session()
+    with session_context(root):
+        v = Value(10)
+    ref = weakref.ref(v)
+
+    await root._run_session_ended_tasks()
+
+    del v
+    gc.collect()
+    assert ref() is None
+
+
+@pytest.mark.asyncio
+async def test_extended_task_settling_after_close_completes():
+    """End-to-end shape of the reported bug: refresh while a task is in flight."""
+    root = _make_real_app_session()
+    loop_errors: list[BaseException] = []
+
+    def on_loop_error(loop: Any, context: dict[str, Any]) -> None:
+        exc = context.get("exception")
+        if exc is not None:
+            loop_errors.append(exc)
+
+    asyncio.get_running_loop().set_exception_handler(on_loop_error)
+
+    started = asyncio.Event()
+    finish: asyncio.Future[int] = asyncio.get_running_loop().create_future()
+
+    with session_context(root):
+
+        @extended_task
+        async def task() -> int:
+            started.set()
+            return await finish
+
+        task()
+        await flush()
+
+    await started.wait()
+    with isolate():
+        assert task.status() == "running"
+
+    await root._run_session_ended_tasks()
+    finish.set_result(42)
+    # Let the task's done callback run.
+    for _ in range(10):
+        await asyncio.sleep(0)
+
+    assert loop_errors == []
+    with isolate():
+        assert task.status() == "success"
+        assert task.result() == 42
+
+
+@pytest.mark.asyncio
+async def test_extended_task_in_module_settling_after_close_completes():
+    """Same as above, for a task owned by a module scope."""
+    root = _make_real_app_session()
+    proxy = root.make_scope("mod1")
+    finish: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+
+    with session_context(proxy):
+
+        @extended_task
+        async def task() -> str:
+            return await finish
+
+        task()
+        await flush()
+
+    await root._run_session_ended_tasks()
+    finish.set_result("streamed")
+    for _ in range(10):
+        await asyncio.sleep(0)
+
+    with isolate():
+        assert task.status() == "success"
+        assert task.result() == "streamed"


### PR DESCRIPTION
Ports rstudio/shiny#4421 to py-shiny. Same bug, same architecture, same fix.

## Problem

Since #2209 / #2264 (shipped in v1.6.1), closing a session tears down every reactive created in it: `AppSession._run_session_ended_tasks()` calls `destroy()` with the root namespace, which fires the weak destroy callback that each `reactive.Value` and `reactive.calc` registers at construction.

So any async continuation that outlives the websocket close errors on its first reactive access. Refreshing the page during in-flight async work is routine, which turns a previously benign race into a user-visible error. Reproduced in this checkout with a real `AppSession` and an `@reactive.extended_task` in flight when the connection drops:

```
errors: [DestroyedReactiveError("Reactive value 'None' has been destroyed.")]
status read raised: DestroyedReactiveError Reactive value 'None' has been destroyed.
```

The write comes from `ExtendedTask._done_callback` -> `_impl` (`shiny/reactive/_extended_task.py:199-215`), which sets `status`/`value`/`error` with no guard. It raises inside a bare `asyncio.create_task()`, so the exception is never retrieved, the queued invocations never run, `await flush()` is skipped, and the task is left in neither `"success"` nor `"error"`. User-created reactives fail identically.

The R report came in via shinychat, where the first reactive touched happened to be bslib's `Theme Counter`. py-shiny's `get_current_theme()` isn't backed by a session reactive, so that particular first-touch doesn't exist here — `ExtendedTask` is what bites, plus any user code holding a reactive across an `await` that outlives the close.

## Fix

A close is not a destroy, so the two are now distinguished:

- **On close**, reactive values and calcs are left intact, readable at their last value, and reclaimed by ordinary garbage collection. `on_destroy()` callbacks still fire, so module cleanup is unaffected, and effects are still destroyed via `Effect_`'s separate `on_ended(self.destroy)` registration.
- **On explicit `session.destroy(id)`** against a live session, teardown is unchanged and a later access still raises `DestroyedReactiveError` — there, a stale access is a genuine bug worth surfacing.

`_weak_callback()` becomes `_weak_destroy_callback(method, session)` and no-ops when that session is closed. No new state: `AppSession._is_closed()` reads `_has_run_session_ended_tasks`, which was already set at the top of `_run_session_ended_tasks()` before any teardown callback runs. `SessionProxy` delegates to its root (module-scoped reactives are exactly the ones that need the gate, and they hold a proxy, not an `AppSession`), and `ExpressStubSession` is never closed.

## Why not keep erroring on post-close access

- **Shiny's own code depends on it.** `ExtendedTask` sets its own status when its task settles, which routinely lands after a refresh. Under the old rule `ExtendedTask` itself was in violation.
- **App authors cannot comply.** The access is usually inside `ExtendedTask` or a library, not user code, and checking "is the session still up?" before the write is TOCTOU.
- **The write was already inert.** The session's effects are destroyed at `on_ended`, and outbound messages are dropped once the connection is closed (`shiny/_connection.py:71-73`). Verified by test: an effect does not re-run on a post-close write.
- **Erroring made teardown worse**, not better — the first error aborted the continuation and left `ExtendedTask` in a bogus state.

## Tests

12 new tests in `tests/pytest/test_destroy.py`. Verified by stashing only `shiny/reactive/_reactives.py`: **9 of the 12 fail** with the exact errors from the report.

- values and calcs readable *and* writable after close, and module reactives surviving a root close
- inputs readable after close
- an effect does **not** re-run on a post-close write (soft teardown must not resurrect the session)
- values are still garbage-collectable after close (soft teardown must not pin them)
- destroy callbacks still fire on close
- explicit module `destroy()` still raises `DestroyedReactiveError`; a `destroy()` that lands after close is a no-op rather than an error
- a real `ExtendedTask` that settles after close reaches `"success"` with its result, at both root and module scope, with an asyncio exception handler asserting no orphan-task errors

The bundled `shiny-for-python` Agent Skill (`references/session-lifecycle.md`) documents `on_ended`/`destroy`, so it gains the close-vs-destroy distinction in the same PR.

Full unit suite: `976 passed, 2 skipped`. `uv run make format check-lint check-types` and `make check-pyright` are clean.

## Follow-up, out of scope

Nothing cancels the underlying `asyncio` task at session end, so an in-flight extended task still runs to completion after disconnect rather than being torn down. R leaves its promise running too, so this PR matches upstream; cancelling on close would be a separate behavior change.