### PR TITLE
refactor(data frame): Address columns by position on the Python side

### DIFF
--- a/shiny/render/_data_frame_utils/_tbl_data.py
+++ b/shiny/render/_data_frame_utils/_tbl_data.py
@@ -6,12 +6,13 @@ import narwhals.stable.v1 as nw
 import orjson
 
 from ...session import Session, require_active_session
-from ...types import Jsonifiable, JsonifiableDict
+from ...types import Jsonifiable, JsonifiableDict, ListOrTuple
 from ._html import as_cell_html, ui_must_be_processed
 from ._types import (
     CellHtml,
     CellPatch,
     CellValue,
+    ColIndexes,
     ColsList,
     DataFrame,
     DataFrameT,
@@ -25,6 +26,7 @@ from ._types import (
 )
 
 __all__ = (
+    "as_col_indexes",
     "as_data_frame",
     "data_frame_to_native",
     "apply_frame_patches",
@@ -150,34 +152,34 @@ def apply_frame_patches(
     # This allows for a single column to be updated in a single operation (rather than multiple updates to the same column)
     #
     # In; patches: List[Dict[row_index: int, column_index: int, value: Any]]
-    # Out; cell_patches_by_column: Dict[column_name: Any, List[Dict[row_index: int, value: Any]]]
+    # Out; cell_patches_by_column: Dict[column_index: int, List[Dict[row_index: int, value: Any]]]
     #
-    # Narwhals types `get_column(name)`'s `name` as `str`, but its docs note that pandas
-    # does allow non-string column names and that they work when passed to it, as there
-    # is no ambiguity:
-    # https://narwhals-dev.github.io/narwhals/api-reference/dataframe/#narwhals.dataframe.DataFrame.get_column
-    # This dict is not exported, so its key type is relaxed to match.
-    cell_patches_by_column: dict[Any, ScatterValues] = {}
+    # Patches arrive from the browser keyed by column *index*, and the column is read
+    # back out positionally, so the column name never enters the lookup. Names are not
+    # dependable keys: they may be empty or, in pandas, not even strings.
+    cell_patches_by_column: dict[int, ScatterValues] = {}
     for cell_patch in patches:
-        column_name = nw_data.columns[cell_patch["column_index"]]
-        if column_name not in cell_patches_by_column:
-            cell_patches_by_column[column_name] = {
+        column_index = cell_patch["column_index"]
+        if column_index not in cell_patches_by_column:
+            cell_patches_by_column[column_index] = {
                 "row_indexes": [],
                 "values": [],
             }
 
         # Append the row index and value to the column information
-        cell_patches_by_column[column_name]["row_indexes"].append(
+        cell_patches_by_column[column_index]["row_indexes"].append(
             cell_patch["row_index"]
         )
-        cell_patches_by_column[column_name]["values"].append(cell_patch["value"])
+        cell_patches_by_column[column_index]["values"].append(cell_patch["value"])
 
-    # Upgrade the Scatter info to new column Series objects
+    # Upgrade the Scatter info to new column Series objects.
+    # `nw_data[:, i]` selects positionally; the resulting Series keeps the column's
+    # name, which is what `with_columns()` below matches on.
     scatter_columns = [
-        nw_data.get_column(column_name).scatter(
+        nw_data[:, column_index].scatter(
             scatter_values["row_indexes"], scatter_values["values"]
         )
-        for column_name, scatter_values in cell_patches_by_column.items()
+        for column_index, scatter_values in cell_patches_by_column.items()
     ]
     # Apply patches to the nw data
     return nw_data.with_columns(*scatter_columns)
@@ -304,6 +306,47 @@ def serialize_frame(into_data: IntoDataFrame) -> FrameJson:
     }
 
 
+# as_col_indexes -----------------------------------------------------------------------
+def as_col_indexes(data: DataFrame[Any], cols: ListOrTuple[str | int]) -> ColIndexes:
+    """Resolve caller-supplied columns to column positions.
+
+    This is the single place where a column name is turned into a column position.
+    Everything downstream addresses columns by position only (:data:`ColIndexes`),
+    because names are not dependable identifiers: they may be empty, and pandas allows
+    names that are not strings.
+
+    Parameters
+    ----------
+    data
+        The data frame the columns belong to.
+    cols
+        Column names (`str`) or column positions (`int`).
+
+        An `int` is **always** read as a position, never as a label. The two cannot be
+        told apart otherwise, and narwhals reads a list of ints in the column slot
+        positionally, so a pandas frame whose labels are ints (e.g. `{5: ..., 3: ...}`)
+        must be addressed by position.
+
+    Raises
+    ------
+    ValueError
+        If a name is not a column of `data`.
+    """
+    col_indexes: list[int] = []
+    for col in cols:
+        if isinstance(col, int):
+            col_indexes.append(col)
+            continue
+        try:
+            col_indexes.append(data.columns.index(col))
+        except ValueError:
+            raise ValueError(
+                f"Column name {col!r} not found in the data frame. "
+                "To select a column by position, pass an `int`."
+            ) from None
+    return col_indexes
+
+
 # subset_frame -------------------------------------------------------------------------
 def subset_frame(
     data: DataFrameT,
@@ -311,14 +354,13 @@ def subset_frame(
     rows: RowsList = None,
     cols: ColsList = None,
 ) -> DataFrameT:
-    """Return a subsetted DataFrame, based on row positions and column names.
+    """Return a subsetted DataFrame, based on row positions and column names or positions.
 
     Note that when None is passed, all rows or columns get included.
-    """
-    # Note that this type signature assumes column names are string objects.
-    # This is always true in Polars, but not in Pandas (e.g. a column name could be an
-    # int, or even a tuple of ints)
 
+    Known narwhals behavior: on polars, selecting columns positionally renames a column
+    whose name is `""` to `"column_0"`. Selecting rows only is unaffected.
+    """
     # The nested if-else structure is used to navigate around narwhals' typing system and lack of `:` operator outside of `[`, `]`.
 
     # Note: pyright resolves `DataFrame.__getitem__` to the overload returning `Self`
@@ -330,14 +372,9 @@ def subset_frame(
         else:
             return data[rows, :]  # pyrefly: ignore[bad-return]
     else:
-        # `cols` is not None
-        # Resolve each column to its position rather than its name. Narwhals reads a
-        # list of ints in the column slot as positions, so a non-string column name
-        # (e.g. pandas' integer labels) would be taken as a position instead: selecting
-        # the wrong columns, or raising `IndexError` when it is out of bounds.
-        col_indexes = [
-            col if isinstance(col, int) else data.columns.index(col) for col in cols
-        ]
+        # `cols` is not None. Resolve names to positions once, here, so that the
+        # subsetting below only ever deals with positions.
+        col_indexes = as_col_indexes(data, cols)
 
         # Return a DataFrame with no rows or columns
         # If there are no columns, there are no Series objects to support any rows

--- a/shiny/render/_data_frame_utils/_tbl_data.py
+++ b/shiny/render/_data_frame_utils/_tbl_data.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, List, TypedDict, cast
+import operator
+from typing import TYPE_CHECKING, Any, List, SupportsIndex, TypedDict, cast
 
 import narwhals.stable.v1 as nw
 import orjson
 
+from ..._typing_extensions import TypeIs
 from ...session import Session, require_active_session
 from ...types import Jsonifiable, JsonifiableDict, ListOrTuple
 from ._html import as_cell_html, ui_must_be_processed
@@ -307,35 +309,74 @@ def serialize_frame(into_data: IntoDataFrame) -> FrameJson:
 
 
 # as_col_indexes -----------------------------------------------------------------------
-def as_col_indexes(data: DataFrame[Any], cols: ListOrTuple[str | int]) -> ColIndexes:
+def _is_col_position(col: str | SupportsIndex) -> TypeIs[SupportsIndex]:
+    """Whether `col` should be read as a column position rather than a column name.
+
+    Anything integer-like counts, not only `int`: `numpy` integers (what `np.where()`,
+    `np.arange()`, and `Index.get_indexer()` hand back) are the most likely source of a
+    position, and `isinstance(np.int64(0), int)` is `False`.
+
+    `bool` is integer-like in Python but is never a position here; the caller is
+    rejected instead, so that `[True, False]` cannot silently mean `[1, 0]`.
+    """
+    if isinstance(col, (str, bool)):
+        return False
+    return hasattr(col, "__index__")
+
+
+def as_col_indexes(
+    data: DataFrame[Any], cols: ListOrTuple[str | SupportsIndex]
+) -> ColIndexes:
     """Resolve caller-supplied columns to column positions.
 
-    This is the single place where a column name is turned into a column position.
-    Everything downstream addresses columns by position only (:data:`ColIndexes`),
-    because names are not dependable identifiers: they may be empty, and pandas allows
-    names that are not strings.
+    This is the single place where `subset_frame()` turns a column name into a column
+    position; everything downstream of it addresses columns by position only
+    (:data:`ColIndexes`), because names are not dependable identifiers: they may be
+    empty, and pandas allows names that are not strings. (Other name lookups still exist
+    elsewhere in the data frame code, e.g. `update_cell_value()` and `style_info_cols()`.)
 
     Parameters
     ----------
     data
         The data frame the columns belong to.
     cols
-        Column names (`str`) or column positions (`int`).
+        Column names (`str`) or column positions (any integer-like value, e.g. `int` or
+        `numpy.int64`).
 
-        An `int` is **always** read as a position, never as a label. The two cannot be
+        An integer is **always** read as a position, never as a label. The two cannot be
         told apart otherwise, and narwhals reads a list of ints in the column slot
         positionally, so a pandas frame whose labels are ints (e.g. `{5: ..., 3: ...}`)
         must be addressed by position.
 
     Raises
     ------
+    TypeError
+        If a column is a `bool`. `bool` is a subclass of `int`, so accepting it would
+        read `[True, False]` as positions `[1, 0]` rather than as a mask.
     ValueError
-        If a name is not a column of `data`.
+        If a name is not a column of `data`, or if a position is negative or beyond the
+        last column.
     """
+    ncol = len(data.columns)
     col_indexes: list[int] = []
     for col in cols:
-        if isinstance(col, int):
-            col_indexes.append(col)
+        if isinstance(col, bool):
+            raise TypeError(
+                f"Column {col!r} must be a column name (`str`) or a column position "
+                "(`int`), not a `bool`."
+            )
+        if _is_col_position(col):
+            col_index = operator.index(col)
+            if col_index < 0:
+                raise ValueError(
+                    f"Column position {col_index} must be greater than or equal to 0."
+                )
+            if col_index >= ncol:
+                raise ValueError(
+                    f"Column position {col_index} is out of range. "
+                    f"The data frame has {ncol} columns."
+                )
+            col_indexes.append(col_index)
             continue
         try:
             col_indexes.append(data.columns.index(col))
@@ -358,8 +399,12 @@ def subset_frame(
 
     Note that when None is passed, all rows or columns get included.
 
-    Known narwhals behavior: on polars, selecting columns positionally renames a column
-    whose name is `""` to `"column_0"`. Selecting rows only is unaffected.
+    Known narwhals behavior: on polars, any selection that names columns positionally
+    renames a column whose name is `""` to `"column_<position in the result>"` -- both
+    the columns-only and the rows-and-columns branches below, e.g. selecting all of
+    `["a", "", "c"]` yields `["a", "column_1", "c"]` and selecting `[2, 1]` of it yields
+    `["c", "column_1"]`. Only the rows-only branch is unaffected. (polars 1.43.2,
+    narwhals 2.24.0)
     """
     # The nested if-else structure is used to navigate around narwhals' typing system and lack of `:` operator outside of `[`, `]`.
 

--- a/shiny/render/_data_frame_utils/_types.py
+++ b/shiny/render/_data_frame_utils/_types.py
@@ -50,6 +50,7 @@ __all__ = (
     "FrameJson",
     "RowsList",
     "ColsList",
+    "ColIndexes",
     "FrameDtypeSubset",
     "FrameDtypeCategories",
     "FrameDtype",
@@ -166,7 +167,20 @@ class FrameJson(TypedDict):
 
 
 RowsList = Optional[ListOrTuple[int]]
+
 ColsList = Optional[ListOrTuple[Union[str, int]]]
+"""
+Columns as a caller may supply them: either column names or column positions.
+
+Resolve to :data:`ColIndexes` with `as_col_indexes()` before doing any work, as column
+names are not dependable identifiers (they may be empty, and pandas allows names that
+are not strings).
+"""
+
+ColIndexes = ListOrTuple[int]
+"""
+Columns as the internals address them: positions only, never names.
+"""
 
 
 # ---------------------------------------------------------------------

--- a/shiny/render/_data_frame_utils/_types.py
+++ b/shiny/render/_data_frame_utils/_types.py
@@ -6,6 +6,7 @@ from typing import (
     Literal,
     Optional,
     Protocol,
+    SupportsIndex,
     Tuple,
     Union,
     cast,
@@ -168,9 +169,13 @@ class FrameJson(TypedDict):
 
 RowsList = Optional[ListOrTuple[int]]
 
-ColsList = Optional[ListOrTuple[Union[str, int]]]
+ColsList = Optional[ListOrTuple[Union[str, SupportsIndex]]]
 """
 Columns as a caller may supply them: either column names or column positions.
+
+A position is anything integer-like (`SupportsIndex`), not only `int`, so that a
+`numpy` integer -- what `np.where()` and `Index.get_indexer()` hand back -- is read as a
+position rather than falling through to the name lookup.
 
 Resolve to :data:`ColIndexes` with `as_col_indexes()` before doing any work, as column
 names are not dependable identifiers (they may be empty, and pandas allows names that

--- a/tests/pytest/test_render_data_frame_tbl_data.py
+++ b/tests/pytest/test_render_data_frame_tbl_data.py
@@ -8,6 +8,7 @@ from typing import Any, Union, cast
 
 import htmltools
 import narwhals.stable.v1 as nw
+import numpy as np
 import pandas as pd
 import polars as pl
 import polars.testing as pl_testing
@@ -464,11 +465,49 @@ def test_as_col_indexes_unknown_name_raises():
 
 def test_as_col_indexes_int_is_always_a_position():
     # An `int` cannot be told apart from a pandas integer label, so it is documented and
-    # tested as a position. Here position 0 is the column labelled `5`.
+    # tested as a position. The only input that tells the two readings apart is an int
+    # that is also a label: on this frame `5` is the label of position 0, so reading it
+    # as a label would give `[0]` while reading it as a position is out of range.
     df = as_data_frame(pd.DataFrame([["a", 1]], columns=[5, 3]))
 
-    assert as_col_indexes(df, [0]) == [0]
-    assert subset_frame(df, cols=[0]).columns == [5]
+    with pytest.raises(ValueError, match="Column position 5 is out of range"):
+        as_col_indexes(df, [5])
+
+    # Position 1 is the column labelled `3`, not the label `1` (which does not exist)
+    assert as_col_indexes(df, [1]) == [1]
+    assert subset_frame(df, cols=[1]).columns == [3]
+
+
+def test_as_col_indexes_numpy_int_is_a_position():
+    # `np.int64` is not an `int`, but it is what `np.where()` and friends hand back, so
+    # it has to follow the same rule rather than falling through to the name lookup: on
+    # this frame the label `5` would resolve to position 0 by equality.
+    df = as_data_frame(pd.DataFrame([["a", 1]], columns=[5, 3]))
+
+    assert as_col_indexes(df, [np.int64(1)]) == [1]
+    with pytest.raises(ValueError, match="Column position 5 is out of range"):
+        as_col_indexes(df, [np.int64(5)])
+
+
+def test_as_col_indexes_out_of_range_position_raises():
+    df = as_data_frame(pd.DataFrame({"chr": ["a"], "num": [1]}))
+
+    # Negative positions are rejected rather than wrapping around to the last column
+    with pytest.raises(ValueError, match="Column position -1 must be greater than"):
+        as_col_indexes(df, [-1])
+
+    # Out of range is rejected here rather than escaping as a narwhals `IndexError`
+    with pytest.raises(ValueError, match="Column position 99 is out of range"):
+        as_col_indexes(df, [99])
+
+
+def test_as_col_indexes_bool_raises():
+    # `bool` is a subclass of `int`, so `[True, False]` would otherwise read as
+    # positions `[1, 0]`. `StyleInfo`'s `cols` accepts a bool mask; this does not.
+    df = as_data_frame(pd.DataFrame({"chr": ["a"], "num": [1]}))
+
+    with pytest.raises(TypeError, match="not a `bool`"):
+        as_col_indexes(df, [True, False])
 
 
 def test_subset_frame_rows_single(small_df_f: IntoDataFrame):

--- a/tests/pytest/test_render_data_frame_tbl_data.py
+++ b/tests/pytest/test_render_data_frame_tbl_data.py
@@ -18,6 +18,7 @@ from shiny.module import ResolvedId
 from shiny.render._data_frame_utils._html import maybe_as_cell_html
 from shiny.render._data_frame_utils._tbl_data import (
     apply_frame_patches,
+    as_col_indexes,
     as_data_frame,
     serialize_dtype,
     serialize_frame,
@@ -351,6 +352,23 @@ def test_apply_frame_patches_numeric_column_names():
     assert df.rows(named=False) == [("a", "x"), ("b", "y"), ("c", "z")]
 
 
+@pytest.mark.parametrize("constructor", [pd.DataFrame, pl.DataFrame])
+def test_apply_frame_patches_empty_column_name(constructor: Any):
+    # Patches are keyed by column index all the way through, so a column whose name is
+    # `""` is patched like any other. https://github.com/posit-dev/py-shiny/issues/1844
+    df = as_data_frame(constructor({"": ["a", "b"], "num": [1, 2]}))
+
+    patches: list[CellPatch] = [
+        {"row_index": 1, "column_index": 0, "value": "B"},
+        {"row_index": 0, "column_index": 1, "value": 10},
+    ]
+
+    res = apply_frame_patches(df, patches)
+
+    assert res.columns == ["", "num"]
+    assert res.rows(named=False) == [("a", 10), ("B", 2)]
+
+
 def test_apply_frame_patches_non_string_values():
     # `CellValue` allows non-string scalars so that `@<data_frame>.set_patch_fn` can
     # coerce the browser's string to the column's type. Writing a `str` into these
@@ -423,6 +441,34 @@ def test_subset_frame_numeric_column_names():
 
     assert res.columns == [20]
     assert res.rows(named=False) == [(2,)]
+
+
+def test_as_col_indexes_resolves_names_and_positions():
+    df = as_data_frame(pd.DataFrame({"chr": ["a"], "": ["b"], "num": [1]}))
+
+    # Names resolve to positions, including the empty name
+    assert as_col_indexes(df, ["chr", "", "num"]) == [0, 1, 2]
+    # Ints are already positions and pass straight through
+    assert as_col_indexes(df, [2, 0]) == [2, 0]
+    # Mixed input is fine
+    assert as_col_indexes(df, ["num", 0]) == [2, 0]
+    assert as_col_indexes(df, []) == []
+
+
+def test_as_col_indexes_unknown_name_raises():
+    df = as_data_frame(pd.DataFrame({"chr": ["a"], "num": [1]}))
+
+    with pytest.raises(ValueError, match="Column name 'nope' not found"):
+        as_col_indexes(df, ["nope"])
+
+
+def test_as_col_indexes_int_is_always_a_position():
+    # An `int` cannot be told apart from a pandas integer label, so it is documented and
+    # tested as a position. Here position 0 is the column labelled `5`.
+    df = as_data_frame(pd.DataFrame([["a", 1]], columns=[5, 3]))
+
+    assert as_col_indexes(df, [0]) == [0]
+    assert subset_frame(df, cols=[0]).columns == [5]
 
 
 def test_subset_frame_rows_single(small_df_f: IntoDataFrame):


### PR DESCRIPTION
Follow-up from reviewing #2421. Stacked on #2456, but independent of it — this one is Python-only and could be rebased onto `main` if you'd rather land it separately.

Two internal paths translated a column index into a column *name* and then back again. Column names are not dependable identifiers — they may be empty, and pandas allows names that are not strings — so both now stay positional.

## 1. `apply_frame_patches()` — fewer hops

It grouped patches into a `dict` keyed by column name, looked each name up with `nw_data.columns[index]`, and read the column back with `get_column(name)`. Patches arrive from the browser keyed by column index, so the dict is now keyed by index and the column is read positionally with `nw_data[:, index]`.

That drops both name lookups, and with them the `dict[Any, ScatterValues]` key type (and its explanatory comment) that the non-string-name case had forced. One implicit name step remains and is unavoidable: `with_columns()` matches the scattered Series back onto the frame by its name. That's noted in a comment rather than hidden.

## 2. `subset_frame(cols=)` — narrower internals, same caller-facing input

Callers may still pass names or positions, but resolution now happens once, in a new `as_col_indexes()`, and everything downstream is typed `ColIndexes` (positions only). Things that were previously implicit are now documented, validated, and tested:

- An integer is **always** a position, never a pandas integer label. The two can't be told apart, and narwhals reads a list of ints in the column slot positionally, so a frame labelled `{5: ..., 3: ...}` has to be addressed by position.
- "Integer" means anything integer-like, not just `int`. `isinstance(np.int64(5), int)` is `False`, so a numpy integer used to take the *name* branch and resolve by label equality — inverting the rule for exactly the values `np.where()` and `Index.get_indexer()` produce. Detection is `__index__`-based, and `ColsList` is widened from `str | int` to `str | SupportsIndex` to match.
- `bool` is a `TypeError`. It is a subclass of `int`, so `[True, False]` would otherwise read as positions `[1, 0]`. `StyleInfo`'s `cols` accepts a bool mask; this deliberately does not, rather than silently accepting a third form.
- Positions are bounds-checked. A negative position used to select from the end of the frame, and an out-of-range one escaped as narwhals' `IndexError: positional indexers are out-of-bounds`; both now raise a `ValueError` naming the position, as `update_cell_value()` and `style_info_cols()` already do.
- An unknown name raises `ValueError: Column name 'nope' not found in the data frame. To select a column by position, pass an int.` instead of `ValueError: 'nope' is not in list`.

## Also recorded, not fixed

While testing this I found that on **polars**, any selection that names columns positionally renames a column named `""` to `"column_<position in the result>"` — for `["a", "", "c"]`, `data[:, [0, 1, 2]]` gives `["a", "column_1", "c"]` and `data[:, [2, 1]]` gives `["c", "column_1"]`. It applies to the rows-and-columns branch too; only the rows-only branch is unaffected. No caller in shiny selects columns by position — `data_view()` passes `rows=` only — so this is latent. It's documented in the `subset_frame` docstring rather than worked around, since working around it would mean selecting by name and reintroducing the dependence on names this PR removes. Happy to file it upstream if you think it's a narwhals bug.

No user-facing behavior change, so no CHANGELOG entry.

## Verification

Rebased onto the updated #2421 head (`011c63b2`) — this commit applied cleanly, since the new work on #2421 is all client-side.

- New tests: `apply_frame_patches` on an empty-named column (pandas **and** polars), and `as_col_indexes` covering name resolution, int pass-through, mixed input, the empty list, the unknown-name error, the int-is-a-position rule (pinned with an int that is *also* a label, the only input where the two readings differ), numpy integers, negative and out-of-range positions, and `bool`.
- `tests/pytest` — 1111 passed, 2 skipped.
- `tests/playwright/shiny/components/data_frame` + `.../bugs/1844-datagrid-empty-column-name` — 48 passed, 1 rerun (the known `test_single_selection` flake).
- `uv run make format check-lint check-types` and `make check-pyright` — clean, 0 errors.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
