### PR TITLE
fix: Flush reactives by waking the session's message loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* Reactive work started outside the WebSocket message cycle is now flushed promptly. A `reactive.Value` set by a `@render.download_button()` / `@render.download_link()` or `session.dynamic_route()` handler, and a message queued by `session.send_input_message()`, used to sit unapplied (leaving the session stuck in its "busy" state) until an unrelated client message arrived, because only client messages flushed the reactive graph. `Session._request_flush()` now wakes the session's message loop, which is what Shiny for R's `requestFlush()` does. (#2450)
+
 * A dynamically-rendered output (e.g. `@render.ui`) inside a `ui.popover()` or `ui.tooltip()` without a `title=` no longer gets stuck showing "recalculating". The container collapsed to 0 width, so the output's `ResizeObserver` never fired; vendored bslib CSS now gives it a non-zero minimum width. (#2446)
 
 * `playwright.controller.InputSelectize` no longer clicks the page body to close the selectize dropdown. `expect_choices()`, `expect_choice_labels()`, and `expect_choice_groups()` open the dropdown, because selectize renders its choices into the DOM only after the first open. The click that closed the dropdown again landed on app content and fired the app's own click handlers, so a test could record an interaction that it never made. The controller now calls `close()` on the selectize instance instead, which touches no app content. (#2426)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
-* Reactive work started outside the WebSocket message cycle is now flushed promptly. A `reactive.Value` set by a `@render.download_button()` / `@render.download_link()` or `session.dynamic_route()` handler, and a message queued by `session.send_input_message()`, used to sit unapplied (leaving the session stuck in its "busy" state) until an unrelated client message arrived, because only client messages flushed the reactive graph. `Session._request_flush()` now wakes the session's message loop, which is what Shiny for R's `requestFlush()` does. (#2450)
+* Reactive work started outside the WebSocket message cycle is now flushed promptly. A `reactive.Value` set by a `@render.download_button()` / `@render.download_link()` or `session.dynamic_route()` handler, and a message queued by `session.send_input_message()`, used to sit unapplied (leaving the session stuck in its "busy" state) until an unrelated client message arrived, because only client messages flushed the reactive graph. `Session._request_flush()` now wakes the session's message loop, which is what Shiny for R's `requestFlush()` does. (#2449)
 
 * A dynamically-rendered output (e.g. `@render.ui`) inside a `ui.popover()` or `ui.tooltip()` without a `title=` no longer gets stuck showing "recalculating". The container collapsed to 0 width, so the output's `ResizeObserver` never fired; vendored bslib CSS now gives it a non-zero minimum width. (#2446)
 

--- a/shiny/.agents/skills/shiny-for-python/references/files.md
+++ b/shiny/.agents/skills/shiny-for-python/references/files.md
@@ -88,6 +88,14 @@ file that already exists on disk — for temp files you create, `yield` the
 bytes instead so Shiny does not leave the temp file behind. The handler may be
 sync or async.
 
+The handler runs isolated, so reading a reactive value or input does not create a
+dependency: the handler runs when the user clicks the control, not when the
+values it reads change. Writing works, though — a `reactive.Value` the handler
+sets takes effect once the handler finishes, so downstream effects and outputs
+update (e.g. a "downloads so far" counter). That update arrives a moment after
+the download, so in a test wait for it with an `.expect_*()` method rather than
+asserting immediately after the click.
+
 In Express mode, `@render.download_button` renders its own button (and
 `@render.download_link` its own link) — pass `label=` and skip the separate
 `ui.download_button`/`ui.download_link` (see `references/express.md`).

--- a/shiny/otel/_span_wrappers.py
+++ b/shiny/otel/_span_wrappers.py
@@ -281,5 +281,17 @@ async def shiny_otel_span_stream(
         required_level=required_level,
         collection_level=collection_level,
     ):
-        async for chunk in inner:
-            yield chunk
+        try:
+            async for chunk in inner:
+                yield chunk
+        finally:
+            # Closing this wrapper must close what it wraps. Without this, a
+            # consumer that stops early (Starlette closing the body iterator
+            # when a client cancels a download) abandons `inner` mid-yield, and
+            # its cleanup runs whenever the garbage collector gets round to
+            # finalizing it -- which on Python 3.10 is not before the request is
+            # over. Any `finally` in the wrapped generator is then arbitrarily
+            # delayed rather than running at close.
+            aclose = getattr(inner, "aclose", None)
+            if aclose is not None:
+                await aclose()

--- a/shiny/reactive/_core.py
+++ b/shiny/reactive/_core.py
@@ -132,6 +132,7 @@ class ReactiveEnvironment:
         self._next_id: int = 0
         self._pending_flush_queue: PriorityQueueFIFO[Context] = PriorityQueueFIFO()
         self._lock: Optional[asyncio.Lock] = None
+        self._lock_loop: Optional[asyncio.AbstractEventLoop] = None
         self._flushed_callbacks = _utils.AsyncCallbacks()
 
     @property
@@ -142,11 +143,16 @@ class ReactiveEnvironment:
         yet. This causes the asyncio.Lock to be created with a different loop than it
         will be invoked from later; when that happens, acquire() will succeed if there's
         no contention, but throw a "hey you're on the wrong loop" error if there is.
+
+        For the same reason the lock is recreated whenever the running loop changes:
+        this environment is a process-wide singleton, so it outlives any one loop. That
+        only matters for test suites, where each test gets a fresh loop -- without it,
+        the first test to contend the lock breaks every later test that does.
         """
-        if self._lock is None:
-            # Ensure we have a loop; get_running_loop() throws an error if we don't
-            asyncio.get_running_loop()
+        loop = asyncio.get_running_loop()
+        if self._lock is None or self._lock_loop is not loop:
             self._lock = asyncio.Lock()
+            self._lock_loop = loop
         return self._lock
 
     def next_id(self) -> int:

--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -793,15 +793,25 @@ class Session(ABC):
     def _decrement_busy_count(self) -> None: ...
 
 
-def _cancel_task(task: Optional["asyncio.Task[Any]"]) -> None:
+def _discard_task(task: Optional["asyncio.Task[Any]"]) -> None:
     """
-    Cancel a task if it is still running.
+    Discard a task the message loop no longer needs.
 
-    Used to tear down the message loop's in-flight `receive()` when the loop
-    exits, so it does not outlive the session as a pending task.
+    Used to tear down an in-flight `receive()` when the loop exits, so it does
+    not outlive the session as a pending task. A task that already finished is
+    not cancelled but *is* read, because the loop can exit without ever
+    consuming a receive that failed (say the connection broke while the loop was
+    off servicing a flush, and the flush then raised). Leaving that exception
+    unretrieved makes asyncio log it whenever the task is garbage-collected,
+    long after the session is gone.
     """
-    if task is not None and not task.done():
-        task.cancel()
+    if task is None:
+        return
+    if task.done():
+        if not task.cancelled():
+            task.exception()
+        return
+    task.cancel()
 
 
 def _print_exception(e: Exception) -> None:
@@ -1048,7 +1058,7 @@ class AppSession(Session):
                 # to the next iteration rather than recreated -- recreating it
                 # would drop whatever message the old one had already consumed.
                 pending_receive: Optional[asyncio.Task[str]] = None
-                stack.callback(lambda: _cancel_task(pending_receive))
+                stack.callback(lambda: _discard_task(pending_receive))
 
                 while True:
                     if pending_receive is None:
@@ -1324,20 +1334,29 @@ class AppSession(Session):
     async def _handle_request(
         self, request: Request, action: str, subpath: Optional[str]
     ) -> ASGIApp:
+        response: Optional[ASGIApp] = None
         self._increment_busy_count()
         try:
-            return await self._handle_request_impl(request, action, subpath)
+            response = await self._handle_request_impl(request, action, subpath)
+            return response
         finally:
             self._decrement_busy_count()
             # These two actions invoke app-author code, which may have set a
-            # reactive value. The other actions ("upload", "dataobj") only run
-            # Shiny's own plumbing, and uploads arrive one request per chunk, so
-            # asking for a flush there would be pure overhead. A streaming
-            # download asks again when its generator finishes, which is when the
-            # handler body has actually run; this covers the file-path form,
-            # which has already run by now.
-            if action in ("download", "dynamic_route"):
-                self._request_flush()
+            # reactive value. The others ("upload", "dataobj") only run Shiny's
+            # own plumbing, and uploads arrive one request per chunk, so asking
+            # for a flush there would be pure overhead.
+            #
+            # A streaming response is skipped because the handler body has not
+            # run yet -- it runs when the ASGI server iterates the body, after
+            # this returns. Asking now would flush *during* the stream, pushing
+            # half-generated state to the client; the content-wrapping
+            # generators ask for themselves once the stream ends. (A
+            # `dynamic_route` handler that returns a `StreamingResponse` is
+            # therefore not covered, since Shiny does not wrap its iterator.)
+            if action in ("download", "dynamic_route") and not isinstance(
+                response, StreamingResponse
+            ):
+                self._request_out_of_band_flush()
 
     async def _handle_request_impl(
         self, request: Request, action: str, subpath: Optional[str]
@@ -1462,7 +1481,7 @@ class AppSession(Session):
                                     # for a flush, or the values the handler did
                                     # set never reach the client and the session
                                     # stays "busy".
-                                    self._request_flush()
+                                    self._request_out_of_band_flush()
 
                             wrapped_contents = wrap_content_async()
 
@@ -1481,7 +1500,7 @@ class AppSession(Session):
                                                     yield chunk
                                 finally:
                                     # See `wrap_content_async` above.
-                                    self._request_flush()
+                                    self._request_out_of_band_flush()
 
                             wrapped_contents = wrap_content_sync()
 
@@ -1682,16 +1701,18 @@ class AppSession(Session):
         return self._flushed_callbacks.register(wrap_async(fn), once)
 
     def _request_flush(self) -> None:
+        self.app._request_flush(self)
+
+    def _request_out_of_band_flush(self) -> None:
         """
         Ask this session's message loop to flush the reactive graph.
 
-        Reactive work that starts outside the WebSocket message cycle has no
-        flush of its own: a download or dynamic-route handler runs on the ASGI
-        request task, and `send_input_message()` can be called from anywhere.
-        Whatever such code invalidates would otherwise sit in the pending-flush
-        queue -- with the session stuck "busy", because the busy-count
-        increments from the invalidated effects are never balanced -- until an
-        unrelated client message happened to arrive.
+        A download or dynamic-route handler runs on the ASGI request task, which
+        is outside the WebSocket message cycle, so nothing would otherwise flush
+        what it set: the invalidations sit in the pending-flush queue -- with the
+        session stuck "busy", because the busy-count increments from the
+        invalidated effects are never balanced -- until an unrelated client
+        message happens to arrive.
         (https://github.com/posit-dev/py-shiny/issues/1785)
 
         This is Shiny for R's `requestFlush()`: it only marks, and the session's
@@ -1700,9 +1721,18 @@ class AppSession(Session):
         session's task, so it is ordered against client messages, runs under the
         reactive lock the loop already takes, and reports failures through the
         loop's existing error handling.
+
+        Deliberately *not* wired to `_request_flush()`, which
+        `send_input_message()` calls and which is still the no-op stub it has
+        always been. A `session.on_flush` callback that queues a client message
+        -- which is exactly how every `ui.update_*()` delivers itself -- would
+        re-arm the loop from inside the flush it was already part of, costing an
+        extra empty flush per interaction and spinning without bound when such a
+        callback is registered with `once=False`. Making `_request_flush()` live
+        up to its name needs a way to distinguish "deliver the outbound queue"
+        from "flush the reactive graph"; see the PR discussion.
         """
         self._flush_requested.set()
-        self.app._request_flush(self)
 
     async def _flush_reactives(self) -> None:
         """

--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -793,6 +793,17 @@ class Session(ABC):
     def _decrement_busy_count(self) -> None: ...
 
 
+def _cancel_task(task: Optional["asyncio.Task[Any]"]) -> None:
+    """
+    Cancel a task if it is still running.
+
+    Used to tear down the message loop's in-flight `receive()` when the loop
+    exits, so it does not outlive the session as a pending task.
+    """
+    if task is not None and not task.done():
+        task.cancel()
+
+
 def _print_exception(e: Exception) -> None:
     traceback.print_exception(type(e), e, e.__traceback__)
 
@@ -887,6 +898,8 @@ class AppSession(Session):
         self._conn: Connection = conn
         self._debug: bool = debug
         self._busy_count: int = 0
+        self._flush_requested: asyncio.Event = asyncio.Event()
+        """Set by `_request_flush()`; the message loop waits on it and clears it."""
         self._message_handlers: dict[
             str,
             tuple[Callable[..., Awaitable[Jsonifiable]], Session],
@@ -1029,8 +1042,41 @@ class AppSession(Session):
                     }
                 )
 
+                # The receive is a task rather than a bare await because the loop
+                # now has two things to wake up for. When a flush request wins
+                # the race the receive is still in flight, so it is carried over
+                # to the next iteration rather than recreated -- recreating it
+                # would drop whatever message the old one had already consumed.
+                pending_receive: Optional[asyncio.Task[str]] = None
+                stack.callback(lambda: _cancel_task(pending_receive))
+
                 while True:
-                    message: str = await self._conn.receive()
+                    if pending_receive is None:
+                        pending_receive = asyncio.create_task(self._conn.receive())
+
+                    # Wake for a client message, or for a flush requested from
+                    # outside the message cycle (a download, a dynamic route,
+                    # `send_input_message()`), whichever happens first.
+                    flush_requested = asyncio.create_task(self._flush_requested.wait())
+                    try:
+                        done, _ = await asyncio.wait(
+                            (pending_receive, flush_requested),
+                            return_when=asyncio.FIRST_COMPLETED,
+                        )
+                    finally:
+                        flush_requested.cancel()
+
+                    if pending_receive not in done:
+                        # Only a flush was asked for. Unlike the message path
+                        # below, nothing here holds the reactive lock yet.
+                        async with lock():
+                            await self._flush_reactives()
+                        continue
+
+                    # If both fired, handle the message and leave the request
+                    # set; the flush at the end of this iteration services it.
+                    receive_task, pending_receive = pending_receive, None
+                    message: str = receive_task.result()
                     if self._debug:
                         print("RECV: " + message, flush=True)
 
@@ -1125,11 +1171,7 @@ class AppSession(Session):
                         # https://github.com/posit-dev/py-shiny/issues/1381
                         await asyncio.sleep(0)
 
-                        # Keep session context active for reactive flush so
-                        # reactive_update spans can consistently include session.id.
-                        with session_context(self):
-                            self._request_flush()
-                            await reactive_flush()
+                        await self._flush_reactives()
 
             except ConnectionClosed:
                 ...
@@ -1287,6 +1329,15 @@ class AppSession(Session):
             return await self._handle_request_impl(request, action, subpath)
         finally:
             self._decrement_busy_count()
+            # These two actions invoke app-author code, which may have set a
+            # reactive value. The other actions ("upload", "dataobj") only run
+            # Shiny's own plumbing, and uploads arrive one request per chunk, so
+            # asking for a flush there would be pure overhead. A streaming
+            # download asks again when its generator finishes, which is when the
+            # handler body has actually run; this covers the file-path form,
+            # which has already run by now.
+            if action in ("download", "dynamic_route"):
+                self._request_flush()
 
     async def _handle_request_impl(
         self, request: Request, action: str, subpath: Optional[str]
@@ -1392,26 +1443,45 @@ class AppSession(Session):
                             # implementation of handle_request(), but the iterators
                             # aren't invoked until after handle_request() returns.
                             async def wrap_content_async() -> AsyncIterable[bytes]:
-                                with session_context(self):
-                                    with isolate():
-                                        async for chunk in contents:
-                                            if isinstance(chunk, str):
-                                                yield chunk.encode(download.encoding)
-                                            else:
-                                                yield chunk
+                                try:
+                                    with session_context(self):
+                                        with isolate():
+                                            async for chunk in contents:
+                                                if isinstance(chunk, str):
+                                                    yield chunk.encode(
+                                                        download.encoding
+                                                    )
+                                                else:
+                                                    yield chunk
+                                finally:
+                                    # `finally`, and outside the `with`s above:
+                                    # the handler may raise, and the client may
+                                    # hang up mid-stream (which throws
+                                    # GeneratorExit in at the `yield`, skipping
+                                    # the rest of the body). Both must still ask
+                                    # for a flush, or the values the handler did
+                                    # set never reach the client and the session
+                                    # stays "busy".
+                                    self._request_flush()
 
                             wrapped_contents = wrap_content_async()
 
                         else:  # isinstance(contents, Iterable):
 
                             async def wrap_content_sync() -> AsyncIterable[bytes]:
-                                with session_context(self):
-                                    with isolate():
-                                        for chunk in contents:
-                                            if isinstance(chunk, str):
-                                                yield chunk.encode(download.encoding)
-                                            else:
-                                                yield chunk
+                                try:
+                                    with session_context(self):
+                                        with isolate():
+                                            for chunk in contents:
+                                                if isinstance(chunk, str):
+                                                    yield chunk.encode(
+                                                        download.encoding
+                                                    )
+                                                else:
+                                                    yield chunk
+                                finally:
+                                    # See `wrap_content_async` above.
+                                    self._request_flush()
 
                             wrapped_contents = wrap_content_sync()
 
@@ -1612,7 +1682,39 @@ class AppSession(Session):
         return self._flushed_callbacks.register(wrap_async(fn), once)
 
     def _request_flush(self) -> None:
+        """
+        Ask this session's message loop to flush the reactive graph.
+
+        Reactive work that starts outside the WebSocket message cycle has no
+        flush of its own: a download or dynamic-route handler runs on the ASGI
+        request task, and `send_input_message()` can be called from anywhere.
+        Whatever such code invalidates would otherwise sit in the pending-flush
+        queue -- with the session stuck "busy", because the busy-count
+        increments from the invalidated effects are never balanced -- until an
+        unrelated client message happened to arrive.
+        (https://github.com/posit-dev/py-shiny/issues/1785)
+
+        This is Shiny for R's `requestFlush()`: it only marks, and the session's
+        own loop does the flushing on a later tick, the way `serviceApp()` does.
+        Marking rather than flushing in place is what keeps the flush on the
+        session's task, so it is ordered against client messages, runs under the
+        reactive lock the loop already takes, and reports failures through the
+        loop's existing error handling.
+        """
+        self._flush_requested.set()
         self.app._request_flush(self)
+
+    async def _flush_reactives(self) -> None:
+        """
+        Service a flush, whether requested or part of handling a client message.
+
+        The caller must already hold the reactive lock. The session context is
+        kept active so that `reactive_update` spans consistently include
+        `session.id`.
+        """
+        self._flush_requested.clear()
+        with session_context(self):
+            await reactive_flush()
 
     async def _flush(self) -> None:
         with session_context(self):

--- a/tests/pytest/test_otel_download.py
+++ b/tests/pytest/test_otel_download.py
@@ -209,6 +209,39 @@ class TestSpanStream:
         download_spans = [s for s in spans if s.name == "download"]
         assert len(download_spans) == 0
 
+    @pytest.mark.asyncio
+    async def test_closing_the_wrapper_closes_the_wrapped_stream(self):
+        """
+        A consumer that stops early must not leave the inner stream suspended.
+
+        Starlette closes the body iterator when a client cancels a download. If
+        that close does not reach the wrapped generator, the generator's cleanup
+        runs whenever the garbage collector finalizes it instead of at close --
+        on Python 3.10, not before the request is over. Anything the download
+        handler does in a `finally` (such as asking for a reactive flush) is
+        then arbitrarily delayed.
+        """
+        closed: list[bool] = []
+
+        async def inner() -> AsyncIterator[bytes]:
+            try:
+                yield b"first"
+                yield b"second"
+            finally:
+                closed.append(True)
+
+        with patch_otel_tracing_state(tracing_enabled=False):
+            stream = shiny_otel_span_stream(
+                "download",
+                inner(),
+                infer_session_id=False,
+                required_level=OtelCollectLevel.REACTIVITY,
+            )
+            assert await stream.__anext__() == b"first"
+            await stream.aclose()
+
+        assert closed == [True]
+
 
 # ---------------------------------------------------------------------------
 # TestDownloadHandlerSpans — tests for OTel integration in the download

--- a/tests/pytest/test_out_of_band_flush.py
+++ b/tests/pytest/test_out_of_band_flush.py
@@ -55,11 +55,23 @@ def _request(action: str, subpath: str) -> Request:
 
 
 async def _read_body(response: object) -> bytes:
-    """Consume the body of a download response, the way an HTTP client would."""
+    """
+    Consume the body of a download response, the way an HTTP client would.
+
+    Yields to the event loop between chunks, because a real ASGI server awaits
+    `send()` for each one. Without that the session's task never gets to run
+    mid-stream, and a test cannot tell "flushed once at the end" apart from
+    "flushed during the stream".
+    """
     if isinstance(response, StreamingResponse):
         chunks: list[bytes] = []
         async for chunk in response.body_iterator:
             chunks.append(chunk.encode() if isinstance(chunk, str) else bytes(chunk))
+            # Generously: a single yield is not enough for the session's task to
+            # get through a whole flush, so one would let a mid-stream flush slip
+            # past unnoticed.
+            for _ in range(50):
+                await asyncio.sleep(0)
         return b"".join(chunks)
     if isinstance(response, FileResponse):
         return Path(response.path).read_bytes()
@@ -116,13 +128,6 @@ class Harness:
         for message in self.sent:
             values.update(message.get("values") or {})  # type: ignore[union-attr]
         return values
-
-    @property
-    def input_messages(self) -> list[dict[str, Any]]:
-        messages: list[dict[str, Any]] = []
-        for message in self.sent:
-            messages.extend(message.get("inputMessages") or [])  # type: ignore[union-attr]
-        return messages
 
 
 @asynccontextmanager
@@ -389,25 +394,39 @@ async def test_dynamic_route_updates_reactives():
 
 
 @pytest.mark.asyncio
-async def test_send_input_message_outside_the_message_cycle_is_delivered():
+async def test_a_flush_callback_that_queues_a_message_does_not_spin_the_loop():
     """
-    `send_input_message()` queues a message and calls `_request_flush()`.
+    `ui.update_*()` must not re-arm the loop from inside the flush it is part of.
 
-    Called from outside the message cycle -- from an `on_ended` callback, a
-    background task, or just directly -- the queued message needs the loop to
-    wake up, or it sits there until the client happens to say something.
+    Every `ui.update_*()` delivers itself by registering a `session.on_flush`
+    callback that calls `send_input_message()`, and session flush callbacks run
+    inside the flush. If queueing a message asked for another flush, each flush
+    would beget the next: with `once=False` that spins without bound, pegging a
+    CPU and spamming every connected client with empty messages.
     """
+    flushes = [0]
 
     def server(input: Inputs, output: Outputs, session: Session) -> None:
         @render.text
         def count_text():
             return "hi"
 
-    async with _running_session(server) as h:
-        h.session.send_input_message("slider", {"value": 42})
-        await h.settle()
+        session.on_flush(
+            lambda: ui.update_text("txt", value="x", session=session), once=False
+        )
 
-        assert h.input_messages == [{"id": "slider", "message": {"value": 42}}]
+    async with _running_session(server) as h:
+        original = h.session._flush_reactives
+
+        async def counting() -> None:
+            flushes[0] += 1
+            await original()
+
+        h.session._flush_reactives = counting  # type: ignore[method-assign]
+
+        # No client input at all: the session should be idle, not flushing.
+        await h.settle()
+        assert flushes[0] == 0
 
 
 @pytest.mark.asyncio

--- a/tests/pytest/test_out_of_band_flush.py
+++ b/tests/pytest/test_out_of_band_flush.py
@@ -445,6 +445,37 @@ async def test_a_flush_request_does_not_swallow_the_next_client_message():
 
 
 @pytest.mark.asyncio
+async def test_interleaved_messages_and_flush_requests_lose_nothing():
+    """
+    Every client message survives a stream of flush requests racing it.
+
+    The single-request guard above covers the parked case; this covers the
+    contended one, where messages and flush requests keep arriving together and
+    the loop is choosing between them on every iteration.
+    """
+    seen: list[int] = []
+
+    def server(input: Inputs, output: Outputs, session: Session) -> None:
+        @reactive.effect
+        def _():
+            seen.append(input.n())
+
+        @render.text
+        def count_text():
+            return "hi"
+
+    async with _running_session(server) as h:
+        for i in range(1, 21):
+            h.conn.cause_receive(json.dumps({"method": "update", "data": {"n": i}}))
+            h.session._request_flush()
+
+        await _wait_for(lambda: len(seen) >= 20, "all 20 updates to be processed")
+
+        # Exactly once each, in order -- not dropped, not double-processed.
+        assert seen == list(range(1, 21))
+
+
+@pytest.mark.asyncio
 async def test_repeated_downloads_each_flush():
     """A second download is flushed too, i.e. the loop keeps waking up."""
     seen: list[int] = []

--- a/tests/pytest/test_out_of_band_flush.py
+++ b/tests/pytest/test_out_of_band_flush.py
@@ -1,0 +1,466 @@
+"""
+Flushing reactives for work that starts outside the WebSocket message cycle
+(posit-dev/py-shiny#1785).
+
+Downloads and dynamic routes are served over plain HTTP requests, and
+`session.send_input_message()` can be called from anywhere. None of those is a
+client message, and the session's message loop is what flushes the reactive
+graph, so anything they invalidate used to sit in the pending-flush queue until
+an unrelated client message happened to arrive.
+
+`Session._request_flush()` now wakes the message loop, so the flush happens on
+the session's own task, in order with client messages.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from contextlib import asynccontextmanager
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, AsyncGenerator, AsyncIterable, Callable, Iterable, cast
+
+import pytest
+from starlette.requests import Request
+
+# Not `shiny.http_staticfiles.FileResponse`, which is a stripped-down class under
+# wasm; tests always run in native mode, where starlette's is used.
+from starlette.responses import FileResponse, HTMLResponse, StreamingResponse
+
+from shiny import App, Inputs, Outputs, Session, reactive, render, ui
+from shiny._connection import MockConnection
+from shiny.session._session import AppSession
+
+DOWNLOAD_ID = "download"
+# Init message that marks the `count_text` output as visible, so that it renders.
+INIT_MESSAGE = json.dumps(
+    {
+        "method": "init",
+        "data": {".clientdata_output_count_text_hidden": False},
+    }
+)
+
+
+def _request(action: str, subpath: str) -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "headers": [],
+            "query_string": b"",
+            "path": f"/session/x/{action}/{subpath}",
+        }
+    )
+
+
+async def _read_body(response: object) -> bytes:
+    """Consume the body of a download response, the way an HTTP client would."""
+    if isinstance(response, StreamingResponse):
+        chunks: list[bytes] = []
+        async for chunk in response.body_iterator:
+            chunks.append(chunk.encode() if isinstance(chunk, str) else bytes(chunk))
+        return b"".join(chunks)
+    if isinstance(response, FileResponse):
+        return Path(response.path).read_bytes()
+    raise AssertionError(f"Unexpected download response: {response!r}")
+
+
+async def _wait_for(predicate: Callable[[], bool], what: str) -> None:
+    # The session runs in a separate task; yield to it until it catches up.
+    for _ in range(1000):
+        if predicate():
+            return
+        await asyncio.sleep(0)
+    raise AssertionError(f"Timed out waiting for {what}")
+
+
+class Harness:
+    """A running session, plus the plumbing needed to observe what it sends."""
+
+    def __init__(
+        self,
+        session: AppSession,
+        conn: MockConnection,
+        sent: list[dict[str, object]],
+    ) -> None:
+        self.session = session
+        self.conn = conn
+        self.sent = sent
+
+    async def request(self, action: str, subpath: str) -> object:
+        return await self.session._handle_request(
+            _request(action=action, subpath=subpath),
+            action=action,
+            subpath=subpath,
+        )
+
+    async def download(self) -> object:
+        return await self.request(action="download", subpath=DOWNLOAD_ID)
+
+    async def settle(self) -> None:
+        """
+        Let the session's message loop wake up and flush.
+
+        The flush is deliberately not awaited by whoever requested it, so tests
+        have to yield to the loop's task. Nothing here does real I/O, so
+        repeatedly ceding control is enough.
+        """
+        for _ in range(100):
+            await asyncio.sleep(0)
+
+    @property
+    def values(self) -> dict[str, Any]:
+        """Output values pushed to the client since the session went idle."""
+        values: dict[str, Any] = {}
+        for message in self.sent:
+            values.update(message.get("values") or {})  # type: ignore[union-attr]
+        return values
+
+    @property
+    def input_messages(self) -> list[dict[str, Any]]:
+        messages: list[dict[str, Any]] = []
+        for message in self.sent:
+            messages.extend(message.get("inputMessages") or [])  # type: ignore[union-attr]
+        return messages
+
+
+@asynccontextmanager
+async def _running_session(
+    server: Callable[[Inputs, Outputs, Session], None],
+) -> AsyncGenerator[Harness, None]:
+    """
+    Run `server` in a real session, parked and idle, ready to serve a request.
+
+    Idle -- i.e. parked waiting for the next client message -- is the state a
+    real session is in when the browser asks for a download.
+    """
+    conn = MockConnection()
+    session = App(ui.TagList(), server)._create_session(conn)
+
+    # Record everything the session pushes to the client.
+    sent: list[dict[str, object]] = []
+    send_message = session._send_message
+
+    async def record_message(message: dict[str, object]) -> None:
+        # Copy: `_flush()` sends the (mutable) outbound message queues, then
+        # clears them.
+        sent.append(deepcopy(message))
+        await send_message(message)
+
+    session._send_message = record_message  # type: ignore[method-assign]
+
+    # Count how many times the loop asks the connection for a message; the 2nd
+    # time means `init` (and its reactive flush) has been fully processed.
+    n_receives = 0
+    receive = conn.receive
+
+    async def counted_receive() -> str:
+        nonlocal n_receives
+        n_receives += 1
+        return await receive()
+
+    conn.receive = counted_receive  # type: ignore[method-assign]
+
+    run_task = asyncio.create_task(session._run())
+    try:
+        conn.cause_receive(INIT_MESSAGE)
+        await _wait_for(lambda: n_receives >= 2, "the session to become idle")
+        sent.clear()
+        yield Harness(session, conn, sent)
+    finally:
+        # Unconditionally, so that a failing assertion above does not leave
+        # `session._run()` parked with its reactive callbacks still registered
+        # on the global environment.
+        conn.cause_disconnect()
+        await run_task
+
+
+def _counting_server(
+    seen: list[int],
+    download: Callable[[reactive.Value[int]], Any],
+) -> Callable[[Inputs, Outputs, Session], None]:
+    """An app with a value, an effect and an output watching it, and a download."""
+
+    def server(input: Inputs, output: Outputs, session: Session) -> None:
+        n_downloads = reactive.value(0)
+
+        @reactive.effect
+        def _():
+            seen.append(n_downloads.get())
+
+        @render.text
+        def count_text():
+            return f"downloads: {n_downloads.get()}"
+
+        download(n_downloads)
+
+    return server
+
+
+@pytest.mark.asyncio
+async def test_sync_generator_download_updates_reactives():
+    """A `reactive.Value` set in a sync generator download handler is flushed."""
+    seen: list[int] = []
+
+    def make_download(n_downloads: reactive.Value[int]) -> None:
+        @render.download_button(filename="data.csv")
+        def download() -> Iterable[bytes]:
+            n_downloads.set(n_downloads.get() + 1)
+            yield b"a,b\n1,2\n"
+
+    async with _running_session(_counting_server(seen, make_download)) as h:
+        body = await _read_body(await h.download())
+        await h.settle()
+
+        assert body == b"a,b\n1,2\n"
+        # The effect re-ran with the new value, without any further client input.
+        assert seen == [0, 1]
+        # ...and the new output value was pushed to the client.
+        assert h.values.get("count_text") == "downloads: 1"
+        # ...and the session is no longer telling the client it is busy.
+        assert h.session._busy_count == 0
+
+
+@pytest.mark.asyncio
+async def test_async_generator_download_updates_reactives():
+    """A `reactive.Value` set in an async generator download handler is flushed."""
+    seen: list[int] = []
+
+    def make_download(n_downloads: reactive.Value[int]) -> None:
+        @render.download_button(filename="data.csv")
+        async def download() -> AsyncIterable[bytes]:
+            n_downloads.set(n_downloads.get() + 1)
+            yield b"a,b\n1,2\n"
+
+    async with _running_session(_counting_server(seen, make_download)) as h:
+        body = await _read_body(await h.download())
+        await h.settle()
+
+        assert body == b"a,b\n1,2\n"
+        assert seen == [0, 1]
+        assert h.values.get("count_text") == "downloads: 1"
+        assert h.session._busy_count == 0
+
+
+@pytest.mark.asyncio
+async def test_file_path_download_updates_reactives(tmp_path: Path):
+    """A `reactive.Value` set in a file-path download handler is flushed."""
+    csv_file = tmp_path / "data.csv"
+    csv_file.write_text("a,b\n1,2\n")
+    seen: list[int] = []
+
+    def make_download(n_downloads: reactive.Value[int]) -> None:
+        @render.download_button()
+        def download() -> str:
+            n_downloads.set(n_downloads.get() + 1)
+            return str(csv_file)
+
+    async with _running_session(_counting_server(seen, make_download)) as h:
+        body = await _read_body(await h.download())
+        await h.settle()
+
+        assert body == b"a,b\n1,2\n"
+        assert seen == [0, 1]
+        assert h.values.get("count_text") == "downloads: 1"
+        assert h.session._busy_count == 0
+
+
+@pytest.mark.asyncio
+async def test_download_flush_waits_for_the_stream_to_finish():
+    """
+    The flush happens after the download's contents are generated, not before.
+
+    A generator handler's body does not start running until the response is
+    streamed, so flushing when the handler is merely *called* would miss any
+    reactive value it sets.
+    """
+    seen: list[int] = []
+
+    def make_download(n_chunks: reactive.Value[int]) -> None:
+        @render.download_button(filename="data.txt")
+        def download() -> Iterable[bytes]:
+            for i in range(3):
+                n_chunks.set(i + 1)
+                yield b"x"
+
+    async with _running_session(_counting_server(seen, make_download)) as h:
+        body = await _read_body(await h.download())
+        await h.settle()
+
+        assert body == b"xxx"
+        # One flush after the whole stream, not one per chunk.
+        assert seen == [0, 3]
+        assert h.values.get("count_text") == "downloads: 3"
+
+
+@pytest.mark.asyncio
+async def test_download_flushes_when_the_handler_raises():
+    """
+    A handler that blows up mid-stream still flushes what it managed to set.
+
+    Otherwise the invalidated effects never re-run, their busy-count increments
+    are never balanced, and the client's "recalculating" indicator stays on.
+    """
+    seen: list[int] = []
+
+    def make_download(n_downloads: reactive.Value[int]) -> None:
+        @render.download_button(filename="data.csv")
+        def download() -> Iterable[bytes]:
+            n_downloads.set(n_downloads.get() + 1)
+            yield b"partial"
+            raise RuntimeError("boom")
+
+    async with _running_session(_counting_server(seen, make_download)) as h:
+        with pytest.raises(RuntimeError, match="boom"):
+            await _read_body(await h.download())
+        await h.settle()
+
+        assert seen == [0, 1]
+        assert h.values.get("count_text") == "downloads: 1"
+        assert h.session._busy_count == 0
+
+
+@pytest.mark.asyncio
+async def test_download_flushes_when_the_client_aborts():
+    """
+    A download the client walks away from still flushes what the handler set.
+
+    Starlette closes the body iterator when the client disconnects, which throws
+    `GeneratorExit` in at the `yield`, skipping the rest of the generator body.
+    Only a `finally` still runs.
+    """
+    seen: list[int] = []
+
+    def make_download(n_downloads: reactive.Value[int]) -> None:
+        @render.download_button(filename="data.csv")
+        def download() -> Iterable[bytes]:
+            n_downloads.set(n_downloads.get() + 1)
+            yield b"first"
+            yield b"second"
+
+    async with _running_session(_counting_server(seen, make_download)) as h:
+        response = await h.download()
+        assert isinstance(response, StreamingResponse)
+
+        # Read one chunk, then hang up, the way an aborted download does.
+        iterator = cast("AsyncGenerator[bytes, None]", response.body_iterator)
+        assert await iterator.__anext__() == b"first"
+        await iterator.aclose()
+
+        await h.settle()
+
+        assert seen == [0, 1]
+        assert h.values.get("count_text") == "downloads: 1"
+        assert h.session._busy_count == 0
+
+
+@pytest.mark.asyncio
+async def test_dynamic_route_updates_reactives():
+    """A dynamic route is served out-of-band too, so it needs the same flush."""
+    seen: list[int] = []
+
+    def server(input: Inputs, output: Outputs, session: Session) -> None:
+        n_hits = reactive.value(0)
+
+        @reactive.effect
+        def _():
+            seen.append(n_hits.get())
+
+        @render.text
+        def count_text():
+            return f"downloads: {n_hits.get()}"
+
+        def handler(request: Request) -> HTMLResponse:
+            n_hits.set(n_hits.get() + 1)
+            return HTMLResponse("ok")
+
+        session.dynamic_route("thing", handler)
+
+    async with _running_session(server) as h:
+        response = await h.request(action="dynamic_route", subpath="thing")
+        assert isinstance(response, HTMLResponse)
+
+        await h.settle()
+
+        assert seen == [0, 1]
+        assert h.values.get("count_text") == "downloads: 1"
+        assert h.session._busy_count == 0
+
+
+@pytest.mark.asyncio
+async def test_send_input_message_outside_the_message_cycle_is_delivered():
+    """
+    `send_input_message()` queues a message and calls `_request_flush()`.
+
+    Called from outside the message cycle -- from an `on_ended` callback, a
+    background task, or just directly -- the queued message needs the loop to
+    wake up, or it sits there until the client happens to say something.
+    """
+
+    def server(input: Inputs, output: Outputs, session: Session) -> None:
+        @render.text
+        def count_text():
+            return "hi"
+
+    async with _running_session(server) as h:
+        h.session.send_input_message("slider", {"value": 42})
+        await h.settle()
+
+        assert h.input_messages == [{"id": "slider", "message": {"value": 42}}]
+
+
+@pytest.mark.asyncio
+async def test_a_flush_request_does_not_swallow_the_next_client_message():
+    """
+    Waking the loop for a flush must not lose the pending `receive()`.
+
+    The loop now waits on a client message *or* a flush request, so a flush that
+    wins the race has to leave the in-flight receive alone. Getting this wrong
+    drops or double-processes client input, which is far worse than the bug
+    being fixed.
+    """
+    seen: list[int] = []
+
+    def server(input: Inputs, output: Outputs, session: Session) -> None:
+        @reactive.effect
+        def _():
+            # Silent until the client sends `n`, so `seen` records exactly the
+            # updates the message loop actually processed.
+            seen.append(input.n())
+
+        @render.text
+        def count_text():
+            return "hi"
+
+    async with _running_session(server) as h:
+        # Wake the loop for a flush while it is parked on `receive()`.
+        h.session._request_flush()
+        await h.settle()
+        assert seen == []
+
+        # A client message sent afterwards is still processed normally.
+        h.conn.cause_receive(json.dumps({"method": "update", "data": {"n": 7}}))
+        await _wait_for(lambda: seen == [7], "the update message to be processed")
+
+
+@pytest.mark.asyncio
+async def test_repeated_downloads_each_flush():
+    """A second download is flushed too, i.e. the loop keeps waking up."""
+    seen: list[int] = []
+
+    def make_download(n_downloads: reactive.Value[int]) -> None:
+        @render.download_button(filename="data.csv")
+        def download() -> Iterable[bytes]:
+            n_downloads.set(n_downloads.get() + 1)
+            yield b"x"
+
+    async with _running_session(_counting_server(seen, make_download)) as h:
+        await _read_body(await h.download())
+        await h.settle()
+        await _read_body(await h.download())
+        await h.settle()
+
+        assert seen == [0, 1, 2]
+        assert h.values.get("count_text") == "downloads: 2"
+        assert h.session._busy_count == 0

--- a/tests/pytest/test_reactives.py
+++ b/tests/pytest/test_reactives.py
@@ -8,7 +8,7 @@ import pytest
 from shiny import App, render, req, ui
 from shiny._connection import MockConnection
 from shiny.reactive import Value, calc, effect, event, flush, invalidate_later, isolate
-from shiny.reactive._core import ReactiveWarning
+from shiny.reactive._core import ReactiveWarning, lock
 from shiny.types import ActionButtonValue, SilentException
 
 from .mocktime import MockTime
@@ -1568,3 +1568,29 @@ def test_event_effect_stacked_warns_only_once():
 
     assert len(w) == 1
     assert w[0].filename == __file__
+
+
+def test_reactive_lock_is_reusable_across_event_loops():
+    """
+    The reactive lock must not stay bound to an event loop that has closed.
+
+    `_reactive_environment` is a process-wide singleton, so its `asyncio.Lock`
+    outlives any one event loop. `Lock.acquire()` only consults the running loop
+    on its *contended* path, and caches it the first time it does -- so a lock
+    that has ever been contended raises "bound to a different event loop" for
+    every later contended acquire from a different loop. That is invisible until
+    something actually contends the lock (two concurrent flushes, say), and then
+    it silently breaks whatever test happens to run next in the same process.
+    """
+
+    async def contend() -> None:
+        async def take() -> None:
+            async with lock():
+                await asyncio.sleep(0)
+
+        # Two waiters, so the acquire takes the slow path that binds the loop.
+        await asyncio.gather(take(), take())
+
+    asyncio.run(contend())
+    # A second, unrelated event loop -- e.g. the next test in this process.
+    asyncio.run(contend())


### PR DESCRIPTION
Fixes #1785. This PR is an alternative to #2422. The two PRs correct the same defect with a different mechanism and I believe this solution is the better approach. The section "Comparison with #2422" gives the details.

## The problem

Shiny does reactive work only during a flush. A flush does two things: it recomputes values, and it sends the new output values to the client. The session registers `AppSession._flush()` as an `on_flushed` callback. Before this PR, only the message loop of a session started a flush.

A download handler and a dynamic-route handler run on the ASGI request task. That task is not a client message, so no flush happened afterwards. The values that such a handler invalidated stayed in the pending-flush queue. The session also stayed "busy", because each invalidated effect increments the busy count, and only the run of that effect decrements it again. Both conditions continued until an unrelated client message arrived. This behavior is the symptom that #1785 shows: the outputs do not update until another input changes.

## The fix

The message loop now waits for _either_ a client message or a flush request. It continues when the first of the two arrives.

R does the reactive flush on the service loop of the app, and not on a request task. This PR follows that shape, but the details differ. The service loop of R calls `serviceApp()` again and again, and each call runs `flushReact()`. The reactive graph therefore flushes with no request at all. `requestFlush()` only marks a session, and `flushPendingSessions()` then sends the outputs of that session. py-shiny has no equivalent polling loop, so this PR makes the request explicit.

The flush now runs on the session's own asyncio task. Three properties follow from this change:

- The flush is in order with client messages.
- The flush runs under the reactive lock that the loop already takes.
- An error in the flush goes to the error handling of `_run_impl`. That code reports the error to the client and closes the session.

The code makes a flush request in two places:

1. In the `finally` block of [`_handle_request()`](https://github.com/posit-dev/py-shiny/pull/2449/files#diff-af4a1451ac386b2b3fe25b2e5eb15964b14f5c3ccaa34414b5c4920545839041R1356), for the `download` and `dynamic_route` actions. Only these two actions run app-author code. The `upload` and `dataobj` actions run internal Shiny code only, and an upload arrives as one request for each chunk. A flush request for those actions gives no benefit. This block skips a streaming response, because the body of a streaming handler has not run yet.
2. In the `finally` block of [both content-wrapping generators](https://github.com/posit-dev/py-shiny/pull/2449/files#diff-af4a1451ac386b2b3fe25b2e5eb15964b14f5c3ccaa34414b5c4920545839041R1484), for a streaming download. The body of such a handler runs only when Starlette iterates the response. A `finally` block is necessary here, and not a trailing statement. A handler can raise an error part way through the stream, and a client can cancel the download part way through. The flush request must happen on both of these paths.

### The largest risk

The [receive in `_run_impl`](https://github.com/posit-dev/py-shiny/pull/2449/files#diff-af4a1451ac386b2b3fe25b2e5eb15964b14f5c3ccaa34414b5c4920545839041R1065) is now a task, and no longer a plain `await`. This change lets the loop wait for the receive or for a flush request.

When a flush request wins the race, the loop keeps the receive that is still in flight. It uses that same receive on the next pass. A new receive loses a client message, which is a worse defect than the one that this PR corrects.

Two tests hold this behavior. The first test covers a loop with no other work. The second test sends 20 client messages and 20 flush requests together. It then makes sure that the loop processes each message one time, and in order.

### Why this is not wired to `_request_flush()`

The obvious change is to implement the existing `AppSession._request_flush()` stub. Its TODO comment asks for exactly this. That change does not work.

`send_input_message()` calls `_request_flush()`. Every `ui.update_*()` call delivers its message this way. It registers a `session.on_flush` callback that calls `send_input_message()`, and Shiny runs session flush callbacks inside a flush. If a callback queues a message, that message makes a new flush request from inside the flush that it belongs to.

The cost is one extra empty flush for each interaction. The flush is global, so every connected session receives that extra message. With an `on_flush` callback that uses `once=False` and queues a message, the loop never becomes idle. A test measured 999 flushes with no client input at all. The same app on `main` is idle after one flush.

For this reason the out-of-band request is a separate method, `_request_out_of_band_flush()`. `_request_flush()` remains the stub that it has always been. A call to `send_input_message()` from outside the message cycle therefore still waits for the next client message, as it does on `main`.

R already separates the two needs that `_request_flush()` mixes. There, the session method `requestFlush()` marks a session for output delivery through `flushPendingSessions()`. The reactive flush is a separate operation, and each call of `serviceApp()` runs `flushReact()` for it. py-shiny adopted the name without that split. A call from `send_input_message()` asks for output delivery, which matches the R meaning, so this PR leaves the method alone.

### A separate defect that this work found

[`shiny_otel_span_stream()`](https://github.com/posit-dev/py-shiny/pull/2449/files#diff-62a8e9ac8bdf0cfbe37a8cfc23ce365b227bbe922d023370f8a9524d1937297f) iterated `inner` and yielded each chunk, but it never closed `inner`. Starlette closes the body iterator when a client cancels a download. That close stopped the wrapper, but it left the wrapped generator suspended at a `yield`. The garbage collector then ran the cleanup code of that generator at a later time.

This behavior makes the `finally` block of the handler arbitrarily late. CI found the defect on Python 3.10. The abort test failed there, and passed on Python 3.12 and Python 3.14. The `session_context` exit of the wrapped generator appeared as a pytest unraisable exception. That signature shows finalization by the garbage collector, and not a close. `uv run --python 3.10` reproduced the failure locally.

The wrapper now closes `inner` in a `finally` block, and `test_otel_download.py` has a direct test for it. This defect does not depend on the approach in this PR. Any cleanup code in the content-wrapping generators has the same problem, so **#2422 has the same defect** and needs the same correction.

## Comparison with #2422

\#2422 corrects the same defect with a task from `asyncio.create_task()`. That task takes the reactive lock and does the flush. It starts from the same two places. Both PRs correct #1785, both cover `dynamic_route`, and both leave `send_input_message()` alone. These differences matter for the choice:

- **Error handling.** In #2422 nothing awaits the task, so a failed flush can only go to `traceback.print_exc()`. Here the error goes to the handler in `_run_impl`, and the client learns about it.
- **Lock contention.** In #2422 a request task takes the reactive lock. That code is the first in py-shiny to contend the lock. The contention bound the process-wide `asyncio.Lock` to an event loop that then closed, and `test_poll` failed in the same xdist worker. #2422 therefore also needs a separate correction to `ReactiveEnvironment.lock`. No request task takes the lock here, so this PR does not reach that defect. The defect is still real, and it deserves a correction of its own.
- **OpenTelemetry.** In #2422 the new task inherits the OTel context of the download span. The flush there needs `detached_otel_context()`. Without it the whole `reactive_update` subtree nests under `download` and inflates the recorded duration of that span. This PR has no such problem.
- **Blast radius.** This PR edits the message loop, which every session uses for every message. #2422 does not. This is the strongest argument for #2422.
- **Order.** Here the flush is in order with client messages by construction. In #2422 the flush races them.
- **A third option that neither PR takes.** R does not need a flush request for reactives at all. Its service loop calls `serviceApp()` repeatedly, and every call flushes the reactive graph. Neither PR adds such a loop to py-shiny.
- **Neither PR corrects this.** The handler's own `set()` calls still run outside the reactive lock. A flush that a client message starts can therefore still publish a value from the middle of a stream. A lock around the handler means one lock for a whole streaming download, which blocks every session.

## Tests

[`tests/pytest/test_out_of_band_flush.py`](https://github.com/posit-dev/py-shiny/pull/2449/files#diff-9fa12df955dcd9d398b429f858a15972a28e4f518cce167734a228a88edcc44c) runs a real `AppSession` over a `MockConnection`. It waits until the session waits for a client message, which is the state of a real session when a browser asks for a download. It then makes the request through the real ASGI path.

The file has 11 tests:

- the three handler forms
- a flush after the end of a stream
- a handler that raises an error in the middle of a stream
- a client that cancels in the middle of a stream
- two downloads in sequence
- a `dynamic_route` request
- a guard against the flush loop above
- two guards for the message loop

One note on `_read_body()`, which yields to the event loop many times between chunks. A real ASGI server awaits `send()` for each chunk. Without those yields the task of the session never runs during the stream. A test then cannot separate "one flush at the end" from "a flush during the stream". The test for the end of the stream passed against a wrong implementation until this change.

## Verification

`uv run make format check-lint check-types` and `make check-pyright` report no errors. The unit suite passes 1078 tests on Python 3.12 and on Python 3.10, in one process and under xdist.

This PR edits the message loop, so it also passes these checks:

- The full `tests/playwright/shiny` suite: 339 tests.
- `tests/playwright/examples`: 360 tests. Two failures come from this machine, which has no `pytz` and no build of `shinymediapipe`.
- An adversarial script for three cases. The cases are client messages together with flush requests, a flush request from inside message handling, and cancellation with a receive in flight. The script runs under `asyncio` debug mode, with warnings as errors.

A code review found four problems. All four now have corrections. Each correction has a measurement from before and after. The four problems were:

- the flush loop above
- an early flush for streaming responses
- a test that measured its own harness
- an exception from a receive task that the loop never read

CI then found the defect in generator finalization on Python 3.10. For that reason the unit suite now runs on both versions of Python locally.



