### PR TITLE
fix(build): Exclude nested api-examples and __pycache__ from the wheel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* The wheel no longer ships `shiny/experimental/api-examples/`. These files are only read when building the documentation, and the exclusion pattern that already dropped the top-level `shiny/api-examples/` tree did not reach nested ones. (#2436)
+
+* The wheel no longer ships `__pycache__` directories. The package-data glob matched them, so building a wheel from a working tree that had been imported added a few hundred `.pyc` files whose contents varied by machine. (#2436)
+
 * Closing a session no longer destroys the reactive values and calcs created in it, so async work that outlives the connection does not error. Since v1.6.1, refreshing the page while an `@reactive.extended_task` (or any `asyncio` task) was in flight could raise `DestroyedReactiveError: Reactive value '<name>' has been destroyed.` once it settled, leaving the task in neither `"success"` nor `"error"`. Values and calcs are now left readable at their last value on close and reclaimed by garbage collection, while an explicit `session.destroy(id)` on a live session still tears them down. Effects are still destroyed on close. (#2428)
 
 * The `ui.Theme` API reference examples now run in Shinylive. Compiling a customized theme requires `libsass`, but Shinylive only auto-loads packages it finds in an app's top-level imports and `Theme.to_css()` imports `sass` lazily, so the examples died with an `ImportError`. The example directory now declares `libsass` in a `requirements.txt`. (#2387)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
-* The wheel no longer ships `shiny/experimental/api-examples/`. These files are only read when building the documentation, and the exclusion pattern that already dropped the top-level `shiny/api-examples/` tree did not reach nested ones. (#2436)
-
-* The wheel no longer ships `__pycache__` directories. The package-data glob matched them, so building a wheel from a working tree that had been imported added a few hundred `.pyc` files whose contents varied by machine. (#2436)
-
 * Closing a session no longer destroys the reactive values and calcs created in it, so async work that outlives the connection does not error. Since v1.6.1, refreshing the page while an `@reactive.extended_task` (or any `asyncio` task) was in flight could raise `DestroyedReactiveError: Reactive value '<name>' has been destroyed.` once it settled, leaving the task in neither `"success"` nor `"error"`. Values and calcs are now left readable at their last value on close and reclaimed by garbage collection, while an explicit `session.destroy(id)` on a live session still tears them down. Effects are still destroyed on close. (#2428)
 
 * The `ui.Theme` API reference examples now run in Shinylive. Compiling a customized theme requires `libsass`, but Shinylive only auto-loads packages it finds in an app's top-level imports and `Theme.to_css()` imports `sass` lazily, so the examples died with an `ImportError`. The example directory now declares `libsass` in a `requirements.txt`. (#2387)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,10 @@ test = [
     "pytest-cov",
     "coverage",
     "syrupy>=5.5.1",
+    # tests/pytest/test_packaging.py builds a wheel to check its contents.
+    # `[build-system].requires` only guarantees setuptools inside an isolated
+    # PEP 517 build, and shiny itself requires it at runtime only on 3.12+.
+    "setuptools>=77",
     "psutil",
     "astropy",
     "suntime",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,16 @@ include = ["shiny*"]
 # instead shipped as data files via the package-data globs above.
 namespaces = false
 
+# Keep files the `package-data` globs above sweep up out of the wheel: the
+# `api-examples/` trees are only read when building the docs (`@add_example()`).
+# Guarded by tests/pytest/test_packaging.py.
 [tool.setuptools.exclude-package-data]
-"*" = ["api-examples/**"]
+"*" = [
+    "api-examples/**",
+    "**/api-examples/**",
+    "__pycache__/**",
+    "**/__pycache__/**",
+]
 
 [tool.setuptools_scm]
 write_to = "shiny/_version.py"

--- a/tests/pytest/test_packaging.py
+++ b/tests/pytest/test_packaging.py
@@ -19,6 +19,7 @@ agrees with itself.
 
 from __future__ import annotations
 
+import importlib.util
 import os
 import re
 import shutil
@@ -46,9 +47,35 @@ WHEEL_FILE_COUNT_MIN = 850
 WHEEL_FILE_COUNT_MAX = 1100
 
 
+def unbuildable_reason() -> str | None:
+    """Why the *installed* toolchain cannot build a wheel, or None if it can.
+
+    These tests build with the current environment rather than through an
+    isolated PEP 517 build, so they stay offline and fast. The cost is that
+    they depend on what happens to be installed, which is not the toolchain a
+    real build would provision.
+    """
+    if importlib.util.find_spec("setuptools") is None:
+        return "setuptools is not installed"
+    if importlib.util.find_spec("packaging.licenses") is None:
+        # setuptools>=77 canonicalizes this project's PEP 639 `license = "MIT"`
+        # expression through `packaging.licenses`, added in packaging 24.2.
+        return "the installed `packaging` predates 24.2"
+    return None
+
+
 @pytest.fixture(scope="session")
 def wheel_names(tmp_path_factory: pytest.TempPathFactory) -> list[str]:
     """Names of every entry in a freshly built wheel."""
+    reason = unbuildable_reason()
+    if reason is not None:
+        pytest.skip(
+            f"Cannot build a wheel here: {reason}. A real build gets its "
+            "requirements from an isolated PEP 517 environment, so this only "
+            "limits where the packaging guards run, not whether the published "
+            "wheel is correct."
+        )
+
     build_root = tmp_path_factory.mktemp("wheel")
     src = build_root / "src"
     outdir = build_root / "dist"

--- a/tests/pytest/test_packaging.py
+++ b/tests/pytest/test_packaging.py
@@ -1,45 +1,103 @@
-"""Guard that bundled Agent Skills stay covered by the wheel packaging globs.
+"""Guard what the built wheel actually contains.
 
-Agent Skills ship as package data under ``shiny/.agents/skills/`` (the
-library-skills convention). Because ``**`` in setuptools package-data globs does
-not match hidden directories, the ``.agents`` tree needs its own glob in
-``pyproject.toml`` -- and nothing at build time fails if that glob is dropped,
-the files just silently disappear from the wheel. These tests replicate
-setuptools' matching (``glob.glob(os.path.join(src_dir, pattern),
-recursive=True)`` in ``setuptools.command.build_py``) against the declared
-patterns so a regression fails loudly here instead.
+The packaging globs in ``pyproject.toml`` can go wrong in two directions, and
+neither one fails the build:
+
+* Files that *should* ship stop matching. Agent Skills live under
+  ``shiny/.agents/skills/`` (the library-skills convention), and ``**`` in a
+  setuptools package-data glob does not match hidden directories, so the
+  ``.agents`` tree needs its own pattern. Drop it and the skills silently
+  vanish from the wheel.
+* Files that should *not* ship start matching. ``api-examples/`` trees are only
+  read when building the docs, and every extra file costs deploy time on
+  platforms that pay a per-file latency (posit-dev/py-shiny#2125).
+
+So these tests build a real wheel and read its contents, rather than
+reimplementing setuptools' glob matching -- a reimplementation only proves it
+agrees with itself.
 """
 
 from __future__ import annotations
 
-import glob
 import os
 import re
+import shutil
+import subprocess
+import sys
+import zipfile
 from pathlib import Path
 from typing import cast
 
 import pytest
-
-tomllib = pytest.importorskip("tomllib")  # Stdlib in Python 3.11+
 
 REPO_ROOT = Path(__file__).parents[2]
 PACKAGE_DIR = REPO_ROOT / "shiny"
 SKILLS_DIR = PACKAGE_DIR / ".agents" / "skills"
 ROUTER_SKILL_DIR = SKILLS_DIR / "shiny-for-python"
 
+# Bounds on the number of files in the wheel, as a tripwire for packaging
+# changes that add or drop files wholesale. As of #2435 the wheel holds ~975
+# files. The ceiling keeps #2125 from regressing (before the `api-examples`
+# exclusions the wheel held ~1490); the floor catches a broken include glob
+# dropping an asset tree. Moving either bound is fine -- do it deliberately,
+# after checking `sorted(Counter(n.split("/")[1] for n in names).items())` for
+# what changed.
+WHEEL_FILE_COUNT_MIN = 850
+WHEEL_FILE_COUNT_MAX = 1100
 
-def package_data_files() -> set[Path]:
-    """Files shipped as `shiny` package data, per pyproject.toml globs."""
-    with open(REPO_ROOT / "pyproject.toml", "rb") as f:
-        pyproject = tomllib.load(f)
-    patterns: list[str] = pyproject["tool"]["setuptools"]["package-data"]["shiny"]
 
-    matched: set[Path] = set()
-    for pattern in patterns:
-        for match in glob.glob(os.path.join(str(PACKAGE_DIR), pattern), recursive=True):
-            if os.path.isfile(match):
-                matched.add(Path(match))
-    return matched
+@pytest.fixture(scope="session")
+def wheel_names(tmp_path_factory: pytest.TempPathFactory) -> list[str]:
+    """Names of every entry in a freshly built wheel."""
+    build_root = tmp_path_factory.mktemp("wheel")
+    src = build_root / "src"
+    outdir = build_root / "dist"
+
+    # Build from a copy rather than the repo itself: setuptools writes to a
+    # `build/` directory beside the sources, so building in place both litters
+    # the working tree and races when pytest-xdist runs this fixture in several
+    # workers at once. `__pycache__` is copied along deliberately -- the wheel
+    # must not pick it up, and that is one of the things under test.
+    src.mkdir()
+    shutil.copytree(PACKAGE_DIR, src / "shiny", symlinks=True)
+    for name in ("pyproject.toml", "MANIFEST.in", "LICENSE", "README.md"):
+        shutil.copyfile(REPO_ROOT / name, src / name)
+
+    # Plant bytecode so `test_bytecode_is_not_shipped_in_the_wheel` has
+    # something to catch. A real `__pycache__` only exists once something has
+    # imported `shiny` from the source tree, which makes the guard fire or not
+    # depending on what else ran first.
+    pycache = src / "shiny" / "__pycache__"
+    pycache.mkdir(exist_ok=True)
+    (pycache / "_packaging_test_sentinel.cpython-000.pyc").write_bytes(b"")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; from setuptools import build_meta; "
+            "print(build_meta.build_wheel(sys.argv[1]))",
+            str(outdir),
+        ],
+        cwd=src,
+        capture_output=True,
+        text=True,
+        # The copy has no `.git`, so setuptools_scm cannot derive a version.
+        # The value is irrelevant here; only the file list matters.
+        env={**os.environ, "SETUPTOOLS_SCM_PRETEND_VERSION": "0.0.0"},
+    )
+    if result.returncode != 0:
+        pytest.fail(f"Could not build the wheel:\n{result.stdout}\n{result.stderr}")
+
+    wheels = list(outdir.glob("*.whl"))
+    assert len(wheels) == 1, f"Expected exactly one wheel, got {wheels}"
+    with zipfile.ZipFile(wheels[0]) as zf:
+        return zf.namelist()
+
+
+def shipped_files(wheel_names: list[str]) -> set[Path]:
+    """Repo paths of the `shiny/...` files present in the wheel."""
+    return {REPO_ROOT / name for name in wheel_names if name.startswith("shiny/")}
 
 
 def skill_dirs() -> list[Path]:
@@ -56,15 +114,67 @@ def test_every_skill_has_a_skill_md() -> None:
         assert (skill_dir / "SKILL.md").is_file(), f"{skill_dir} is missing SKILL.md"
 
 
-def test_skill_files_are_covered_by_package_data_globs() -> None:
-    shipped = package_data_files()
+def test_skill_files_are_shipped_in_the_wheel(wheel_names: list[str]) -> None:
+    shipped = shipped_files(wheel_names)
     skill_files = [p for p in SKILLS_DIR.rglob("*") if p.is_file()]
     assert len(skill_files) > 0
-    missing = [p for p in skill_files if p not in shipped]
+    missing = sorted(
+        str(p.relative_to(REPO_ROOT)) for p in skill_files if p not in shipped
+    )
     assert not missing, (
         "Files under shiny/.agents/ are not matched by any "
-        "[tool.setuptools.package-data] glob in pyproject.toml and would be "
+        "[tool.setuptools.package-data] glob in pyproject.toml and were "
         f"silently dropped from the wheel: {missing}"
+    )
+
+
+def test_api_examples_are_not_shipped_in_the_wheel(wheel_names: list[str]) -> None:
+    # `api-examples/` trees exist for `@add_example()` when building the docs.
+    # Shipping them adds hundreds of files to the wheel, which slows down
+    # deployments that pay a per-file cost. Every such tree must be excluded,
+    # including nested ones like `shiny/experimental/api-examples/`, which the
+    # top-level `api-examples/**` pattern does not reach.
+    example_dirs = [p for p in PACKAGE_DIR.rglob("api-examples") if p.is_dir()]
+    assert example_dirs, "no api-examples directories found -- did they move?"
+
+    shipped = shipped_files(wheel_names)
+    leaked = sorted(
+        str(p.relative_to(REPO_ROOT))
+        for d in example_dirs
+        for p in d.rglob("*")
+        if p.is_file() and p in shipped
+    )
+    assert not leaked, (
+        f"{len(leaked)} api-examples files are not matched by any "
+        "[tool.setuptools.exclude-package-data] pattern in pyproject.toml and "
+        f"shipped in the wheel: {leaked[:10]}"
+    )
+
+
+def test_bytecode_is_not_shipped_in_the_wheel(wheel_names: list[str]) -> None:
+    # The `shiny = ["**"]` package-data glob matches `__pycache__` too, so
+    # without an exclusion the wheel's contents depend on whatever bytecode
+    # happens to sit in the tree at build time -- hundreds of files, and a
+    # different set on every machine.
+    leaked = sorted(
+        name
+        for name in wheel_names
+        if name.endswith(".pyc") or "/__pycache__/" in f"/{name}"
+    )
+    assert (
+        not leaked
+    ), f"{len(leaked)} compiled bytecode files shipped in the wheel: {leaked[:10]}"
+
+
+def test_wheel_file_count_stays_within_bounds(wheel_names: list[str]) -> None:
+    count = len(wheel_names)
+    assert WHEEL_FILE_COUNT_MIN <= count <= WHEEL_FILE_COUNT_MAX, (
+        f"The wheel holds {count} files, outside the expected range of "
+        f"{WHEEL_FILE_COUNT_MIN}-{WHEEL_FILE_COUNT_MAX}. A packaging glob "
+        "likely started matching a tree it should not (file count drives "
+        "deploy time on platforms that pay a per-file latency) or stopped "
+        "matching one it should. If the change is intended, update the bounds "
+        "in this file."
     )
 
 


### PR DESCRIPTION
Part of #2125.

## What

Two categories of extraneous files were shipping in the wheel.

**Nested `api-examples/`.** setuptools matches `exclude-package-data` patterns relative to each *package* directory, and `shiny` is the only package carrying data-file globs — so `api-examples/**` never reached `shiny/experimental/api-examples/`. One file leaked.

**`__pycache__`.** The `shiny = ["**"]` include glob matches it. Building a wheel from a working tree that had been imported produced **1303 files instead of 974** — 329 machine-specific `.pyc` files. CI builds from fresh checkouts, so released wheels were most likely unaffected, but that was luck rather than design.

## Tests

`tests/pytest/test_packaging.py` previously reimplemented setuptools' glob matching in Python and asserted against that model — which only proves the model agrees with itself, not that the wheel is clean. It now **builds a real wheel and reads its contents** (~3.4s, no network, built from a temp copy so it neither writes into the repo nor races under `pytest-xdist`).

It asserts that the bundled Agent Skills ship, that `api-examples` and bytecode do not, and that the total file count stays within bounds. The count bound has a **floor as well as a ceiling**: the ceiling guards against regressing #2125, the floor catches the opposite failure where a broken include glob silently drops an asset tree.

Each guard was mutation-tested rather than assumed to fire:

| mutation | caught by |
|---|---|
| drop `**/api-examples/**` | api-examples test — names the exact leaked file |
| drop `__pycache__` patterns | bytecode test **and** count test (1303 > 1100) |
| drop all exclusions | api-examples + bytecode tests |

The bytecode guard plants a sentinel `.pyc` into the copied tree so it fires deterministically, rather than depending on whether the working tree happens to have a `__pycache__`.

## Note on the issue

#2125 reports 1300+ files; a clean build off `main` was already at **975** (the top-level `api-examples` exclusion landed in #2304). This PR takes it to **974** and makes it deterministic.

The larger remaining item from the issue — moving `shiny/www/shared/sass/` (**308 files**) behind `shiny[theme]` — is **not** addressed here. Worth recording for whoever picks it up: 26 of the 28 presets ship only `.scss` sources with no precompiled CSS, so they are unusable without `libsass` and are dead weight for a plain `pip install shiny`. Only the `shiny` and `bootstrap` presets have a `bootstrap.min.css`, and those two are needed by every app at runtime.

Other remaining blocks, for reference: `datepicker/js` 87, `prism-code-editor/**` 61, `bootstrap/fonts` 39, `templates/**` 135.

## Caveat

The file-count bounds are a tripwire, not a spec. Anyone legitimately adding an asset tree will need to bump them; the failure message says so.
