### PR TITLE
fix: keep a reference to the ExtendedTask completion task

### DIFF
--- a/shiny/reactive/_extended_task.py
+++ b/shiny/reactive/_extended_task.py
@@ -109,6 +109,11 @@ class ExtendedTask(Generic[P, R]):
         # If invoked while a previous invocation is still running, we queue up.
         self._invocation_queue: list[Callable[[], None]] = []
 
+        # The event loop only holds weak references to running tasks, so a task with no
+        # other reference can be garbage collected mid-flight. Keep the completion tasks
+        # created in `_done_callback()` alive until they finish.
+        self._done_tasks: set[asyncio.Task[None]] = set()
+
     def cancel(self) -> None:
         """
         Cancel the current invocation, if any. If there are pending invocations, cancel
@@ -214,7 +219,9 @@ class ExtendedTask(Generic[P, R]):
                     next_invocation()
                     await flush()
 
-        asyncio.create_task(_impl())
+        done_task = asyncio.create_task(_impl())
+        self._done_tasks.add(done_task)
+        done_task.add_done_callback(self._done_tasks.discard)
 
     def result(self) -> R:
         """

--- a/tests/pytest/test_destroy.py
+++ b/tests/pytest/test_destroy.py
@@ -1955,3 +1955,40 @@ async def test_extended_task_in_module_settling_after_close_completes():
     with isolate():
         assert task.status() == "success"
         assert task.result() == "streamed"
+
+
+@pytest.mark.asyncio
+async def test_extended_task_completion_survives_gc():
+    """The task that settles an `ExtendedTask` must outlive a collection pass.
+
+    The event loop only holds weak references to running tasks, so the completion
+    task created in `_done_callback()` needs a strong reference of its own or the
+    status update and flush can be dropped.
+    """
+    root = _make_real_app_session()
+    finish: asyncio.Future[int] = asyncio.get_running_loop().create_future()
+
+    with session_context(root):
+
+        @extended_task
+        async def task() -> int:
+            return await finish
+
+        task()
+        await flush()
+
+    finish.set_result(42)
+    # Let the task finish so `_done_callback()` schedules the completion task, then
+    # collect while that task is still pending.
+    for _ in range(3):
+        await asyncio.sleep(0)
+    assert len(task._done_tasks) == 1
+    gc.collect()
+
+    for _ in range(10):
+        await asyncio.sleep(0)
+
+    with isolate():
+        assert task.status() == "success"
+        assert task.result() == 42
+    assert task._done_tasks == set(), "Completion task was not released once done"


### PR DESCRIPTION
`ExtendedTask._done_callback()` discarded the result of `asyncio.create_task()`:

```python
asyncio.create_task(_impl())
```

The event loop only keeps weak references to running tasks, so a task whose only
reference is the loop's internal set can be garbage collected mid-flight. The
[asyncio docs](https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task)
are explicit about this: *"Save a reference to the result of this function, to
avoid a task disappearing mid-execution."*

If `_impl()` were collected, an `@reactive.extended_task` would lose its status
update, its value/error assignment, and the `flush()` that lets reactive
dependencies move forward — the task would simply never settle. This holds the
completion tasks in a set and discards each on completion.

### On "proven"

Honest accounting of what the test does and does not show:

* The new test asserts the invariant directly — the completion task is
  referenced while pending, survives a `gc.collect()`, settles the task, and is
  released once done. It fails against the old code.
* It is **not** a red-before-green reproduction of an actual dropped task. To
  collect the task for real it has to be unreachable from both the loop's ready
  queue and any future it awaits, and `_impl()` awaits `lock()`, whose waiter
  future holds a callback that references it. That is exactly why the bug is
  latent rather than reported: it needs an interleaving I could not construct on
  demand.

So this is a defensive fix that follows the documented requirement, not a repair
for an observed failure. No behavior changes on any path that works today.

### Context

Found while making the test suite warning-free (#2480). Under
`filterwarnings = error`, a `ValueError: <Token ...> was created in a different
Context` escaping this coroutine during event-loop teardown failed an unrelated
test on the 3.12/macOS job. That symptom is a teardown artifact and is ignored in
`pytest.ini`; the missing reference is the real issue underneath it, so it is
fixed here.

No CHANGELOG entry: nothing user-visible changes.
