### PR TITLE
test: turn unexpected warnings into errors

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -12,4 +12,8 @@ filterwarnings =
     ; narwhals calls polars' deprecated `cat.get_categories()`
     ; https://github.com/narwhals-dev/narwhals/issues/3895
     ignore:`cat.get_categories\(\)` is deprecated:DeprecationWarning
+    ; Raised from finalizers at GC time (e.g. a `TemporaryDirectory` held by a
+    ; session that never ends), so as an error it fails whichever test happens to
+    ; be running when the collector fires, not the test that leaked.
+    ignore::ResourceWarning
 ; verbosity_test_cases=2

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,4 +5,11 @@ asyncio_default_fixture_loop_scope=function
 testpaths=tests/pytest/
 ; Note: Browsers are set within `./Makefile`
 addopts = --strict-markers --durations=6 --durations-min=5.0 --numprocesses auto
+; Tests must not emit stray warnings; assert expected ones with `pytest.warns()`.
+; Third-party deprecations we can't act on go in the ignore list below.
+filterwarnings =
+    error
+    ; narwhals calls polars' deprecated `cat.get_categories()`
+    ; https://github.com/narwhals-dev/narwhals/issues/3895
+    ignore:`cat.get_categories\(\)` is deprecated:DeprecationWarning
 ; verbosity_test_cases=2

--- a/pytest.ini
+++ b/pytest.ini
@@ -12,8 +12,10 @@ filterwarnings =
     ; narwhals calls polars' deprecated `cat.get_categories()`
     ; https://github.com/narwhals-dev/narwhals/issues/3895
     ignore:`cat.get_categories\(\)` is deprecated:DeprecationWarning
-    ; Raised from finalizers at GC time (e.g. a `TemporaryDirectory` held by a
-    ; session that never ends), so as an error it fails whichever test happens to
-    ; be running when the collector fires, not the test that leaked.
+    ; Both of these are raised from finalizers at GC time (a leaked
+    ; `TemporaryDirectory`, an abandoned coroutine), so as errors they fail
+    ; whichever test happens to be running when the collector fires rather than the
+    ; test at fault -- i.e. they make the suite flaky instead of strict.
     ignore::ResourceWarning
+    ignore::pytest.PytestUnraisableExceptionWarning
 ; verbosity_test_cases=2

--- a/tests/pytest/test_offcanvas.py
+++ b/tests/pytest/test_offcanvas.py
@@ -317,9 +317,11 @@ def test_show_offcanvas_with_html_wraps_new_panel():
     """show_offcanvas() treats htmltools.HTML() as content, not an id"""
     mock_session = _mock_session()
 
-    result_id = ui.show_offcanvas(
-        HTML("<p>Rendered content.</p>"), session=mock_session
-    )
+    # An anonymous panel has no title, so it also warns about accessibility.
+    with pytest.warns(UserWarning, match="aria-label"):
+        result_id = ui.show_offcanvas(
+            HTML("<p>Rendered content.</p>"), session=mock_session
+        )
 
     assert isinstance(result_id, str) and result_id != ""
     assert mock_session._send_message_sync.call_count == 1
@@ -333,7 +335,9 @@ def test_show_offcanvas_with_tag_wraps_new_panel():
     """show_offcanvas() wraps a bare Tag into a new anonymous offcanvas"""
     mock_session = _mock_session()
 
-    result_id = ui.show_offcanvas(tags.p("Body content"), session=mock_session)
+    # An anonymous panel has no title, so it also warns about accessibility.
+    with pytest.warns(UserWarning, match="aria-label"):
+        result_id = ui.show_offcanvas(tags.p("Body content"), session=mock_session)
 
     assert mock_session._send_message_sync.call_count == 1
     message = mock_session._messages_sent[0]

--- a/tests/pytest/test_renderer.py
+++ b/tests/pytest/test_renderer.py
@@ -109,13 +109,13 @@ def test_renderer_error_includes_render_prefix():
 def test_download_rejects_function_with_params():
     with pytest.raises(TypeError, match="no required parameters"):
 
-        @render.download  # pyright: ignore[reportArgumentType]
+        @render.download_button  # pyright: ignore[reportArgumentType]
         def bad_download(x: int) -> str:
             return str(x)
 
 
 def test_download_accepts_function_with_no_params():
-    @render.download
+    @render.download_button
     def good_download():
         return "file.txt"
 
@@ -123,7 +123,7 @@ def test_download_accepts_function_with_no_params():
 def test_download_warns_function_with_default_params():
     with pytest.warns(UserWarning, match="parameter.*with default values: x"):
 
-        @render.download
+        @render.download_button
         def good_download(x: str = "file.txt") -> str:
             return x
 


### PR DESCRIPTION
The unit suite was emitting 7 warnings. This clears them and adds
`filterwarnings = error` to `pytest.ini` so new ones fail the suite instead of
scrolling past.

### What was warning

* **`render.download` deprecation (3 tests).** Three `test_renderer.py`
  validation tests still decorated with the deprecated `render.download`; they
  now use `render.download_button`. The deprecation itself is still covered by
  `test_render_download_is_deprecated`.
* **Offcanvas accessibility (2 tests).** The two anonymous-panel
  `show_offcanvas()` tests legitimately trigger the "should have an
  `aria-label`" warning — `show_offcanvas()` on bare content has no way to set
  a title — so they now assert it with `pytest.warns()` rather than leak it.
* **polars `cat.get_categories()` (2 tests).** Not ours to fix — see below.

### The narwhals bug this turned up

Chasing the last warning found a real upstream problem, filed as
**https://github.com/narwhals-dev/narwhals/issues/3895**.

`serialize_dtype()` in `shiny/render/_data_frame_utils/_tbl_data.py` calls
`col.cat.get_categories()` to send a categorical column's levels to the client.
narwhals' polars cat namespace is a pure passthrough — `class
PolarsSeriesCatNamespace(PolarsSeriesNamespace, PolarsCatNamespace): ...`, an
empty body dispatching via `__getattr__` — so that lands verbatim on polars'
own `Series.cat.get_categories()`, deprecated as of polars 1.44 and documented
for removal in polars 2.0. It isn't only test noise: **any app rendering a
polars categorical column prints this `DeprecationWarning` to its user's
console**, and there's nothing the app author can do about it.

I prototyped a fix in `_tbl_data.py` and then threw it away, because every
version of it was polars-specific, which defeats the point of going through
narwhals at all:

* Branching on `col.implementation.is_polars()` to read the native series works,
  but puts backend-specific code in a module whose whole job is being
  backend-agnostic.
* `col.unique(maintain_order=True)` is backend-agnostic but wrong: pandas
  categoricals carry *declared* categories, including unused ones and in
  declared order, and two existing test cases cover exactly that.
* `dtype.categories` — what polars' own deprecation message recommends — raises
  `AttributeError: 'narwhals.stable.v1._dtypes.Enum' object has no attribute
  '_cached_categories'`, because `narwhals/stable/v1/_dtypes.py` skips
  `NwEnum.__init__`. We import `narwhals.stable.v1`, so the documented
  workaround is unavailable to us. That's noted as a secondary item on the
  issue.

So the upstream issue is the fix, with a scoped ignore in `pytest.ini` holding
the line until it lands. It carries a runnable reprex, its real output, a
suggested implementation for the polars backend (Enum → `pl.Series(dtype.categories)`,
Categorical → `unique(maintain_order=True).drop_nulls().cast(pl.String)`, both
verified to return today's values), and an offer to send the PR.

### Note on `filterwarnings = error`

The tradeoff: a new pandas/polars/starlette release that adds a
`DeprecationWarning` will turn CI red on an unrelated PR. The fix is one ignore
line, and the red is usually a real signal — as the narwhals case shows, a
warning in our test output was a warning in users' app consoles. Every ignore
carries a comment so the list stays prunable.

CI turned up a second, more awkward class, which the later commits here ignore:

* `ResourceWarning` from a leaked `TemporaryDirectory` (failed the oldest-deps
  job, blamed on `test_theme_css_compiles_and_is_cached`).
* `PytestUnraisableExceptionWarning` wrapping `ValueError: <Token ...> was
  created in a different Context` from an abandoned
  `ExtendedTask._done_callback` coroutine (failed 3.12/macOS, blamed on
  `test_otel_reactive_execution.py`).

Both are raised from finalizers at GC time, so they fail whichever test happens
to be running when the collector fires rather than the test at fault — flaky
rather than strict, so they're ignored as a class. Warnings raised on a real
call stack are still fatal, which is where the value is.

The `ExtendedTask` one looks like a genuine latent bug (a context token reset
from the wrong context during teardown), currently invisible because it only
happens in an abandoned coroutine. Out of scope here; worth its own issue.

No library code changes; test config and tests only.

