### PR TITLE
test: ignore starlette's deprecated `anyio.abc.BlockingPortal` annotation

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -12,6 +12,12 @@ filterwarnings =
     ; narwhals calls polars' deprecated `cat.get_categories()`
     ; https://github.com/narwhals-dev/narwhals/issues/3895
     ignore:`cat.get_categories\(\)` is deprecated:DeprecationWarning
+    ; starlette's `TestClient` module annotates with `anyio.abc.BlockingPortal`,
+    ; whose alias anyio 4.15.0 deprecated -- so as an error it breaks *collection*
+    ; of any test importing `starlette.testclient`. Fixed on starlette's master by
+    ; https://github.com/encode/starlette/pull/3498 but unreleased as of 1.6.0;
+    ; delete this once we require the release that contains it.
+    ignore:The anyio.abc.BlockingPortal alias is deprecated:DeprecationWarning
     ; Both of these are raised from finalizers at GC time (a leaked
     ; `TemporaryDirectory`, an abandoned coroutine), so as errors they fail
     ; whichever test happens to be running when the collector fires rather than the


### PR DESCRIPTION
`main` has been red since 2026-09-03 and no py-shiny commit caused it.

### What's happening

`tests/pytest/test_app_ui_page_html.py` fails to **collect** — an import error, not a test failure:

```
tests/pytest/test_app_ui_page_html.py:8: from starlette.testclient import TestClient
  starlette/testclient.py:53: _PortalFactoryType = Callable[[], AbstractContextManager[anyio.abc.BlockingPortal]]
E DeprecationWarning: The anyio.abc.BlockingPortal alias is deprecated,
  use anyio.from_thread.BlockingPortal instead.
```

Because the annotation is evaluated at module import, `filterwarnings = error` turns a third-party deprecation into a collection failure — so all ~100 matrix jobs die, not just this test.

Three things collided:

| Date | Event |
|---|---|
| 2026-08-08 | starlette 1.6.0 released, still annotating with `anyio.abc.BlockingPortal` |
| 2026-09-02 | **anyio 4.15.0** released, deprecating that alias |
| 2026-09-03 | daily `main` run starts failing |
| 2026-09-05 | starlette merges the fix; anyio 4.15.1 released |

`#2480` (`filterwarnings = error`) and `#2475` (added the only test importing `starlette.testclient`) were both correct; an unpinned transitive dep moved underneath them.

### Fix

Ignore this one warning. It's deliberately temporary — starlette already fixed it on master in [encode/starlette#3498](https://github.com/encode/starlette/pull/3498) (merged 2026-09-05, followed by #3512 dropping AnyIO 3 support entirely), but there's no release containing it yet; I checked the `1.6.0` tag directly and it still has the old line. The comment names the PR so the next person knows the deletion condition: **remove once we require the starlette release that contains #3498.**

Pinning `anyio<4.15` was the alternative, but that constrains the whole dependency tree over a test-only warning.

### Verification

Locally, on this branch: `tests/pytest/test_app_ui_page_html.py` → **14 passed**. Forcing the warning back to an error (`-W error::DeprecationWarning`) reproduces the failure — **12 errors** — confirming the filter is what's doing the work. Full unit suite: **1104 passed, 1 skipped**.