### PR TITLE
ci: Upgrade astral-sh/setup-uv to v10.0.1 for manifest fetch retries

### DIFF
--- a/.github/py-shiny/narwhals-setup/action.yaml
+++ b/.github/py-shiny/narwhals-setup/action.yaml
@@ -11,7 +11,7 @@ runs:
       shell: bash
       run: |
         if ! command -v uv &> /dev/null; then
-          echo "::error::uv is required but not installed. Please add 'astral-sh/setup-uv@v7' before this action."
+          echo "::error::uv is required but not installed. Please add 'astral-sh/setup-uv@v10.0.1' before this action."
           exit 1
         fi
 

--- a/.github/py-shiny/narwhals-test/action.yaml
+++ b/.github/py-shiny/narwhals-test/action.yaml
@@ -11,7 +11,7 @@ runs:
       shell: bash
       run: |
         if ! command -v uv &> /dev/null; then
-          echo "::error::uv is required but not installed. Please add 'astral-sh/setup-uv@v7' before this action."
+          echo "::error::uv is required but not installed. Please add 'astral-sh/setup-uv@v10.0.1' before this action."
           exit 1
         fi
 

--- a/.github/py-shiny/setup/action.yaml
+++ b/.github/py-shiny/setup/action.yaml
@@ -23,10 +23,15 @@ runs:
       # cache instead of copying files onto the slow `C:` drive where
       # setup-python's interpreter lives.
       - name: Install `uv`
-        # Pinned to an exact release; astral-sh/setup-uv has no floating `v8` tag
-        uses: astral-sh/setup-uv@v8.2.0
+        # Pinned to an exact release; astral-sh/setup-uv has no floating `v10` tag
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
+          # setup-uv v9 flipped this default to false. We keep pruning
+          # because we store a separate cache entry per Python version, and
+          # unpruned entries risk hitting the repo cache limit and evicting
+          # each other.
+          prune-cache: true
           cache-dependency-glob: "pyproject.toml"
           cache-suffix: py${{ inputs.python-version }}
           activate-environment: true

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -411,8 +411,12 @@ jobs:
           python-version: "3.12"
       # Pinned to an exact release; astral-sh/setup-uv has no floating `v10` tag
       - uses: astral-sh/setup-uv@v10.0.1
-              with:
-                prune-cache: true
+        with:
+          # setup-uv v9 flipped this default to false. We keep pruning
+          # because we store a separate cache entry per Python version, and
+          # unpruned entries risk hitting the repo cache limit and evicting
+          # each other.
+          prune-cache: true
 
       - name: Narwhals integration setup
         uses: ./.github/py-shiny/narwhals-setup

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -96,10 +96,15 @@ jobs:
           fetch-depth: 0
 
       - name: Install `uv`
-        # Pinned to an exact release; astral-sh/setup-uv has no floating `v8` tag
-        uses: astral-sh/setup-uv@v8.2.0
+        # Pinned to an exact release; astral-sh/setup-uv has no floating `v10` tag
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
+          # setup-uv v9 flipped this default to false. We keep pruning
+          # because we store a separate cache entry per Python version, and
+          # unpruned entries risk hitting the repo cache limit and evicting
+          # each other.
+          prune-cache: true
           cache-dependency-glob: "pyproject.toml"
           cache-suffix: py3.10-oldest-deps
           activate-environment: true
@@ -404,7 +409,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - uses: astral-sh/setup-uv@v7
+      # Pinned to an exact release; astral-sh/setup-uv has no floating `v10` tag
+      - uses: astral-sh/setup-uv@v10.0.1
 
       - name: Narwhals integration setup
         uses: ./.github/py-shiny/narwhals-setup

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -411,6 +411,8 @@ jobs:
           python-version: "3.12"
       # Pinned to an exact release; astral-sh/setup-uv has no floating `v10` tag
       - uses: astral-sh/setup-uv@v10.0.1
+              with:
+                prune-cache: true
 
       - name: Narwhals integration setup
         uses: ./.github/py-shiny/narwhals-setup


### PR DESCRIPTION
Fixes #2459.

`astral-sh/setup-uv@v8.2.0` resolves the uv version by fetching a manifest from `raw.githubusercontent.com`, and in that release the request has a 5 second timeout and no retry. One transient connection error kills the job during setup, which is what happened in [this "Run deploy tests" job](https://github.com/posit-dev/py-shiny/actions/runs/32180773599/job/95853003964). Upstream added three retries with backoff around that fetch in [astral-sh/setup-uv#1016](https://github.com/astral-sh/setup-uv/pull/1016), first released in v10.0.1.

All three call sites move to v10.0.1, including the narwhals integration job that was still on the floating `v7` tag and has the same exposure. The two guard messages in the narwhals composite actions referenced `@v7`, so they are updated to match.

## Notes for review

Pinning an exact uv `version:` instead would not have avoided this. The download path calls `getArtifact()`, which fetches the same manifest, and the runner tool cache misses on a fresh image.

The upgrade crosses two major versions, and only one breaking change affects us. v9.0.0 flipped the `prune-cache` default from `true` to `false`, so this PR sets `prune-cache: true` explicitly to keep cache behavior identical to today rather than letting it drift as a side effect of a reliability fix. The reasoning is in a comment next to the input. v10.0.0's breaking change only applies to `enable-cache: auto`, and we set `enable-cache: true`.

Verified that the retry is present in the shipped `dist/setup/index.cjs` bundle at the v10.0.1 tag, not only in source, and that every input we pass is still declared in that release's `action.yml`.

This only takes effect for CI runs after merge, so the fix cannot be demonstrated in this PR's own checks.
