### PR TITLE
fix(tests): Add httpx to the dev extra for chatlas

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,11 @@ dev = [
     "shinyswatch>=0.7.0",
     "python-dotenv",
     "chatlas>=0.6.1",
+    # chatlas imports `httpx` without declaring it, relying on `openai` to pull
+    # it in. openai 3.0.0 switched to the `httpx2` distribution, so `import
+    # chatlas` now fails with ModuleNotFoundError unless httpx is installed
+    # directly. Drop this once chatlas declares its own httpx dependency.
+    "httpx",
     "aiohttp",
     "beautifulsoup4",
 ]


### PR DESCRIPTION
## Problem

`import chatlas` now raises `ModuleNotFoundError: No module named 'httpx'`, which takes out `tests/playwright/shiny/bookmark/chat/chatlas/test_bookmark_chatlas.py` on every Python version and browser (13 failing jobs on an unrelated PR).

## Cause

Upstream drift, not a py-shiny change:

- `chatlas` does a bare `import httpx` in `_utils.py` and **does not declare httpx** in its dependencies — it relied on `openai` pulling it in transitively.
- **`openai 3.0.0`**, released **2026-08-12T01:55Z**, switched its HTTP dependency from `httpx` to the separate **`httpx2`** distribution (`httpx2<3,>=2.7.0`).

So a fresh resolve now installs `httpx2` and no `httpx`, and chatlas fails at import.

`main`'s last green run was 2026-08-11T16:58Z, before the openai release — this is not a regression from any merged PR, and `main` will hit it on its next run.

## Fix

Declare `httpx` directly in the `dev` extra, next to `chatlas`, until chatlas declares its own.

Verified in a clean environment that this is sufficient — `chatlas` works with `openai 3.0.0` as long as `httpx` is present alongside `httpx2`:

```
chatlas 0.21.0 | openai 3.0.0 | httpx 0.28.1 | httpx2 2.10.0
import chatlas OK
```

I chose adding `httpx` over pinning `openai<3` so we track openai forward rather than freezing it for an unrelated reason.

## Follow-up

Filing an issue upstream on chatlas for the undeclared dependency; the comment in `pyproject.toml` says to drop this line once that lands.
