### PR TITLE
chore: migrate stub generation to Pyrefly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
+* Stub files for `folium`, `uvicorn`, and `seaborn` are now generated with Pyrefly instead of Pyright. (Thanks, @ChidiebereNjoku!) (#2478)
+
 * The README and the `shiny skills` CLI help now explain that [`library-skills`](https://library-skills.io) must be run from your own project directory, since it installs the bundled Agent Skills of the packages that project has installed. The previous wording left that precondition implicit, so running the command from an empty directory or from a clone of py-shiny silently installed nothing. (#2447)
 
 * Navsets created with an `id` (e.g. `ui.navset_tab(id="tabs")`) now use that `id` as their `data-tabsetid`, so their tab panes get stable `tab-tabs-0` style DOM ids instead of ones built from a random integer. This makes the rendered markup reproducible across renders and easier to target from custom CSS and JavaScript. Navsets without an `id`, and `ui.nav_menu()` dropdowns, keep the random ID. (Thanks, @pevolution-ahmed!) (#2410)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ steps.
 ### Type Checking Notes
 
 - Pyright is the primary type checker (not mypy)
-- Some packages require manual stubs: run `make pyright-typings` to generate
+- Some packages require manual stubs: run `make typings` to generate
 - Stubs are placed in `typings/` (gitignored)
 - Parameter types: prefer `T | None` over `Optional[T]` when no default `None` value is provided
 - Use `Literal` instead of `Enum` for string options

--- a/Makefile
+++ b/Makefile
@@ -58,13 +58,16 @@ clean-test: FORCE
 
 typings/folium:
 	@echo "Creating folium stubs"
-	pyright --createstub folium
+	pyrefly stubgen "$$(python -c "import importlib.util as u,os;print(os.path.dirname(u.find_spec('folium').origin))")" \
+		-o typings/folium --include-private
 typings/uvicorn:
 	@echo "Creating uvicorn stubs"
-	pyright --createstub uvicorn
+	pyrefly stubgen "$$(python -c "import importlib.util as u,os;print(os.path.dirname(u.find_spec('uvicorn').origin))")" \
+		-o typings/uvicorn --include-private
 typings/seaborn:
 	@echo "Creating seaborn stubs"
-	pyright --createstub seaborn
+	pyrefly stubgen "$$(python -c "import importlib.util as u,os;print(os.path.dirname(u.find_spec('seaborn').origin))")" \
+		-o typings/seaborn --include-private
 typings/matplotlib/__init__.pyi:
 	@echo "Creating matplotlib stubs"
 	mkdir -p typings
@@ -72,7 +75,7 @@ typings/matplotlib/__init__.pyi:
 	mv typings/python-type-stubs/stubs/matplotlib typings/
 	rm -rf typings/python-type-stubs
 
-pyright-typings: typings/folium typings/uvicorn typings/seaborn typings/matplotlib/__init__.pyi
+pyrefly-typings: typings/folium typings/uvicorn typings/seaborn typings/matplotlib/__init__.pyi
 
 check: check-format check-lint check-types check-tests  ## check code, style, types, and test (basic CI)
 check-fix: format check-lint check-types check-tests ## check and format code, style, types, and test
@@ -90,13 +93,13 @@ check-black: FORCE
 check-isort: FORCE
 	@echo "-------- Sorting imports with isort ---------"
 	isort --check-only --diff .
-check-pyright: pyright-typings
+check-pyright: pyrefly-typings
 	@echo "-------- Checking types with pyright --------"
 	pyright
-check-pyrefly: pyright-typings
+check-pyrefly: pyrefly-typings
 	@echo "-------- Checking types with pyrefly --------"
 	pyrefly check
-update-pyrefly-baseline: pyright-typings ## Accept current Pyrefly errors as the baseline
+update-pyrefly-baseline: pyrefly-typings ## Accept current Pyrefly errors as the baseline
 	pyrefly check --baseline pyrefly-baseline.json --update-baseline
 check-pytest: FORCE
 	@echo "-------- Running tests with pytest ----------"

--- a/Makefile
+++ b/Makefile
@@ -58,16 +58,16 @@ clean-test: FORCE
 
 typings/folium:
 	@echo "Creating folium stubs"
-	pyrefly stubgen "$$(python -c "import importlib.util as u,os;print(os.path.dirname(u.find_spec('folium').origin))")" \
-		-o typings/folium --include-private
+	dir="$$(python -c "import importlib.util as u,os;print(os.path.dirname(u.find_spec('folium').origin))")" && \
+		pyrefly stubgen "$$dir" -o typings/folium --include-private
 typings/uvicorn:
 	@echo "Creating uvicorn stubs"
-	pyrefly stubgen "$$(python -c "import importlib.util as u,os;print(os.path.dirname(u.find_spec('uvicorn').origin))")" \
-		-o typings/uvicorn --include-private
+	dir="$$(python -c "import importlib.util as u,os;print(os.path.dirname(u.find_spec('uvicorn').origin))")" && \
+		pyrefly stubgen "$$dir" -o typings/uvicorn --include-private
 typings/seaborn:
 	@echo "Creating seaborn stubs"
-	pyrefly stubgen "$$(python -c "import importlib.util as u,os;print(os.path.dirname(u.find_spec('seaborn').origin))")" \
-		-o typings/seaborn --include-private
+	dir="$$(python -c "import importlib.util as u,os;print(os.path.dirname(u.find_spec('seaborn').origin))")" && \
+		pyrefly stubgen "$$dir" -o typings/seaborn --include-private
 typings/matplotlib/__init__.pyi:
 	@echo "Creating matplotlib stubs"
 	mkdir -p typings
@@ -75,7 +75,7 @@ typings/matplotlib/__init__.pyi:
 	mv typings/python-type-stubs/stubs/matplotlib typings/
 	rm -rf typings/python-type-stubs
 
-pyrefly-typings: typings/folium typings/uvicorn typings/seaborn typings/matplotlib/__init__.pyi
+typings: FORCE typings/folium typings/uvicorn typings/seaborn typings/matplotlib/__init__.pyi
 
 check: check-format check-lint check-types check-tests  ## check code, style, types, and test (basic CI)
 check-fix: format check-lint check-types check-tests ## check and format code, style, types, and test
@@ -93,13 +93,13 @@ check-black: FORCE
 check-isort: FORCE
 	@echo "-------- Sorting imports with isort ---------"
 	isort --check-only --diff .
-check-pyright: pyrefly-typings
+check-pyright: typings
 	@echo "-------- Checking types with pyright --------"
 	pyright
-check-pyrefly: pyrefly-typings
+check-pyrefly: typings
 	@echo "-------- Checking types with pyrefly --------"
 	pyrefly check
-update-pyrefly-baseline: pyrefly-typings ## Accept current Pyrefly errors as the baseline
+update-pyrefly-baseline: typings ## Accept current Pyrefly errors as the baseline
 	pyrefly check --baseline pyrefly-baseline.json --update-baseline
 check-pytest: FORCE
 	@echo "-------- Running tests with pytest ----------"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,7 +152,7 @@ dev = [
     "isort>=5.10.1",
     "libsass>=0.23.0",
     "brand_yml>=0.2.0",
-    "pyrefly>=1.1.1",
+    "pyrefly>=1.2.0",
     "pyright>=1.1.407",
     "pre-commit>=2.15.0",
     "wheel",

--- a/shiny/_uvicorn.py
+++ b/shiny/_uvicorn.py
@@ -28,7 +28,7 @@ _UVICORN_STARTUP_FAILURE = 3
 
 class ShinyConfig(Config):
     # uvicorn's Config assigns these in __init__, but the generated stubs
-    # (`make pyright-typings`) omit instance attributes, so declare them here.
+    # (`make typings`) omit instance attributes, so declare them here.
     reload: bool
     workers: int
     uds: str | None


### PR DESCRIPTION
## Summary

* bump the minimum Pyrefly version to 1.2.0
* migrate folium, uvicorn, and seaborn stub generation from `pyright --createstub` to `pyrefly stubgen --include-private`
* rename the aggregate Makefile target from `pyright-typings` to `pyrefly-typings`
* keep the Pyright checker, dependency, and matplotlib stub-generation process unchanged

## Testing

* `git diff --check`
* parsed `pyproject.toml` successfully with `tomllib`
* verified the generated commands with `make -n pyrefly-typings`
* verified Makefile tabs and line continuations

Full stub generation could not complete in my 2-core Codespace because Pyrefly was terminated or timed out while processing Folium.

Closes #2479 
