### PR TITLE
ci(tests): pin plotly to <7 to fix failing example tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ test = [
     "shinychat>=0.6.0",
     "seaborn",
     "plotnine",
-    "plotly",
+    "plotly<7",
     "anywidget",
     "duckdb",
     "holoviews",


### PR DESCRIPTION
### Summary

Plotly 7.0.0 was recently released and removed `plotly.figure_factory.create_distplot`, which caused the `nba-dashboard` external template tests in `test_external_templates.py` to fail with:
```
AttributeError: module 'plotly.figure_factory' has no attribute 'create_distplot'
```

This pins `plotly<7` in the optional test dependencies in [pyproject.toml](file:///Users/karangathani/Documents/GitHub/py-shiny/pyproject.toml) so CI installs a compatible version of Plotly for example tests.