### PR TITLE
fix(express): Find functions in the AST when a decorator renames them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `@expressify` and `@render.express` no longer fail with `RuntimeError: Failed to find function '...' in AST` when another decorator has changed the function's `__name__`. The AST lookup matched on `__name__`, which a decorator can rewrite; it now matches on the function's code object name, which always reflects the name at the `def` site. This pattern is commonly used to give each `@render.express` function in a loop a unique output id. (#2016)
 
+* When `@expressify` cannot locate a function's definition, the error now names the function as it appears in the source (rather than a `__name__` a decorator may have rewritten), points at the file and line it looked at, and lists the likely causes — an `async def`, a decorator below `expressify()` that returns a wrapper instead of the original function, or a source file modified after import. (#2016)
+
 ## [1.7.0] - 2026-07-28
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `shiny run --app-dir <dir> <app>` now honors `--app-dir` for Shiny Express apps. Express detection looked for the app file relative to `--app-dir`, but the entrypoint that gets handed to uvicorn was then built by resolving the app path against the current working directory instead, so running an Express app from outside its directory failed with a `FileNotFoundError` for a path that never existed. (#2419)
 
+* `@expressify` and `@render.express` no longer fail with `RuntimeError: Failed to find function '...' in AST` when another decorator has changed the function's `__name__`. The AST lookup matched on `__name__`, which a decorator can rewrite; it now matches on the function's code object name, which always reflects the name at the `def` site. This pattern is commonly used to give each `@render.express` function in a loop a unique output id. (#2016)
+
 ## [1.7.0] - 2026-07-28
 
 ### New features

--- a/shiny/express/expressify_decorator/_expressify.py
+++ b/shiny/express/expressify_decorator/_expressify.py
@@ -177,6 +177,22 @@ def expressify(
     return decorator
 
 
+def _describe_func(fn: types.FunctionType) -> str:
+    """
+    Describe a function for use in error messages.
+
+    Reports the name from the function's code object, because that -- not `__name__` --
+    is the name we search the source AST for. The two differ whenever a decorator has
+    rewritten `__name__`, and reporting only `__name__` has sent people looking for a
+    name that never appears in their source at all.
+    https://github.com/posit-dev/py-shiny/issues/2016
+    """
+    code_name = fn.__code__.co_name
+    if fn.__name__ == code_name:
+        return f"'{code_name}'"
+    return f"'{code_name}' (whose `__name__` has since been changed to '{fn.__name__}')"
+
+
 def _transform_body(
     fn: types.FunctionType,
     has_docstring: bool = False,
@@ -197,15 +213,18 @@ def _transform_body(
     filename = inspect.getsourcefile(fn)
     if filename is None:
         raise RuntimeError(
-            f"Failed to find source code for function '{fn.__name__}'."
-            " This should never happen, please file an issue!"
+            f"Failed to find the source file for function {_describe_func(fn)}."
+            " `expressify()` needs to re-read the function's source, so the function"
+            " must be defined in a file (not, say, by `exec()` or in a bare REPL)."
         )
 
     parsed_ast = read_ast(filename)
     if parsed_ast is None:
         raise RuntimeError(
-            f"Failed to read source code for function '{fn.__name__}'."
-            " This should never happen, please file an issue!"
+            f"Failed to read the source code for function {_describe_func(fn)}"
+            f" from '{filename}'."
+            " `expressify()` needs to re-read the function's source; if the file has"
+            " been moved or deleted since it was imported, that is not possible."
         )
 
     # A wrapper for _transform_function_ast that conveys the value of has_docstring.
@@ -221,8 +240,17 @@ def _transform_body(
     new_ast = tft.visit(parsed_ast)
     if not tft.found:
         raise RuntimeError(
-            f"Failed to find function '{fn.__name__}' in AST."
-            " This should never happen, please file an issue!"
+            f"Failed to find the definition of function {_describe_func(fn)} in the"
+            f" source of '{filename}'"
+            f" (looking for a `def` at line {fn.__code__.co_firstlineno})."
+            "\n\nThis can happen if:"
+            "\n* The function is an `async def`. `expressify()` can only transform"
+            " regular functions; use `@render.ui` instead of `@render.express`."
+            "\n* A decorator between the `def` and `expressify()` replaced the function"
+            " with a wrapper. Decorators applied below `expressify()` must return the"
+            " original function, not a wrapper around it."
+            "\n* The source file was modified after it was imported."
+            "\n\nIf none of these apply, please file an issue!"
         )
 
     # The new AST contains new nodes; give them locations so the compiler will
@@ -241,7 +269,8 @@ def _transform_body(
     )
     if fcode is None:
         raise RuntimeError(
-            f"Failed to find code object for function '{fn.__name__}'."
+            f"Failed to find the code object for function {_describe_func(fn)}"
+            f" after recompiling '{filename}'."
             " This should never happen, please file an issue!"
         )
 

--- a/shiny/express/expressify_decorator/_helpers.py
+++ b/shiny/express/expressify_decorator/_helpers.py
@@ -44,8 +44,16 @@ def ast_matches_func(node: ast.AST, func: FunctionType) -> bool:
     linenos = [*[dec.lineno for dec in node.decorator_list], node.lineno]
     # Compare against `co_name` rather than `__name__`: a decorator applied between the
     # `def` and `expressify()` may have changed `__name__`, but `co_name` always matches
-    # the name at the `def` site (i.e., the name in the AST).
+    # the name at the `def` site (i.e., the name in the AST). This also makes this stage
+    # consistent with the code-object comparisons in `match_name_and_lineno()` above and
+    # `compare_decorated_code_objects()`, which already key off `co_name`.
     # https://github.com/posit-dev/py-shiny/issues/2016
+    #
+    # Using `co_name` cannot introduce a mis-match: the line number is the
+    # discriminating constraint and the name is only a secondary sanity check. A `def`
+    # line and a decorator line each belong to exactly one function, so `linenos` sets
+    # are disjoint across nodes; changing which *name* is compared can't create a
+    # collision that the line numbers would not already have caught.
     return (
         func.__code__.co_firstlineno in linenos and func.__code__.co_name == node.name
     )

--- a/shiny/express/expressify_decorator/_helpers.py
+++ b/shiny/express/expressify_decorator/_helpers.py
@@ -42,4 +42,10 @@ def ast_matches_func(node: ast.AST, func: FunctionType) -> bool:
     if not isinstance(node, ast.FunctionDef):
         return False
     linenos = [*[dec.lineno for dec in node.decorator_list], node.lineno]
-    return func.__code__.co_firstlineno in linenos and func.__name__ == node.name
+    # Compare against `co_name` rather than `__name__`: a decorator applied between the
+    # `def` and `expressify()` may have changed `__name__`, but `co_name` always matches
+    # the name at the `def` site (i.e., the name in the AST).
+    # https://github.com/posit-dev/py-shiny/issues/2016
+    return (
+        func.__code__.co_firstlineno in linenos and func.__code__.co_name == node.name
+    )

--- a/tests/pytest/test_display_decorator.py
+++ b/tests/pytest/test_display_decorator.py
@@ -3,15 +3,19 @@
 from __future__ import annotations
 
 import contextlib
+import functools
 import inspect
 import sys as sys1
-from typing import Callable, Generator, cast
+from typing import Any, Callable, Generator, TypeVar, cast
 
 import pytest
 from htmltools import Tagifiable
 
 from shiny import render, ui
 from shiny.express import expressify
+from shiny.express.expressify_decorator._expressify import expressify_unwrap_inplace
+
+TFunc = TypeVar("TFunc", bound=Callable[..., Any])
 
 
 @contextlib.contextmanager
@@ -129,19 +133,28 @@ def test_duplicate_func_names_ok():
         x + " nobody"
 
 
+# ============================================================================
+# Renaming decorators (https://github.com/posit-dev/py-shiny/issues/2016)
+#
+# A common Express idiom is to generate several `@render.express` outputs in a
+# loop, using a decorator to give each one a unique `__name__` (and therefore a
+# unique output id). That decorator mutates `__name__` but leaves the code
+# object alone, so expressify must locate the `def` in the AST by the code
+# object's name rather than by `__name__`.
+# ============================================================================
+
+
+def rename(new_name: str) -> Callable[[TFunc], TFunc]:
+    """A decorator that rewrites `__name__` in place, leaving the function itself."""
+
+    def decorator(fn: TFunc) -> TFunc:
+        fn.__name__ = new_name
+        return fn
+
+    return decorator
+
+
 def test_renamed_func():
-    """
-    A decorator that changes `__name__` (without changing the code object) should not
-    prevent us from finding the function in the AST. https://github.com/posit-dev/py-shiny/issues/2016
-    """
-
-    def rename(new_name: str):
-        def decorator(fn: Callable[[], None]) -> Callable[[], None]:
-            fn.__name__ = new_name
-            return fn
-
-        return decorator
-
     @expressify()
     @rename("renamed")
     def original():
@@ -149,19 +162,235 @@ def test_renamed_func():
         2
 
     assert original.__name__ == "renamed"
+    assert original.__code__.co_name == "original"  # type: ignore[attr-defined]
 
     with capture_display() as d:
         original()
         assert d == [1, 2]
 
 
-def test_renamed_func_unwrap_inplace():
-    """Same as `test_renamed_func()`, but for the in-place variant used by
-    `@render.express`."""
-    from shiny.express.expressify_decorator._expressify import (
-        expressify_unwrap_inplace,
-    )
+def test_renamed_func_preserves_metadata():
+    @expressify(has_docstring=True)
+    @rename("renamed_with_docstring")
+    def original(x: int) -> None:
+        """A docstring that must not be displayed."""
+        x + 1
 
+    assert original.__name__ == "renamed_with_docstring"
+    assert original.__doc__ == "A docstring that must not be displayed."
+    assert original.__annotations__ == {"x": "int", "return": "None"}
+    assert inspect.getsource(original) == inspect.getsource(original.__wrapped__)  # type: ignore
+
+    with capture_display() as d:
+        original(41)
+        assert d == [42]
+
+
+def test_rename_colliding_with_another_func_name():
+    """
+    The dangerous case: the new name collides with a *different* function defined in
+    this same file. We must transform the renamed function's own body, not the
+    unrelated same-named function's body.
+    """
+
+    def decoy():
+        "decoy body should never be displayed"
+
+    @expressify()
+    @rename("decoy")
+    def real():
+        "real body"
+
+    assert real.__name__ == "decoy"
+
+    with capture_display() as d:
+        real()
+        assert d == ["real body"]
+
+    # The decoy is untouched -- it was never expressified.
+    with capture_display() as d:
+        decoy()
+        assert d == []
+
+
+def test_rename_colliding_with_an_expressified_func():
+    """Same as above, but the decoy is itself expressified, so both are in the cache."""
+
+    @expressify()
+    def twin():
+        "twin body"
+
+    @expressify()
+    @rename("twin")
+    def other():
+        "other body"
+
+    with capture_display() as d:
+        twin()
+        assert d == ["twin body"]
+
+    with capture_display() as d:
+        other()
+        assert d == ["other body"]
+
+
+def test_renamed_funcs_in_a_loop_keep_distinct_closures():
+    """
+    The exact shape of #2016: one `def` inside a loop, renamed per iteration. All
+    iterations share a single code object (and therefore a single `code_cache`
+    entry), so this also guards against the cache leaking state between them.
+    """
+    funcs: list[Callable[[], None]] = []
+
+    for label in ["a", "b", "c"]:
+
+        @expressify()
+        @rename(f"boxed_{label}")
+        def boxed(label: str = label):
+            "value for " + label
+
+        funcs.append(boxed)
+
+    assert [f.__name__ for f in funcs] == ["boxed_a", "boxed_b", "boxed_c"]
+
+    with capture_display() as d:
+        for f in funcs:
+            f()
+        assert d == ["value for a", "value for b", "value for c"]
+
+
+def test_renamed_funcs_in_a_loop_via_closure_cell():
+    """As above, but capturing the loop variable via a closure cell rather than a
+    default argument -- the pattern used in the original bug report."""
+    funcs: list[Callable[[], None]] = []
+
+    for label in ["x", "y"]:
+
+        def make(label: str) -> Callable[[], None]:
+            @expressify()
+            @rename(f"boxed_{label}")
+            def boxed():
+                "value for " + label
+
+            return boxed
+
+        funcs.append(make(label))
+
+    assert [f.__name__ for f in funcs] == ["boxed_x", "boxed_y"]
+
+    with capture_display() as d:
+        for f in funcs:
+            f()
+        assert d == ["value for x", "value for y"]
+
+
+def test_renamed_funcs_in_a_loop_share_one_cache_entry():
+    import shiny.express.expressify_decorator._expressify as _expressify
+
+    before = len(_expressify.code_cache)
+    for label in ["p", "q", "r", "s"]:
+
+        @expressify()
+        @rename(f"cached_{label}")
+        def cached():
+            label
+
+    after = len(_expressify.code_cache)
+    # One `def` site == one code object == one cache entry, regardless of renames.
+    assert after - before == 1
+
+
+def test_stacked_renames():
+    """Multiple renaming decorators between the `def` and `expressify()`."""
+
+    @expressify()
+    @rename("second")
+    @rename("first")
+    def original():
+        "body"
+
+    assert original.__name__ == "second"
+
+    with capture_display() as d:
+        original()
+        assert d == ["body"]
+
+
+def test_rename_above_expressify():
+    """Renaming *after* expressify has run is unaffected by any of this."""
+
+    @rename("renamed_after")
+    @expressify()
+    def original():
+        "body"
+
+    assert original.__name__ == "renamed_after"
+
+    with capture_display() as d:
+        original()
+        assert d == ["body"]
+
+
+def test_rename_on_nested_expressified_func():
+    """A renamed inner function still resolves its enclosing closure correctly."""
+    multiplier = 10
+
+    def outer():
+        @expressify()
+        @rename("inner_renamed")
+        def inner():
+            multiplier * 5
+
+        return inner
+
+    with capture_display() as d:
+        outer()()
+        assert d == [50]
+
+
+def test_rename_with_args_and_flow_control():
+    """Renaming must not disturb signature handling or control-flow transforms."""
+
+    @expressify()
+    @rename("renamed_variadic")
+    def variadic(*args: object, sep: str = "-", **kwargs: object):
+        for arg in args:
+            arg
+        if kwargs:
+            sep.join(sorted(kwargs))
+
+    with capture_display() as d:
+        variadic(1, 2, b="", a="")
+        assert d == [1, 2, "a-b"]
+
+    with capture_display() as d:
+        variadic(1, sep="+", z="", y="")
+        assert d == [1, "y+z"]
+
+
+def test_rename_with_implicit_output():
+    """A renamed expressify function still auto-displays inner renderers."""
+
+    @expressify()
+    @rename("renamed_outer")
+    def has_implicit_outputs():
+        @render.code
+        def foo():
+            return "hello"
+
+    with capture_display() as d:
+        has_implicit_outputs()
+        assert len(d) == 1
+        d0 = cast(Tagifiable, d[0])
+        assert str(d0.tagify()) == str(ui.output_code("foo"))
+
+
+# ----------------------------------------------------------------------------
+# expressify_unwrap_inplace() -- the variant used by `@render.express`
+# ----------------------------------------------------------------------------
+
+
+def test_renamed_func_unwrap_inplace():
     def renamed_in_place():
         1
         2
@@ -169,9 +398,146 @@ def test_renamed_func_unwrap_inplace():
     renamed_in_place.__name__ = "some_other_name"
     fn = expressify_unwrap_inplace()(renamed_in_place)
 
+    # Transforms the function in place and hands back the same object.
+    assert fn is renamed_in_place
+    assert fn.__name__ == "some_other_name"
+
     with capture_display() as d:
         fn()
         assert d == [1, 2]
+
+
+def test_unwrap_inplace_sees_through_wrapped_chain():
+    """
+    `expressify_unwrap_inplace()` follows `__wrapped__` to the real function. The
+    wrapper's `__name__` (copied by `functools.wraps`) must not be used for matching.
+    """
+
+    def target():
+        7
+        8
+
+    target.__name__ = "renamed_target"
+
+    @functools.wraps(target)
+    def wrapper():
+        return target()
+
+    fn = expressify_unwrap_inplace()(wrapper)
+
+    assert fn is wrapper
+    with capture_display() as d:
+        fn()
+        assert d == [7, 8]
+
+
+def test_unwrap_inplace_is_idempotent_with_rename():
+    def target():
+        1
+        2
+
+    target.__name__ = "renamed_twice"
+    once = expressify_unwrap_inplace()(target)
+    twice = expressify_unwrap_inplace()(once)
+
+    assert twice is target
+    # Applying twice must not double-wrap the displayhook calls.
+    with capture_display() as d:
+        twice()
+        assert d == [1, 2]
+
+
+# ----------------------------------------------------------------------------
+# @render.express -- the end-to-end path from the bug report
+# ----------------------------------------------------------------------------
+
+
+def test_render_express_renamed_outputs_get_distinct_ids():
+    """
+    The user-visible payoff of #2016: renaming yields one output id per loop
+    iteration, instead of every iteration colliding on the same id.
+    """
+    labels = ["human_animal", "environmental"]
+    renderers: list[render.express] = []
+
+    for label in labels:
+        # A factory so each output captures its own `label` in a closure cell
+        # (rather than a default arg, which `@render.express` warns about).
+        def make(label: str) -> render.express:
+            @render.express
+            @rename(f"docs_label_{label}")
+            def docs_label():
+                "count for " + label
+
+            return docs_label
+
+        renderers.append(make(label))
+
+    assert [r.output_id for r in renderers] == [
+        "docs_label_human_animal",
+        "docs_label_environmental",
+    ]
+    assert [r.__name__ for r in renderers] == [
+        "docs_label_human_animal",
+        "docs_label_environmental",
+    ]
+
+    # And each renders its own value rather than sharing one.
+    for r, label in zip(renderers, labels):
+        with capture_display() as d:
+            r.fn._orig_fn()  # type: ignore[attr-defined]
+            assert d == ["count for " + label]
+
+
+# ----------------------------------------------------------------------------
+# Documented limitations (pinned so any change here is deliberate)
+# ----------------------------------------------------------------------------
+
+
+def test_expressify_async_is_unsupported():
+    """
+    `ast_matches_func()` only matches `ast.FunctionDef`, never `ast.AsyncFunctionDef`,
+    so `@expressify` cannot transform an async function. This is pre-existing behavior
+    -- `@render.express` rejects async functions up front with a clearer message.
+    """
+    with pytest.raises(RuntimeError, match="Failed to find function"):
+
+        @expressify()
+        async def async_fn():
+            1
+
+    with pytest.raises(TypeError, match="does not support async functions"):
+
+        @render.express
+        async def async_out():
+            1
+
+
+def test_expressify_cannot_see_through_a_wrapper_below_it():
+    """
+    When a *wrapping* decorator sits between the `def` and `expressify()`, the
+    function handed to expressify is the wrapper. Expressify transforms the wrapper's
+    body (which has no expressions of its own), so the inner function's expressions
+    are not captured. Renaming decorators work because they return the original
+    function; wrapping decorators do not.
+    """
+
+    def wrapping(fn: TFunc) -> TFunc:
+        @functools.wraps(fn)
+        def wrapper(*args: object, **kwargs: object):
+            return fn(*args, **kwargs)
+
+        return cast(TFunc, wrapper)
+
+    @expressify()
+    @wrapping
+    def wrapped():
+        1
+        2
+
+    with capture_display() as d:
+        wrapped()
+        assert d == []
 
 
 def test_not_decorated():

--- a/tests/pytest/test_display_decorator.py
+++ b/tests/pytest/test_display_decorator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import contextlib
 import inspect
 import sys as sys1
-from typing import Generator, cast
+from typing import Callable, Generator, cast
 
 import pytest
 from htmltools import Tagifiable
@@ -127,6 +127,51 @@ def test_duplicate_func_names_ok():
     @expressify()
     def inner():
         x + " nobody"
+
+
+def test_renamed_func():
+    """
+    A decorator that changes `__name__` (without changing the code object) should not
+    prevent us from finding the function in the AST. https://github.com/posit-dev/py-shiny/issues/2016
+    """
+
+    def rename(new_name: str):
+        def decorator(fn: Callable[[], None]) -> Callable[[], None]:
+            fn.__name__ = new_name
+            return fn
+
+        return decorator
+
+    @expressify()
+    @rename("renamed")
+    def original():
+        1
+        2
+
+    assert original.__name__ == "renamed"
+
+    with capture_display() as d:
+        original()
+        assert d == [1, 2]
+
+
+def test_renamed_func_unwrap_inplace():
+    """Same as `test_renamed_func()`, but for the in-place variant used by
+    `@render.express`."""
+    from shiny.express.expressify_decorator._expressify import (
+        expressify_unwrap_inplace,
+    )
+
+    def renamed_in_place():
+        1
+        2
+
+    renamed_in_place.__name__ = "some_other_name"
+    fn = expressify_unwrap_inplace()(renamed_in_place)
+
+    with capture_display() as d:
+        fn()
+        assert d == [1, 2]
 
 
 def test_not_decorated():

--- a/tests/pytest/test_display_decorator.py
+++ b/tests/pytest/test_display_decorator.py
@@ -13,7 +13,10 @@ from htmltools import Tagifiable
 
 from shiny import render, ui
 from shiny.express import expressify
-from shiny.express.expressify_decorator._expressify import expressify_unwrap_inplace
+from shiny.express.expressify_decorator._expressify import (
+    _describe_func,
+    expressify_unwrap_inplace,
+)
 
 TFunc = TypeVar("TFunc", bound=Callable[..., Any])
 
@@ -500,7 +503,7 @@ def test_expressify_async_is_unsupported():
     so `@expressify` cannot transform an async function. This is pre-existing behavior
     -- `@render.express` rejects async functions up front with a clearer message.
     """
-    with pytest.raises(RuntimeError, match="Failed to find function"):
+    with pytest.raises(RuntimeError, match="Failed to find the definition of function"):
 
         @expressify()
         async def async_fn():
@@ -511,6 +514,61 @@ def test_expressify_async_is_unsupported():
         @render.express
         async def async_out():
             1
+
+
+# ----------------------------------------------------------------------------
+# Error message diagnostics
+# ----------------------------------------------------------------------------
+
+
+def test_describe_func_reports_code_name():
+    def target():
+        pass
+
+    assert _describe_func(target) == "'target'"
+
+    target.__name__ = "renamed"
+    described = _describe_func(target)
+    # Both names must appear: the one we search the AST for, and the one the user sees.
+    assert "'target'" in described
+    assert "'renamed'" in described
+
+
+def test_ast_lookup_failure_message_is_actionable():
+    """
+    The message must name the function as it appears in the *source* (its code-object
+    name), not `__name__`, and must point at the file and line. Reporting only
+    `__name__` sent the reporter of #2016 looking for a name that was never in the AST.
+    """
+    with pytest.raises(RuntimeError) as excinfo:
+
+        @expressify()
+        @rename("name_that_is_not_in_the_source")
+        async def real_source_name():
+            1
+
+    msg = str(excinfo.value)
+
+    # Identifies the function by the name actually present in the source...
+    assert "'real_source_name'" in msg
+    # ...while still mentioning the renamed `__name__`, so the user can connect it
+    # back to the decorator they wrote.
+    assert "name_that_is_not_in_the_source" in msg
+    # Locates the definition.
+    assert __file__ in msg or "test_display_decorator.py" in msg
+    assert "line " in msg
+    # And explains the likely causes rather than only "please file an issue".
+    assert "async def" in msg
+    assert "wrapper" in msg
+
+
+def test_missing_source_file_message():
+    """A function with no source file on disk cannot be expressified."""
+    ns: dict[str, Any] = {}
+    exec("def no_source():\n    1\n", ns)
+
+    with pytest.raises(RuntimeError, match="Failed to (find|read) the source"):
+        expressify()(ns["no_source"])
 
 
 def test_expressify_cannot_see_through_a_wrapper_below_it():

--- a/tests/pytest/test_expressify_helpers.py
+++ b/tests/pytest/test_expressify_helpers.py
@@ -1,0 +1,248 @@
+# pyright: reportUnusedExpression=false
+# flake8: noqa
+"""
+Direct unit tests for the AST/code-object matching helpers that back
+`@expressify` and `@render.express`.
+
+These helpers are how expressify locates the `def` for a function in its source
+file so it can re-transform the body. The matching rule is intentionally narrow
+(name + line number), so these tests pin down exactly which nodes do and do not
+match.
+"""
+
+from __future__ import annotations
+
+import ast
+import types
+from typing import Any
+
+from shiny.express.expressify_decorator._helpers import (
+    ast_matches_func,
+    find_code_for_func,
+    match_name_and_lineno,
+)
+
+# ----------------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------------
+
+FILENAME = "<test-src>"
+
+
+def compile_src(src: str) -> tuple[dict[str, Any], ast.Module]:
+    """
+    Compile a source string, returning both the resulting namespace and the parsed
+    AST. Because both come from the same source text, line numbers in the AST line
+    up with `co_firstlineno` of the resulting code objects -- which is precisely the
+    invariant that `ast_matches_func()` relies on.
+    """
+    tree = ast.parse(src, filename=FILENAME)
+    ns: dict[str, Any] = {}
+    exec(compile(tree, FILENAME, "exec"), ns)
+    return ns, tree
+
+
+def find_node(tree: ast.AST, name: str, *, nth: int = 0) -> ast.FunctionDef:
+    """Find the `nth` FunctionDef named `name`."""
+    matches = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == name
+    ]
+    return matches[nth]
+
+
+def rename(fn: Any, new_name: str) -> Any:
+    """Mimic a decorator that rewrites `__name__` without touching the code object."""
+    fn.__name__ = new_name
+    return fn
+
+
+# ----------------------------------------------------------------------------
+# ast_matches_func: the happy path
+# ----------------------------------------------------------------------------
+
+
+def test_matches_plain_def():
+    ns, tree = compile_src("def foo():\n    pass\n")
+    assert ast_matches_func(find_node(tree, "foo"), ns["foo"])
+
+
+def test_matches_def_with_decorators():
+    """
+    `co_firstlineno` may point at the first decorator line or at the `def` line,
+    depending on how the code was compiled. Both must match.
+    """
+    src = "def deco(f):\n    return f\n\n\n@deco\n@deco\ndef foo():\n    pass\n"
+    ns, tree = compile_src(src)
+    node = find_node(tree, "foo")
+
+    # Sanity check that this source really does have two decorators above `def`.
+    assert len(node.decorator_list) == 2
+    assert [d.lineno for d in node.decorator_list] == [5, 6]
+    assert node.lineno == 7
+
+    assert ast_matches_func(node, ns["foo"])
+
+    # Both the decorator lines and the `def` line are accepted.
+    for lineno in (5, 6, 7):
+        fake = types.FunctionType(
+            ns["foo"].__code__.replace(co_firstlineno=lineno), {}, "foo"
+        )
+        assert ast_matches_func(node, fake), f"lineno {lineno} should match"
+
+
+# ----------------------------------------------------------------------------
+# ast_matches_func: renamed functions (the regression this guards -- #2016)
+# ----------------------------------------------------------------------------
+
+
+def test_matches_when_dunder_name_was_rewritten():
+    """
+    A decorator applied between the `def` and `expressify()` may rewrite
+    `__name__`. Matching must key off the code object's name, which always
+    reflects the name at the `def` site. https://github.com/posit-dev/py-shiny/issues/2016
+    """
+    ns, tree = compile_src("def foo():\n    pass\n")
+    fn = rename(ns["foo"], "foo_renamed")
+
+    assert fn.__name__ == "foo_renamed"
+    assert fn.__code__.co_name == "foo"
+    assert ast_matches_func(find_node(tree, "foo"), fn)
+
+
+def test_rename_does_not_match_the_colliding_def():
+    """
+    The nastiest case: a function is renamed to the name of a *different* function
+    in the same file. We must match the renamed function's own `def`, and must not
+    match the unrelated function that happens to share the new name.
+    """
+    src = "def other():\n    pass\n\n\ndef foo():\n    pass\n"
+    ns, tree = compile_src(src)
+    fn = rename(ns["foo"], "other")
+
+    assert ast_matches_func(find_node(tree, "foo"), fn)
+    assert not ast_matches_func(find_node(tree, "other"), fn)
+
+
+def test_rename_to_empty_or_odd_names_still_matches_own_def():
+    ns, tree = compile_src("def foo():\n    pass\n")
+    for new_name in ("", "  ", "foo.bar", "<lambda>", "foo" * 100):
+        fn = rename(ns["foo"], new_name)
+        assert ast_matches_func(find_node(tree, "foo"), fn)
+
+
+# ----------------------------------------------------------------------------
+# ast_matches_func: things that must NOT match
+# ----------------------------------------------------------------------------
+
+
+def test_does_not_match_different_function():
+    src = "def foo():\n    pass\n\n\ndef bar():\n    pass\n"
+    ns, tree = compile_src(src)
+    assert not ast_matches_func(find_node(tree, "bar"), ns["foo"])
+    assert not ast_matches_func(find_node(tree, "foo"), ns["bar"])
+
+
+def test_same_name_different_lines_match_only_their_own_def():
+    """Two same-named defs are disambiguated purely by line number."""
+    src = (
+        "def make():\n"
+        "    def inner():\n"
+        "        return 1\n"
+        "    return inner\n"
+        "\n"
+        "def make2():\n"
+        "    def inner():\n"
+        "        return 2\n"
+        "    return inner\n"
+        "\n"
+        "a = make()\n"
+        "b = make2()\n"
+    )
+    ns, tree = compile_src(src)
+    node_a = find_node(tree, "inner", nth=0)
+    node_b = find_node(tree, "inner", nth=1)
+
+    assert ast_matches_func(node_a, ns["a"])
+    assert not ast_matches_func(node_b, ns["a"])
+    assert ast_matches_func(node_b, ns["b"])
+    assert not ast_matches_func(node_a, ns["b"])
+
+
+def test_does_not_match_non_functiondef_nodes():
+    ns, tree = compile_src("class Foo:\n    pass\n\n\ndef foo():\n    pass\n")
+    fn = ns["foo"]
+
+    class_node = next(n for n in ast.walk(tree) if isinstance(n, ast.ClassDef))
+    assert not ast_matches_func(tree, fn)
+    assert not ast_matches_func(class_node, fn)
+
+
+def test_does_not_match_async_functiondef():
+    """
+    `ast.AsyncFunctionDef` is not an `ast.FunctionDef`, so async defs never match.
+    This is why `@expressify` does not support async functions; see
+    `test_expressify_async_is_unsupported()` in test_display_decorator.py.
+    """
+    ns, tree = compile_src("async def foo():\n    pass\n")
+    async_node = next(n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef))
+    assert not ast_matches_func(async_node, ns["foo"])
+
+
+# ----------------------------------------------------------------------------
+# find_code_for_func / match_name_and_lineno
+# ----------------------------------------------------------------------------
+
+
+def test_find_code_for_func_finds_nested_code():
+    src = (
+        "def outer():\n"
+        "    def middle():\n"
+        "        def inner():\n"
+        "            return 42\n"
+        "        return inner\n"
+        "    return middle\n"
+        "inner = outer()()\n"
+    )
+    ns, tree = compile_src(src)
+    module_code = compile(tree, FILENAME, "exec")
+
+    found = find_code_for_func(module_code, ns["inner"])
+    assert found is not None
+    assert found.co_name == "inner"
+    assert found is not ns["inner"].__code__  # a distinct but matching code object
+    assert found.co_firstlineno == ns["inner"].__code__.co_firstlineno
+
+
+def test_find_code_for_func_uses_code_name_not_dunder_name():
+    """Renaming must not confuse the code-object search either."""
+    ns, tree = compile_src("def foo():\n    return 1\n")
+    module_code = compile(tree, FILENAME, "exec")
+    fn = rename(ns["foo"], "totally_different")
+
+    found = find_code_for_func(module_code, fn)
+    assert found is not None
+    assert found.co_name == "foo"
+
+
+def test_find_code_for_func_returns_none_when_absent():
+    ns, _ = compile_src("def foo():\n    return 1\n")
+    other_code = compile("def bar():\n    return 2\n", FILENAME, "exec")
+    assert find_code_for_func(other_code, ns["foo"]) is None
+
+
+def test_find_code_for_func_ignores_non_code_input():
+    ns, _ = compile_src("def foo():\n    return 1\n")
+    assert find_code_for_func("not code", ns["foo"]) is None  # type: ignore[arg-type]
+
+
+def test_match_name_and_lineno():
+    ns, _ = compile_src("def foo():\n    return 1\n")
+    code = ns["foo"].__code__
+
+    assert match_name_and_lineno(code, code)
+    assert not match_name_and_lineno(code.replace(co_name="bar"), code)
+    assert not match_name_and_lineno(
+        code.replace(co_firstlineno=code.co_firstlineno + 1), code
+    )


### PR DESCRIPTION
Fixes #2016.

## The bug

Express apps commonly generate several `@render.express` outputs in a loop, using a decorator to give each one a unique `__name__` (and therefore a unique output id):

```python
for label_name, label_ui in class_labels:
    with ui.value_box(showcase=ICONS[label_name]):
        @render.express
        @extend_name(f"_{label_name}")   # mutates fn.__name__
        def docs_label(): ...
```

This crashed with:

```
RuntimeError: Failed to find function 'docs_label_human_animal' in AST.
This should never happen, please file an issue!
```

## Root cause

`ast_matches_func()` located a function's `def` in its source AST by matching line number **and** `func.__name__`. But `__name__` is a mutable attribute that is merely *initialized* from the code object's name — any decorator can rewrite it. The AST node still says `docs_label` while `__name__` now says `docs_label_human_animal`, so nothing matched.

Notably, the two *downstream* stages of the same lookup (`match_name_and_lineno()` and `compare_decorated_code_objects()`) already keyed off `co_name`. Only the AST stage used `__name__` — a pre-existing inconsistency that the renaming decorator made observable.

## The fix

Match on `func.__code__.co_name`, which is fixed at compile time and always equals the name at the `def` site. One-line semantic change, plus a comment recording why it can't introduce a mis-match: the line number is the discriminating constraint and the name is only a secondary sanity check. A `def` line and a decorator line each belong to exactly one function, so `linenos` sets are disjoint across nodes.

## Diagnostics

The old message pointed users at a name that appeared nowhere in their source. Errors now report the code-object name (plus `__name__` when the two differ), name the file and line searched, and list likely causes:

```
Failed to find the definition of function 'real_source_name' (whose `__name__` has
since been changed to 'name_that_is_not_in_the_source') in the source of
'/path/app.py' (looking for a `def` at line 18).

This can happen if:
* The function is an `async def`. `expressify()` can only transform regular
  functions; use `@render.ui` instead of `@render.express`.
* A decorator between the `def` and `expressify()` replaced the function with a
  wrapper. Decorators applied below `expressify()` must return the original
  function, not a wrapper around it.
* The source file was modified after it was imported.

If none of these apply, please file an issue!
```

"This should never happen" is now reserved for the one lookup that genuinely shouldn't fail.

## Tests

30 new tests (11 → 41 across the two files). Rather than only checking that they pass, I reverted the helper to its pre-fix version and re-ran: **19 of the 30 fail against the old code**; the rest pin pre-existing behavior. All 11 original tests pass before and after, confirming no regression.

`tests/pytest/test_expressify_helpers.py` (new) — direct unit tests of `ast_matches_func()`, `find_code_for_func()`, `match_name_and_lineno()`: happy path, `co_firstlineno` pointing at either a decorator line or the `def` line, renames, same-name/different-line disambiguation, non-`FunctionDef` nodes.

`tests/pytest/test_display_decorator.py` — integration via `@expressify`, `expressify_unwrap_inplace()`, and `@render.express`. The ones that matter most for confidence:

- `test_rename_colliding_with_another_func_name` / `test_rename_does_not_match_the_colliding_def` — rename a function *onto the name of a different function in the same file* and assert we match the renamed function's own `def`, never the same-named decoy.
- `test_renamed_funcs_in_a_loop_keep_distinct_closures` — the issue's exact shape; each output renders its own value.
- `test_renamed_funcs_in_a_loop_share_one_cache_entry` — N renames of one `def` site produce exactly one `code_cache` entry. A cache bug here would make every value box show the same number, which is the user-visible symptom.
- `test_render_express_renamed_outputs_get_distinct_ids` — end-to-end: distinct `output_id`s, not one colliding id.

## Two known limitations, pinned rather than redesigned

Both are pre-existing design gaps in the parse-recompile-relocate mechanism, not things this fix should redesign. I pinned them in tests so any future change is deliberate:

- `test_expressify_async_is_unsupported` — `@expressify` cannot transform an `async def` (`ast_matches_func` only matches `ast.FunctionDef`). `@render.express` is unaffected; it rejects async up front with a clear `TypeError`. Probably deserves its own issue.
- `test_expressify_cannot_see_through_a_wrapper_below_it` — when a *wrapping* decorator sits between the `def` and `expressify()`, the function handed to expressify is the wrapper, so the inner body isn't captured. This is the one case where my change alters behavior: it was a misleading crash, now it's a silent no-op. `co_name` matching is correct here (it does identify the wrapper), but a silent no-op is worse to debug, so the new error text names wrapping decorators as a likely cause. I deliberately avoided a `__wrapped__`-based heuristic, which would catch `functools.wraps` decorators and miss hand-rolled ones — a half-guarantee that invites future confusion. Happy to revisit if you'd prefer a hard error.

## Verification

- 999 unit tests pass, 2 skipped.
- `uv run make format check-lint check-types` and `make check-pyright` clean (0 errors).
- Ran the issue's reproducer as a real Express app: renders two distinct outputs, `docs_label_a` and `docs_label_b`.
