### PR TITLE
fix(playwright): Allocate remote server ports dynamically

### DIFF
--- a/.github/py-shiny/setup-playwright-remote/action.yaml
+++ b/.github/py-shiny/setup-playwright-remote/action.yaml
@@ -28,9 +28,9 @@ inputs:
     required: false
     default: "chromium"
   port:
-    description: "Port to expose the Playwright server on"
+    description: "Fixed host and container port. By default, Docker selects an available host port."
     required: false
-    default: "43424"
+    default: ""
   container-name:
     description: "Docker container name"
     required: false
@@ -138,25 +138,14 @@ runs:
         fi
 
     - name: Start Playwright server
+      id: start-server
       shell: bash
+      env:
+        CONTAINER_NAME: ${{ inputs.container-name }}
+        IMAGE_REF: ${{ steps.server-image.outputs.image-ref }}
+        PLAYWRIGHT_PORT: ${{ inputs.port }}
       run: |
-        docker rm -f "${{ inputs.container-name }}" >/dev/null 2>&1 || true
-
-        # No --rm: if the server crashes, the container must survive so the
-        # logs-on-failure step below can read it. `docker rm -f` above cleans
-        # up any leftover container from a previous attempt.
-        # Playwright exits run-server when stdin closes. Keep stdin open in
-        # detached mode, as required by Playwright's documented Docker setup.
-        docker run -d \
-          --interactive \
-          --name "${{ inputs.container-name }}" \
-          --ipc=host \
-          -p "127.0.0.1:${{ inputs.port }}:${{ inputs.port }}" \
-          --init \
-          --workdir /home/pwuser \
-          --user pwuser \
-          "${{ steps.server-image.outputs.image-ref }}" \
-          /bin/sh -c "npx --no -- playwright run-server --port ${{ inputs.port }} --host 0.0.0.0"
+        bash "${{ github.action_path }}/start-server.sh"
 
     - name: Wait for Playwright server
       shell: bash
@@ -167,7 +156,7 @@ runs:
         from urllib.request import urlopen
 
         host = "127.0.0.1"
-        port = int("${{ inputs.port }}")
+        port = int("${{ steps.start-server.outputs.host-port }}")
         metadata_url = f"http://{host}:{port}/json"
         deadline = time.time() + 60
         last_error = None
@@ -199,7 +188,7 @@ runs:
       id: set-env
       shell: bash
       run: |
-        WS_ENDPOINT="ws://127.0.0.1:${{ inputs.port }}/"
+        WS_ENDPOINT="ws://127.0.0.1:${{ steps.start-server.outputs.host-port }}/"
         echo "PW_TEST_CONNECT_WS_ENDPOINT=$WS_ENDPOINT" >> "$GITHUB_ENV"
         echo 'PW_TEST_CONNECT_EXPOSE_NETWORK=*' >> "$GITHUB_ENV"
         echo "ws-endpoint=$WS_ENDPOINT" >> "$GITHUB_OUTPUT"

--- a/.github/py-shiny/setup-playwright-remote/start-server.sh
+++ b/.github/py-shiny/setup-playwright-remote/start-server.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ -n "${PLAYWRIGHT_PORT:-}" ]; then
+  container_port="$PLAYWRIGHT_PORT"
+  published_port="127.0.0.1:${container_port}:${container_port}"
+else
+  container_port=$(python3 - <<'PY'
+import socket
+
+with socket.socket() as sock:
+    sock.bind(("127.0.0.1", 0))
+    print(sock.getsockname()[1])
+PY
+  )
+  published_port="127.0.0.1::${container_port}"
+fi
+
+if ! [[ "$container_port" =~ ^[0-9]+$ ]] || [ "$container_port" -lt 1 ] || [ "$container_port" -gt 65535 ]; then
+  echo "Invalid Playwright server port: $container_port" >&2
+  exit 1
+fi
+
+docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+
+# No --rm: if the server crashes, the container must survive so the
+# logs-on-failure step can read it. The command above removes an old container.
+# Playwright exits run-server when stdin closes. Keep stdin open in detached
+# mode, as required by Playwright's documented Docker setup.
+docker run -d \
+  --interactive \
+  --name "$CONTAINER_NAME" \
+  --ipc=host \
+  -p "$published_port" \
+  --init \
+  --workdir /home/pwuser \
+  --user pwuser \
+  "$IMAGE_REF" \
+  /bin/sh -c "npx --no -- playwright run-server --port $container_port --host 0.0.0.0"
+
+host_binding=$(docker port "$CONTAINER_NAME" "$container_port/tcp")
+host_port="${host_binding##*:}"
+if ! [[ "$host_port" =~ ^[0-9]+$ ]]; then
+  echo "Could not resolve the Playwright server host port: $host_binding" >&2
+  exit 1
+fi
+
+echo "host-port=$host_port" >> "$GITHUB_OUTPUT"

--- a/.github/py-shiny/setup-playwright-remote/start-server.sh
+++ b/.github/py-shiny/setup-playwright-remote/start-server.sh
@@ -14,9 +14,11 @@ with socket.socket() as sock:
     print(sock.getsockname()[1])
 PY
   )
+  # An empty host port tells Docker to select an available port.
   published_port="127.0.0.1::${container_port}"
 fi
 
+# TCP and UDP port numbers are unsigned 16-bit integers.
 if ! [[ "$container_port" =~ ^[0-9]+$ ]] || [ "$container_port" -lt 1 ] || [ "$container_port" -gt 65535 ]; then
   echo "Invalid Playwright server port: $container_port" >&2
   exit 1

--- a/tests/pytest/test_playwright_reliability.py
+++ b/tests/pytest/test_playwright_reliability.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
 import importlib.util
-import os
-import re
-import subprocess
 from pathlib import Path
 from types import ModuleType
 from typing import Any, Callable
@@ -45,51 +42,6 @@ def test_remote_playwright_readiness_uses_server_metadata() -> None:
     assert "/json" in action
     assert "wsEndpointPath" in action
     assert "socket.socket" not in action
-
-
-def test_remote_playwright_server_uses_dynamic_default_ports(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    fake_bin = tmp_path / "bin"
-    fake_bin.mkdir()
-    docker_calls = tmp_path / "docker-calls"
-    github_output = tmp_path / "github-output"
-    fake_docker = fake_bin / "docker"
-    fake_docker.write_text("""#!/usr/bin/env bash
-printf '%s\\n' "$*" >> "$DOCKER_CALLS"
-if [ "$1" = "run" ]; then
-  echo "container-id"
-elif [ "$1" = "port" ]; then
-  echo "127.0.0.1:51234"
-fi
-""")
-    fake_docker.chmod(0o755)
-
-    monkeypatch.setenv("CONTAINER_NAME", "playwright-test")
-    monkeypatch.setenv("DOCKER_CALLS", str(docker_calls))
-    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
-    monkeypatch.setenv("IMAGE_REF", "playwright:test")
-    monkeypatch.setenv("PATH", f"{fake_bin}{os.pathsep}{os.environ['PATH']}")
-    monkeypatch.setenv("PLAYWRIGHT_PORT", "")
-
-    subprocess.run(
-        ["bash", str(PLAYWRIGHT_REMOTE_START_SERVER)],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-
-    calls = docker_calls.read_text().splitlines()
-    run_call = next(call for call in calls if call.startswith("run "))
-    port_call = next(call for call in calls if call.startswith("port "))
-    published_port = re.search(r"-p 127\.0\.0\.1::(\d+)", run_call)
-    server_port = re.search(r"run-server --port (\d+)", run_call)
-    assert published_port is not None
-    assert server_port is not None
-    assert published_port.group(1) == server_port.group(1)
-    assert port_call == f"port playwright-test {server_port.group(1)}/tcp"
-    assert github_output.read_text() == "host-port=51234\n"
 
 
 def test_new_shared_page_does_not_repeat_initial_blank_navigation(

--- a/tests/pytest/test_playwright_reliability.py
+++ b/tests/pytest/test_playwright_reliability.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import importlib.util
+import os
+import re
+import subprocess
 from pathlib import Path
 from types import ModuleType
 from typing import Any, Callable
@@ -18,6 +21,7 @@ PLAYWRIGHT_REMOTE_ACTION = (
     / "setup-playwright-remote"
     / "action.yaml"
 )
+PLAYWRIGHT_REMOTE_START_SERVER = PLAYWRIGHT_REMOTE_ACTION.parent / "start-server.sh"
 
 
 def _load_module(name: str, path: Path) -> ModuleType:
@@ -30,7 +34,7 @@ def _load_module(name: str, path: Path) -> ModuleType:
 
 
 def test_remote_playwright_server_keeps_stdin_open() -> None:
-    action = PLAYWRIGHT_REMOTE_ACTION.read_text()
+    action = PLAYWRIGHT_REMOTE_START_SERVER.read_text()
 
     assert "--interactive" in action
 
@@ -41,6 +45,51 @@ def test_remote_playwright_readiness_uses_server_metadata() -> None:
     assert "/json" in action
     assert "wsEndpointPath" in action
     assert "socket.socket" not in action
+
+
+def test_remote_playwright_server_uses_dynamic_default_ports(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    docker_calls = tmp_path / "docker-calls"
+    github_output = tmp_path / "github-output"
+    fake_docker = fake_bin / "docker"
+    fake_docker.write_text("""#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$DOCKER_CALLS"
+if [ "$1" = "run" ]; then
+  echo "container-id"
+elif [ "$1" = "port" ]; then
+  echo "127.0.0.1:51234"
+fi
+""")
+    fake_docker.chmod(0o755)
+
+    monkeypatch.setenv("CONTAINER_NAME", "playwright-test")
+    monkeypatch.setenv("DOCKER_CALLS", str(docker_calls))
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+    monkeypatch.setenv("IMAGE_REF", "playwright:test")
+    monkeypatch.setenv("PATH", f"{fake_bin}{os.pathsep}{os.environ['PATH']}")
+    monkeypatch.setenv("PLAYWRIGHT_PORT", "")
+
+    subprocess.run(
+        ["bash", str(PLAYWRIGHT_REMOTE_START_SERVER)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    calls = docker_calls.read_text().splitlines()
+    run_call = next(call for call in calls if call.startswith("run "))
+    port_call = next(call for call in calls if call.startswith("port "))
+    published_port = re.search(r"-p 127\.0\.0\.1::(\d+)", run_call)
+    server_port = re.search(r"run-server --port (\d+)", run_call)
+    assert published_port is not None
+    assert server_port is not None
+    assert published_port.group(1) == server_port.group(1)
+    assert port_call == f"port playwright-test {server_port.group(1)}/tcp"
+    assert github_output.read_text() == "host-port=51234\n"
 
 
 def test_new_shared_page_does_not_repeat_initial_blank_navigation(


### PR DESCRIPTION
## Summary

- The action selects an available container port when `port` is empty.
- Docker selects an available host port and returns it to the action.
- The readiness probe and pytest use the resolved host port.
- A caller can still set `port` for a fixed mapping.

## Problem

The action used port `43424` for every remote Playwright server. A port collision stopped `run-server` before the tests started.

Closes #2444