### PR TITLE
chore: Remove the httpx workaround for chatlas

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,12 +163,7 @@ dev = [
     "numpy",
     "shinyswatch>=0.7.0",
     "python-dotenv",
-    "chatlas>=0.6.1",
-    # chatlas imports `httpx` without declaring it, relying on `openai` to pull
-    # it in. openai 3.0.0 switched to the `httpx2` distribution, so `import
-    # chatlas` now fails with ModuleNotFoundError unless httpx is installed
-    # directly. Drop this once chatlas declares its own httpx dependency.
-    "httpx",
+    "chatlas>=0.21.1",
     "aiohttp",
     "beautifulsoup4",
 ]


### PR DESCRIPTION
Removes the `httpx` entry from the `dev` extra, added in #2437, and raises the chatlas floor to the release that makes it unnecessary.

## Why it was there

chatlas imported `httpx` unconditionally but did not declare it, relying on `openai` to supply it transitively. `openai 3.0.0` (2026-08-12) switched to the separate `httpx2` distribution, so a fresh resolve installed no `httpx` at all and `import chatlas` raised `ModuleNotFoundError` — taking out the chatlas bookmark Playwright test on every Python version and browser.

`httpx` was declared directly as a stopgap. The real fix is upstream, and has now shipped.

## Blockers — cleared

- [x] **posit-dev/chatlas#387 is resolved** — merged 2026-08-12T16:53Z
- [x] **A chatlas release containing that fix is published to PyPI** — `chatlas 0.21.1`, uploaded 2026-08-12T17:16Z. Its metadata declares both `httpx` and `httpx2`.
- [x] **`chatlas>=` floor raised** — `chatlas>=0.6.1` → `chatlas>=0.21.1`

The floor is load-bearing, not decoration: 0.21.0 and earlier still carry the undeclared import, so without it a constrained resolve could reintroduce the failure.

## Verification

Clean environment, no explicit `httpx` anywhere:

```
$ uv pip install "chatlas>=0.21.1" "openai>=1.104.1"
chatlas  0.21.1
openai   3.0.0
httpx    0.28.1   <- now arrives via chatlas's own declaration
httpx2   2.10.0
import chatlas OK
```

## Other places checked — no change needed

* **py-shiny never imports `httpx` itself.** `grep -rn "import httpx" shiny/ tests/` is empty, so nothing here depended on the workaround.
* **`add-test`'s `chatlas[anthropic,openai]`** is unpinned, but it is only ever installed alongside `dev` (`ci-install-ai-deps` → `.[dev,test,add-test]`), so the new `dev` floor governs the resolution.
* **`shinychat>=0.6.0`** only depends on chatlas under its `providers` extra, which py-shiny does not request.
* **The `shiny create` chat templates** pin `chatlas>=0.4` and similar. Left alone: those floors only set a lower bound, and a default resolve picks 0.21.1. Raising them would be churn without a failure to prevent.
