### PR TITLE
test(playwright): assert InputSelect multiple selection order

### DIFF
--- a/tests/playwright/shiny/inputs/input_kitchensink/input_select/test_input_select_kitchensink.py
+++ b/tests/playwright/shiny/inputs/input_kitchensink/input_select/test_input_select_kitchensink.py
@@ -23,7 +23,15 @@ def test_input_select_kitchensink(page: Page, local_app: ShinyAppProc) -> None:
     multiple_options = ["Banana", "Cherry"]
     multiple_select.set(multiple_options)
     multiple_select.expect_multiple(True)
+    multiple_select.expect_selected(multiple_options)
     multiple_select_txt.expect_value("Banana, Cherry")
+
+    # A multiple select's value is always in choices order, never selection order.
+    # `.expect_selected()` asserts that same order, so it must list the values in
+    # choices order even when they were selected in a different one.
+    multiple_select.set(["Elderberry", "Apple"])
+    multiple_select.expect_selected(["Apple", "Elderberry"])
+    multiple_select_txt.expect_value("Apple, Elderberry")
 
     select_with_selected = controller.InputSelect(page, "select_with_selected")
     select_with_selected_txt = controller.OutputCode(page, "select_with_selected_txt")


### PR DESCRIPTION
## Summary

Follow-up to the discussion on #2468 / #2123.

A multiple `<select>`'s input value is always in **choices order**, never selection order — and `InputSelect.expect_selected()` asserts that same order. Nothing in the suite covered it, so the contract was only implicit.

This adds the out-of-order case to the select kitchensink: select `["Elderberry", "Apple"]` (reverse of choices order) and assert that both the controller and the server-side input value report `["Apple", "Elderberry"]`. It also adds the missing in-order `expect_selected()` assertion on the same input, which had a `.set()` but no selection assertion at all.

This mirrors the coverage `InputSelectize` already has at `tests/playwright/shiny/inputs/input_selectize/test_input_selectize.py:68-70`, where the order is *selection* order and is likewise pinned to the input value.

Not stacked on #2468: that PR's head branch lives on a fork, so a PR in this repo can't target it — and these assertions are independent of it, since it only touches `InputCheckboxGroup`.

## Testing

- `pytest -c tests/playwright/playwright-pytest.ini tests/playwright/shiny/inputs/input_kitchensink/input_select --browser chromium -q` — 2 passed
- Confirmed non-vacuous: reversing the expected list to `["Elderberry", "Apple"]` fails
- `uv run make format check-lint check-types` and `make check-pyright` — clean
