### PR TITLE
fix: show_offcanvas() accepts a string id and tag content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* `ui.show_offcanvas()` now accepts the `id` (a string) of an `ui.offcanvas()` panel already in the UI and reveals it, matching its sibling functions `ui.hide_offcanvas()` / `ui.toggle_offcanvas()`. Previously, passing a string raised an unhandled `AttributeError` from deep inside the implementation. `show_offcanvas()` also now accepts bare tag content (wrapping it into a new anonymous panel), in addition to an `ui.offcanvas()` object; a string that looks like body text instead of an id (empty, or containing whitespace) raises an actionable `ValueError`. (#2445)
+
 * A dynamically-rendered output (e.g. `@render.ui`) inside a `ui.popover()` or `ui.tooltip()` without a `title=` no longer gets stuck showing "recalculating". The container collapsed to 0 width, so the output's `ResizeObserver` never fired; vendored bslib CSS now gives it a non-zero minimum width. (#2446)
 
 * `playwright.controller.InputSelectize` no longer clicks the page body to close the selectize dropdown. `expect_choices()`, `expect_choice_labels()`, and `expect_choice_groups()` open the dropdown, because selectize renders its choices into the DOM only after the first open. The click that closed the dropdown again landed on app content and fired the app's own click handlers, so a test could record an interaction that it never made. The controller now calls `close()` on the selectize instance instead, which touches no app content. (#2426)

--- a/shiny/api-examples/show_offcanvas/app-core.py
+++ b/shiny/api-examples/show_offcanvas/app-core.py
@@ -1,14 +1,28 @@
 from shiny import App, Inputs, Outputs, Session, reactive, ui
 
 app_ui = ui.page_fluid(
-    ui.input_action_button("show_btn", "Show panel"),
+    ui.offcanvas(
+        ui.p("This panel is declared in the UI."),
+        title="Existing panel",
+        id="existing_panel",
+    ),
+    ui.input_action_button("show_existing_btn", "Show existing panel"),
+    ui.input_action_button("show_server_btn", "Show server panel"),
+    ui.input_action_button("show_markdown_btn", "Show markdown content"),
 )
 
 
 def server(input: Inputs, output: Outputs, session: Session):
     @reactive.effect
-    @reactive.event(input.show_btn)
+    @reactive.event(input.show_existing_btn)
     def _():
+        # Reveal a panel already declared in the UI, by its id.
+        ui.show_offcanvas("existing_panel")
+
+    @reactive.effect
+    @reactive.event(input.show_server_btn)
+    def _():
+        # Build and show a new, anonymous panel entirely from the server.
         ui.show_offcanvas(
             ui.offcanvas(
                 ui.p("This panel was inserted dynamically by the server."),
@@ -16,6 +30,18 @@ def server(input: Inputs, output: Outputs, session: Session):
                 placement="left",
             )
         )
+
+    @reactive.effect
+    @reactive.event(input.show_markdown_btn)
+    def _():
+        # Bare tag content (here, rendered Markdown) is wrapped into a new
+        # anonymous panel with default settings.
+        ui.show_offcanvas(ui.markdown("""
+                ### Markdown content
+
+                This panel's body was written in **Markdown** and wrapped
+                into a new anonymous offcanvas by `show_offcanvas()`.
+                """))
 
 
 app = App(app_ui, server=server)

--- a/shiny/api-examples/show_offcanvas/app-express.py
+++ b/shiny/api-examples/show_offcanvas/app-express.py
@@ -1,12 +1,27 @@
 from shiny import reactive
 from shiny.express import input, ui
 
-ui.input_action_button("show_btn", "Show panel")
+ui.offcanvas(
+    ui.p("This panel is declared in the UI."),
+    title="Existing panel",
+    id="existing_panel",
+)
+ui.input_action_button("show_existing_btn", "Show existing panel")
+ui.input_action_button("show_server_btn", "Show server panel")
+ui.input_action_button("show_markdown_btn", "Show markdown content")
 
 
 @reactive.effect
-@reactive.event(input.show_btn)
+@reactive.event(input.show_existing_btn)
 def _():
+    # Reveal a panel already declared in the UI, by its id.
+    ui.show_offcanvas("existing_panel")
+
+
+@reactive.effect
+@reactive.event(input.show_server_btn)
+def _():
+    # Build and show a new, anonymous panel entirely from the server.
     ui.show_offcanvas(
         ui.offcanvas(
             ui.p("This panel was inserted dynamically by the server."),
@@ -14,3 +29,16 @@ def _():
             placement="left",
         )
     )
+
+
+@reactive.effect
+@reactive.event(input.show_markdown_btn)
+def _():
+    # Bare tag content (here, rendered Markdown) is wrapped into a new
+    # anonymous panel with default settings.
+    ui.show_offcanvas(ui.markdown("""
+            ### Markdown content
+
+            This panel's body was written in **Markdown** and wrapped
+            into a new anonymous offcanvas by `show_offcanvas()`.
+            """))

--- a/shiny/ui/_offcanvas.py
+++ b/shiny/ui/_offcanvas.py
@@ -11,7 +11,7 @@ __all__ = (
 import warnings
 from typing import TYPE_CHECKING, Literal, Optional, Union
 
-from htmltools import Tag, TagAttrs, TagAttrValue, TagChild, TagList, tags
+from htmltools import HTML, Tag, TagAttrs, TagAttrValue, TagChild, TagList, tags
 
 from .._docstring import add_example, no_example
 from .._namespaces import resolve_id_or_none
@@ -357,22 +357,34 @@ def offcanvas(
     )
 
 
+_make_offcanvas = offcanvas
+
+
 @add_example()
 def show_offcanvas(
-    offcanvas: Offcanvas,
+    offcanvas: Union[str, TagChild, Offcanvas],
     *,
     session: Optional[Session] = None,
 ) -> str:
     """
     Show an offcanvas panel.
 
-    Programmatically displays an :func:`~shiny.ui.offcanvas` panel in the
-    user's session by inserting its HTML into the page.
+    Programmatically displays an offcanvas panel in the user's session.
+    ``offcanvas`` can be:
+
+    * a string ``id`` of an :func:`~shiny.ui.offcanvas` panel already in the
+      UI, which is revealed; or
+    * arbitrary tag content (e.g. an :class:`~htmltools.HTML` string, a
+      :class:`~htmltools.Tag`, or a :class:`~htmltools.TagList`), which is
+      wrapped into a new anonymous offcanvas panel with default settings; or
+    * an :class:`~shiny.ui.Offcanvas` object created by :func:`~shiny.ui.offcanvas`,
+      which is rendered into the page (if needed) and shown.
 
     Parameters
     ----------
     offcanvas
-        An :class:`~shiny.ui.Offcanvas` object created by :func:`~shiny.ui.offcanvas`.
+        The panel's ``id``, tag content for a new panel, or an
+        :class:`~shiny.ui.Offcanvas` object.
     session
         The :class:`~shiny.Session` to show the panel in. If not provided,
         the session is inferred via :func:`~shiny.session.get_current_session`.
@@ -389,12 +401,31 @@ def show_offcanvas(
     To update an id'd panel's content, update the reactive outputs it contains
     rather than calling ``show_offcanvas()`` again.
 
+    A plain string is always treated as an ``id`` lookup, and raises a
+    ``ValueError`` if it looks like body text instead (it is empty or
+    contains whitespace). To show new string content, wrap it in
+    :func:`~htmltools.HTML` or pass a :func:`~shiny.ui.offcanvas` object.
+
     See Also
     --------
     * :func:`~shiny.ui.offcanvas`
     * :func:`~shiny.ui.hide_offcanvas`
     * :func:`~shiny.ui.toggle_offcanvas`
     """
+    if isinstance(offcanvas, str) and not isinstance(offcanvas, HTML):
+        if not offcanvas or any(c.isspace() for c in offcanvas):
+            raise ValueError(
+                "`offcanvas` looks like body text, not an offcanvas id "
+                "(ids can't be empty or contain whitespace). To show new "
+                "content, wrap it in `htmltools.HTML()` or pass an "
+                "`offcanvas()` object. To reveal an existing panel, pass its id."
+            )
+        toggle_offcanvas(offcanvas, show=True, session=session)
+        return offcanvas
+
+    if not isinstance(offcanvas, Offcanvas):
+        offcanvas = _make_offcanvas(offcanvas)
+
     the_session = require_active_session(session)
 
     local_id = offcanvas.id if offcanvas.id is not None else rand_hex(8)

--- a/tests/playwright/shiny/components/offcanvas/app.py
+++ b/tests/playwright/shiny/components/offcanvas/app.py
@@ -18,6 +18,16 @@ app_ui = ui.page_fluid(
     ui.br(),
     ui.output_code("trigger_state"),
     ui.output_code("server_state"),
+    ui.offcanvas(
+        ui.p("Panel declared for id-based reveal."),
+        title="Existing Panel",
+        id="existing_panel",
+    ),
+    ui.br(),
+    ui.input_action_button("show_existing_btn", "Show existing (by id)"),
+    ui.input_action_button("show_content_btn", "Show wrapped content"),
+    ui.input_action_button("show_bad_id_btn", "Show bad id"),
+    ui.output_text("bad_id_error"),
 )
 
 
@@ -39,6 +49,32 @@ def server(input: Inputs, output: Outputs, session: Session):
     @render.code
     def server_state():
         return "open" if input.server_panel() else "closed"
+
+    @reactive.effect
+    @reactive.event(input.show_existing_btn)
+    def _():
+        # str dispatch: reveals the panel already declared in the UI, by id.
+        ui.show_offcanvas("existing_panel")
+
+    @reactive.effect
+    @reactive.event(input.show_content_btn)
+    def _():
+        # TagChild dispatch: wraps bare content into a new anonymous panel.
+        ui.show_offcanvas(ui.p("Wrapped content panel."))
+
+    bad_id_error_val = reactive.value("")
+
+    @reactive.effect
+    @reactive.event(input.show_bad_id_btn)
+    def _():
+        try:
+            ui.show_offcanvas("bad id with spaces")
+        except ValueError as e:
+            bad_id_error_val.set(str(e))
+
+    @render.text
+    def bad_id_error():
+        return bad_id_error_val()
 
 
 app = App(app_ui, server=server)

--- a/tests/playwright/shiny/components/offcanvas/test_offcanvas.py
+++ b/tests/playwright/shiny/components/offcanvas/test_offcanvas.py
@@ -1,4 +1,6 @@
-from playwright.sync_api import Page
+import re
+
+from playwright.sync_api import Page, expect
 
 from shiny.playwright import controller
 from shiny.run import ShinyAppProc
@@ -39,3 +41,36 @@ def test_offcanvas_server_toggle(page: Page, local_app: ShinyAppProc) -> None:
     controller.InputActionButton(page, "hide_btn").click()
     panel.expect_open(False)
     state.expect_value("closed")
+
+
+def test_show_offcanvas_by_id(page: Page, local_app: ShinyAppProc) -> None:
+    """show_offcanvas() with a bare string reveals an existing panel by id."""
+    page.goto(local_app.url)
+
+    panel = controller.Offcanvas(page, "existing_panel")
+    panel.expect_open(False)
+
+    controller.InputActionButton(page, "show_existing_btn").click()
+    panel.expect_open(True)
+    panel.expect_body("Panel declared for id-based reveal.")
+
+
+def test_show_offcanvas_wraps_content(page: Page, local_app: ShinyAppProc) -> None:
+    """show_offcanvas() with bare tag content wraps it in a new anonymous panel."""
+    page.goto(local_app.url)
+
+    controller.InputActionButton(page, "show_content_btn").click()
+
+    new_panel = page.locator("bslib-offcanvas.show")
+    expect(new_panel).to_be_visible()
+    expect(new_panel.locator(".offcanvas-body")).to_have_text("Wrapped content panel.")
+
+
+def test_show_offcanvas_bad_id_raises(page: Page, local_app: ShinyAppProc) -> None:
+    """show_offcanvas() raises a ValueError for a string that looks like body text."""
+    page.goto(local_app.url)
+
+    controller.InputActionButton(page, "show_bad_id_btn").click()
+
+    error_output = controller.OutputText(page, "bad_id_error")
+    error_output.expect_value(re.compile("looks like body text"))

--- a/tests/pytest/test_offcanvas.py
+++ b/tests/pytest/test_offcanvas.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import warnings
+from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
-from htmltools import TagList, tags
+from htmltools import HTML, TagList, tags
 
 from shiny import ui
 from shiny.ui._offcanvas import Offcanvas
@@ -254,6 +256,105 @@ def test_offcanvas_with_trigger_returns_taglist():
     html = str(result)
     assert "bslib-offcanvas" in html
     assert "Open" in html
+
+
+# ============================================================================
+# show_offcanvas() dispatch tests
+# ============================================================================
+
+
+def _mock_session() -> MagicMock:
+    def _ns(id: str) -> str:
+        return id
+
+    def _send_message_sync(msg: dict[str, Any]) -> None:
+        messages_sent.append(msg)
+
+    def _send_input_message(id: str, msg: dict[str, Any]) -> None:
+        input_messages_sent.append((id, msg))
+
+    def _on_flush(cb: Any, once: bool = True) -> None:
+        cb()
+
+    mock_session = MagicMock()
+    mock_session.ns = MagicMock(side_effect=_ns)
+    mock_session._process_ui = MagicMock(
+        return_value={"html": "<div>test</div>", "deps": []}
+    )
+    messages_sent: list[dict[str, Any]] = []
+    mock_session._send_message_sync = MagicMock(side_effect=_send_message_sync)
+    mock_session._messages_sent = messages_sent
+    input_messages_sent: list[tuple[str, dict[str, Any]]] = []
+    mock_session.send_input_message = MagicMock(side_effect=_send_input_message)
+    mock_session._input_messages_sent = input_messages_sent
+    mock_session.on_flush = MagicMock(side_effect=_on_flush)
+    return mock_session
+
+
+def test_show_offcanvas_with_str_id_reveals_existing_panel():
+    """show_offcanvas() with a bare string reveals an existing panel by id"""
+    mock_session = _mock_session()
+
+    result_id = ui.show_offcanvas("existing-panel", session=mock_session)
+
+    assert result_id == "existing-panel"
+    assert mock_session._input_messages_sent == [
+        ("existing-panel", {"method": "toggle", "value": "show"})
+    ]
+    mock_session._send_message_sync.assert_not_called()
+
+
+@pytest.mark.parametrize("bad_id", ["", "   ", "has space", "\ttab"])
+def test_show_offcanvas_bad_string_raises(bad_id: str):
+    """show_offcanvas() raises when the string looks like body text, not an id"""
+    mock_session = _mock_session()
+
+    with pytest.raises(ValueError, match="looks like body text"):
+        ui.show_offcanvas(bad_id, session=mock_session)
+
+
+def test_show_offcanvas_with_html_wraps_new_panel():
+    """show_offcanvas() treats htmltools.HTML() as content, not an id"""
+    mock_session = _mock_session()
+
+    result_id = ui.show_offcanvas(
+        HTML("<p>Rendered content.</p>"), session=mock_session
+    )
+
+    assert isinstance(result_id, str) and result_id != ""
+    assert mock_session._send_message_sync.call_count == 1
+    message = mock_session._messages_sent[0]
+    payload = message["custom"]["bslib.show-offcanvas"]
+    assert payload["temporary"] is True
+    assert payload["id"] == result_id
+
+
+def test_show_offcanvas_with_tag_wraps_new_panel():
+    """show_offcanvas() wraps a bare Tag into a new anonymous offcanvas"""
+    mock_session = _mock_session()
+
+    result_id = ui.show_offcanvas(tags.p("Body content"), session=mock_session)
+
+    assert mock_session._send_message_sync.call_count == 1
+    message = mock_session._messages_sent[0]
+    payload = message["custom"]["bslib.show-offcanvas"]
+    assert payload["temporary"] is True
+    assert payload["id"] == result_id
+
+
+def test_show_offcanvas_with_offcanvas_object_unchanged():
+    """show_offcanvas() with an Offcanvas object renders + shows it (existing behavior)"""
+    mock_session = _mock_session()
+
+    oc = ui.offcanvas("Body", title="T", id="my_panel")
+    result_id = ui.show_offcanvas(oc, session=mock_session)
+
+    assert result_id == "my_panel"
+    assert mock_session._send_message_sync.call_count == 1
+    message = mock_session._messages_sent[0]
+    payload = message["custom"]["bslib.show-offcanvas"]
+    assert payload["temporary"] is False
+    assert payload["id"] == "my_panel"
 
 
 def test_offcanvas_without_trigger_returns_tag():


### PR DESCRIPTION
Fixes #2445

## Summary

`ui.show_offcanvas()` now dispatches on the type of its first argument, matching bslib's `show_offcanvas()` (rstudio/bslib#1346):

- a string `id` of an `offcanvas()` panel already in the UI → reveals it (same as `toggle_offcanvas(id, show=True)`)
- tag content (e.g. `ui.p(...)`, `htmltools.HTML(...)`, `ui.markdown(...)`) → wrapped into a new anonymous panel
- an `Offcanvas` object → rendered + shown (unchanged)

Previously, `show_offcanvas()` only accepted an `Offcanvas` object; passing a string id raised an unhandled `AttributeError` deep inside the implementation (#2445). A string that looks like body text instead of an id (empty, or containing whitespace) now raises an actionable `ValueError` instead of being silently misinterpreted.

## Examples

Revealing an existing panel by id:

```python
from shiny import App, Inputs, Outputs, Session, reactive, ui

app_ui = ui.page_fluid(
    ui.offcanvas(ui.p("Body."), title="Settings", id="settings"),
    ui.input_action_button("show", "Show settings"),
)

def server(input: Inputs, output: Outputs, session: Session):
    @reactive.effect
    @reactive.event(input.show)
    def _():
        ui.show_offcanvas("settings")

app = App(app_ui, server=server)
```

Showing server-rendered Markdown content in a new anonymous panel:

```python
from shiny import App, Inputs, Outputs, Session, reactive, ui

app_ui = ui.page_fluid(
    ui.input_action_button("show_notes", "Show release notes"),
)

def server(input: Inputs, output: Outputs, session: Session):
    @reactive.effect
    @reactive.event(input.show_notes)
    def _():
        ui.show_offcanvas(
            ui.markdown(
                """
                ## Release notes

                - Added **markdown** support in server-rendered panels.
                - See the [docs](https://shiny.posit.co) for details.
                """
            )
        )

app = App(app_ui, server=server)
```

## Implementation notes

- Related bslib PR: rstudio/bslib#1346. bslib assets are already up to date in py-shiny (#2446), so this is a pure Python port with no client-side changes.
- The string-id path delegates to the existing `toggle_offcanvas(id, show=True, session=session)` rather than duplicating the send logic.
- `hide_offcanvas()` / `toggle_offcanvas()` are unchanged; `toggle_offcanvas` accepting an `Offcanvas` object too (for full parity with `hide_offcanvas`) was raised in #2445 as a separate, independent question and is out of scope here.