### PR TITLE
docs: use an absolute URL for the open-telemetry example link

### DIFF
--- a/shiny/otel/__init__.py
+++ b/shiny/otel/__init__.py
@@ -638,7 +638,7 @@ opentelemetry-instrument shiny run app.py
 
 ### Console (Development)
 
-Simple console output for debugging. See the [open-telemetry example](../../examples/open-telemetry/) for a complete working demonstration of console output with collection control.
+Simple console output for debugging. See the [open-telemetry example](https://github.com/posit-dev/py-shiny/tree/main/examples/open-telemetry) for a complete working demonstration of console output with collection control.
 
 ```bash
 opentelemetry-instrument --traces_exporter console shiny run app.py


### PR DESCRIPTION
The `console` section of `shiny.otel`'s module docstring links to the example
with a repo-relative path:

```
See the [open-telemetry example](../../examples/open-telemetry/) for ...
```

That path only resolves in this repo's layout (`examples/open-telemetry/` is two
levels up from `shiny/otel/`). quartodoc renders this docstring into
py-shiny-site's `api/core/OpenTelemetry.html`, where the same relative path
resolves against the *site* layout and points at a page that does not exist —
py-shiny-site's new internal link checker flags it as a broken link.

Docstring links get rendered into the docs site, so they can't assume the repo's
directory layout. This switches it to the absolute GitHub tree URL, matching the
absolute markdown links already used elsewhere in the same docstring (e.g. the
"GitHub Issues" link). The other three references to the example
(`shiny/otel/__init__.py:166`, `:810`, and the otel skill reference doc) are
inline code rather than links, so they are unaffected.

Refs posit-dev/py-shiny-site#447