### PR TITLE
test(playwright): Log failed network requests when example apps hit console errors

### DIFF
--- a/tests/playwright/examples/example_apps.py
+++ b/tests/playwright/examples/example_apps.py
@@ -4,7 +4,7 @@ import typing
 from pathlib import PurePath
 from typing import Literal
 
-from playwright.sync_api import ConsoleMessage, Page, expect
+from playwright.sync_api import ConsoleMessage, Page, Request, Response, expect
 
 from shiny.run import ShinyAppProc, run_shiny_app
 
@@ -169,15 +169,36 @@ def validate_example(page: Page, ex_app_path: str) -> None:
     sa: ShinyAppProc = run_shiny_app(pyshiny_root / ex_app_path, wait_for_start=True)
 
     console_errors: typing.List[str] = []
+    # Console messages like "Failed to load resource: ... 404" do not name the
+    # resource, so record the requests themselves to make failures actionable.
+    failed_requests: typing.List[str] = []
+
+    def is_favicon(url: str) -> bool:
+        return url.endswith("favicon.ico")
 
     def on_console_msg(msg: ConsoleMessage) -> None:
         if msg.type == "error":
             # Do not report missing favicon errors
-            if msg.location["url"].endswith("favicon.ico"):
+            if is_favicon(msg.location["url"]):
                 return
             console_errors.append(msg.text)
 
+    def on_response(response: Response) -> None:
+        if response.status >= 400 and not is_favicon(response.url):
+            failed_requests.append(
+                f"HTTP {response.status} - {response.request.method} {response.url}"
+            )
+
+    def on_request_failed(request: Request) -> None:
+        if is_favicon(request.url):
+            return
+        failed_requests.append(
+            f"{request.failure or 'request failed'} - {request.method} {request.url}"
+        )
+
     page.on("console", on_console_msg)
+    page.on("response", on_response)
+    page.on("requestfailed", on_request_failed)
 
     with sa:
         page.goto(sa.url, wait_until="domcontentloaded")
@@ -259,7 +280,13 @@ def validate_example(page: Page, ex_app_path: str) -> None:
             "In app "
             + ex_app_path
             + " had JavaScript console errors!\n"
-            + "* ".join(console_errors)
+            + "\n".join(f"* {error}" for error in console_errors)
+            + (
+                "\nFailed network requests:\n"
+                + "\n".join(f"* {request}" for request in failed_requests)
+                if failed_requests
+                else "\nNo failed network requests were recorded."
+            )
         )
 
         if ex_app_path not in app_allow_output_error:


### PR DESCRIPTION
Refs #2431 (diagnostics only — does not fix the flake).

## Summary

The `console_errors` assertion in `tests/playwright/examples/example_apps.py` fails with `Failed to load resource: the server responded with a status of 404 (Not Found)`, which does not say *which* resource 404'd. That is the main obstacle to diagnosing the webkit flake in #2431.

This adds two page listeners alongside the existing `console` one: `response` (collecting any status >= 400) and `requestfailed` (collecting network-level failures). The collected `METHOD url` entries are appended to the console-error assertion message, so the next occurrence names the resource. Favicon filtering — previously inline in the console handler — is factored into a shared `is_favicon()` helper so all three listeners skip it consistently. Console errors are now listed one per line instead of joined with a bare `"* "`.

No behavior change to what the test considers a failure: the assertion still triggers on console errors alone, and `failed_requests` is purely informational (the message says so explicitly when the list is empty, which itself is a useful signal — it would mean the 404 happened outside the page's request lifecycle).

## Verification

`pytest tests/playwright/examples/test_api_examples.py -k todo_list --browser chromium` passes, confirming the added listeners do not affect the passing path.

To see the new output, point `validate_example()` at an app whose UI references a missing asset (`ui.tags.script(src="/definitely-missing-asset.js")`). The assertion message becomes:

```
AssertionError: In app .../app-core.py had JavaScript console errors!
* Failed to load resource: the server responded with a status of 404 (Not Found)
Failed network requests:
* HTTP 404 - GET http://127.0.0.1:21252/definitely-missing-asset.js
* net::ERR_ABORTED - GET http://127.0.0.1:21252/definitely-missing-asset.js
```

The duplicate entry is expected — Chromium reports both the 404 response and the subsequent aborted script load. Both are kept rather than deduped, since the pairing itself distinguishes a served-but-erroring response from a connection-level failure.