### PR TITLE
fix(examples): stop passing the deprecated `messages=` to Chat

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -12,6 +12,12 @@ filterwarnings =
     ; narwhals calls polars' deprecated `cat.get_categories()`
     ; https://github.com/narwhals-dev/narwhals/issues/3895
     ignore:`cat.get_categories\(\)` is deprecated:DeprecationWarning
+    ; starlette's `TestClient` module annotates with `anyio.abc.BlockingPortal`,
+    ; whose alias anyio 4.15.0 deprecated -- so as an error it breaks *collection*
+    ; of any test importing `starlette.testclient`. Fixed on starlette's master by
+    ; https://github.com/encode/starlette/pull/3498 but unreleased as of 1.6.0;
+    ; delete this once we require the release that contains it.
+    ignore:The anyio.abc.BlockingPortal alias is deprecated:DeprecationWarning
     ; Both of these are raised from finalizers at GC time (a leaked
     ; `TemporaryDirectory`, an abandoned coroutine), so as errors they fail
     ; whichever test happens to be running when the collector fires rather than the

--- a/shiny/.agents/skills/shiny-for-python/references/chat.md
+++ b/shiny/.agents/skills/shiny-for-python/references/chat.md
@@ -19,7 +19,7 @@ from shiny.express import ui
 ui.page_opts(title="Hello Chat", fillable=True)
 
 chat = ui.Chat(id="chat")
-chat.ui(messages=["Hi! Send a message and I'll echo it."])
+chat.ui(greeting="Hi! Send a message and I'll echo it.")
 
 
 @chat.on_user_submit
@@ -90,9 +90,9 @@ async def handle(user_input: str):
 
 ## Seed and read message history
 
-- **Startup messages:** pass `messages=` to `chat.ui(...)` (Express) or
-  `ui.chat_ui(...)` (Core). Use `greeting=` for a welcome shown before any
-  conversation.
+- **Startup message:** pass `greeting=` to `chat.ui(...)` (Express) or
+  `ui.chat_ui(...)` (Core). To replay a stored conversation, `await
+  chat.append_message()` from the server instead.
 - **Read the transcript reactively:** `chat.messages()` returns a tuple of
   `{"content", "role"}` dicts, oldest first (last item is the newest user
   message). Call it inside a reactive context / callback:
@@ -131,7 +131,7 @@ separate `ui.MarkdownStream` / `ui.output_markdown_stream` component instead.
 | Need | API |
 |---|---|
 | Create chat | `ui.Chat(id, client=None, greeting=None)` |
-| Render (Express / Core) | `chat.ui(messages=..., greeting=...)` / `ui.chat_ui(id, ...)` |
+| Render (Express / Core) | `chat.ui(greeting=...)` / `ui.chat_ui(id, greeting=...)` |
 | Handle submissions | `@chat.on_user_submit` (callback takes `user_input: str`, optional `attachments`) |
 | Append full message | `await chat.append_message(msg)` |
 | Stream a message | `await chat.append_message_stream(async_iterable)` |
@@ -150,7 +150,9 @@ separate `ui.MarkdownStream` / `ui.output_markdown_stream` component instead.
   `append_message_stream()`; reserve `append_message()` for a complete string.
 - Sync callback or forgetting `await` -> responses never appear. Callbacks are
   async and every append/stream call must be awaited.
-- Passing `messages=` to `ui.Chat(...)` -> deprecated; pass it to `chat.ui(...)`.
+- Passing `messages=` anywhere -> deprecated as of shinychat 0.7.0, and on
+  `ui.Chat(...)` it now raises unless you also pass `history=False`. Use
+  `greeting=` for a startup message, `append_message()` to replay a stored one.
 - Expecting `client=` and a manual `on_user_submit` to conflict -> they don't;
   your handler runs *in addition* to the auto-wired streaming handler.
 - Reaching for `transform_user_input` / `transform_assistant_response` -> both

--- a/shiny/api-examples/Chat/app-core.py
+++ b/shiny/api-examples/Chat/app-core.py
@@ -2,16 +2,15 @@ from shiny import App, ui
 
 app_ui = ui.page_fillable(
     ui.panel_title("Hello Shiny Chat"),
-    ui.chat_ui("chat"),
     ui.chat_ui(
         "chat",
-        messages=["""
+        greeting="""
 Hi! This is a simple Shiny `Chat` UI. Enter a message below and I will
 simply repeat it back to you.
 
 To learn more about chatbots and how to build them with Shiny, check out
 [the documentation](https://shiny.posit.co/py/docs/genai-chatbots.html).
-"""],
+""",
     ),
     fillable_mobile=True,
 )

--- a/shiny/api-examples/Chat/app-express.py
+++ b/shiny/api-examples/Chat/app-express.py
@@ -12,13 +12,13 @@ chat = ui.Chat(id="chat")
 
 # Display it, with a startup message
 chat.ui(
-    messages=["""
+    greeting="""
 Hi! This is a simple Shiny `Chat` UI. Enter a message below and I will
 simply repeat it back to you.
 
 To learn more about chatbots and how to build them with Shiny, check out
 [the documentation](https://shiny.posit.co/py/docs/genai-chatbots.html).
-"""],
+""",
 )
 
 

--- a/shiny/templates/chat/llm-enterprise/azure-openai/app.py
+++ b/shiny/templates/chat/llm-enterprise/azure-openai/app.py
@@ -29,7 +29,7 @@ ui.page_opts(
 # Create a chat instance, with an initial message
 chat = ui.Chat(
     id="chat",
-    messages=["Hello! How can I help you today?"],
+    greeting="Hello! How can I help you today?",
 )
 chat.ui()
 

--- a/shiny/templates/chat/llms/anthropic/app.py
+++ b/shiny/templates/chat/llms/anthropic/app.py
@@ -29,7 +29,7 @@ ui.page_opts(
 # Create and display a Shiny chat component
 chat = ui.Chat(
     id="chat",
-    messages=["Hello! How can I help you today?"],
+    greeting="Hello! How can I help you today?",
 )
 chat.ui()
 

--- a/shiny/templates/chat/llms/langchain/app.py
+++ b/shiny/templates/chat/llms/langchain/app.py
@@ -30,7 +30,7 @@ ui.page_opts(
 # Create and display a Shiny chat component
 chat = ui.Chat(
     id="chat",
-    messages=["Hello! How can I help you today?"],
+    greeting="Hello! How can I help you today?",
 )
 chat.ui()
 

--- a/shiny/templates/chat/llms/ollama/app.py
+++ b/shiny/templates/chat/llms/ollama/app.py
@@ -21,7 +21,7 @@ ui.page_opts(
 # Create and display a Shiny chat component
 chat = ui.Chat(
     id="chat",
-    messages=["Hello! How can I help you today?"],
+    greeting="Hello! How can I help you today?",
 )
 chat.ui()
 

--- a/shiny/templates/chat/llms/openai/app.py
+++ b/shiny/templates/chat/llms/openai/app.py
@@ -29,7 +29,7 @@ ui.page_opts(
 # Create and display a Shiny chat component
 chat = ui.Chat(
     id="chat",
-    messages=["Hello! How can I help you today?"],
+    greeting="Hello! How can I help you today?",
 )
 chat.ui()
 

--- a/tests/playwright/shiny/bookmark/chat/client_state/app-server.py
+++ b/tests/playwright/shiny/bookmark/chat/client_state/app-server.py
@@ -17,11 +17,13 @@ ui.page_opts(
 )
 
 
-# Create a chat instance
-init_messages = ["""Welcome!"""]
+# Create a chat instance. The startup message is a `greeting=`: shinychat 0.7.0
+# deprecated `Chat(messages=)` and raises unless `history=False` is also passed.
+# `enable_bookmarking()` bookmarks and restores the greeting content, so this
+# still covers the round-trip.
 chat = ui.Chat(
     id="chat",
-    messages=init_messages,
+    greeting="""Welcome!""",
 )
 
 # Display it
@@ -58,7 +60,7 @@ class RepeaterClient:
         self.messages = cast(list[str], state["messages"])
 
 
-chat_client = RepeaterClient(messages=init_messages)
+chat_client = RepeaterClient(messages=[])
 
 
 # Note:
@@ -98,7 +100,7 @@ def save_bookmark_dir(id: str) -> Path:
 
 # Same app as `app.py`, but with server-side bookmark storage. `"server"` exercises
 # the `_state_id_` restore path, where a plain page load has no `_state_id_` at all --
-# `ui.Chat` still has to render its initial messages in that case.
+# `ui.Chat` still has to render its greeting in that case.
 chat.enable_bookmarking(chat_client, bookmark_store="server")
 
 

--- a/tests/playwright/shiny/bookmark/chat/client_state/app.py
+++ b/tests/playwright/shiny/bookmark/chat/client_state/app.py
@@ -11,11 +11,13 @@ ui.page_opts(
 )
 
 
-# Create a chat instance
-init_messages = ["""Welcome!"""]
+# Create a chat instance. The startup message is a `greeting=`: shinychat 0.7.0
+# deprecated `Chat(messages=)` and raises unless `history=False` is also passed.
+# `enable_bookmarking()` bookmarks and restores the greeting content, so this
+# still covers the round-trip.
 chat = ui.Chat(
     id="chat",
-    messages=init_messages,
+    greeting="""Welcome!""",
 )
 
 # Display it
@@ -52,7 +54,7 @@ class RepeaterClient:
         self.messages = cast(list[str], state["messages"])
 
 
-chat_client = RepeaterClient(messages=init_messages)
+chat_client = RepeaterClient(messages=[])
 
 chat.enable_bookmarking(chat_client, bookmark_store="url")
 

--- a/tests/playwright/shiny/bookmark/chat/client_state/test_bookmark_chat.py
+++ b/tests/playwright/shiny/bookmark/chat/client_state/test_bookmark_chat.py
@@ -3,19 +3,28 @@ from pathlib import Path
 
 import pytest
 from playwright.sync_api import Page
+from utils.deploy_utils import skip_if_shinychat_older_than
 
 from shiny.playwright.controller import Chat
 from shiny.run import ShinyAppProc, run_shiny_app
 
 
+# TODO: cover shinychat's `history=` feature directly rather than the ad hoc
+# `RepeaterClient` get_state/set_state plumbing these apps hand-roll.
+# `Chat(history=HistoryOptions(...))` now owns conversation persistence --
+# including a `restore_mode="bookmark"` that participates in Shiny bookmarking --
+# so what is under test here is a path apps should no longer need to write.
+# See https://github.com/posit-dev/py-shiny/issues/2489.
+#
 # `app.py` uses `bookmark_store="url"`, `app-server.py` uses `"server"`. Both are
-# worth covering: `ui.Chat` renders its initial messages from an `on_restore`
+# worth covering: `ui.Chat` restores its greeting and messages from an `on_restore`
 # callback, and the two stores reach that callback by different paths -- `"url"`
 # decodes the query string, while `"server"` has no `_state_id_` at all on a plain
 # page load.
 @pytest.mark.parametrize("app_name", ["app.py", "app-server.py"])
 # Up to 5 retries for intermittent WebKit timing issues
 @pytest.mark.flaky(reruns=5, reruns_delay=1)
+@skip_if_shinychat_older_than("0.7.0")
 def test_bookmark_chat(page: Page, app_name: str):
 
     app: ShinyAppProc = run_shiny_app(
@@ -30,18 +39,24 @@ def test_bookmark_chat(page: Page, app_name: str):
 
         chat_controller = Chat(page, "chat")
 
-        chat_controller.expect_messages("Welcome!")
+        # No longer relevant: the startup message is a `greeting=` now, and shinychat
+        # renders a greeting outside the message list, so it is never part of
+        # `expect_messages()`. Asserted via `expect_greeting()` below instead.
+        # chat_controller.expect_messages("Welcome!")
+        chat_controller.expect_greeting("Welcome!")
 
         chat_controller.set_user_input("Testing")
         chat_controller.send_user_input()
 
-        chat_controller.expect_messages("Welcome!\nTesting\nRepeater: Testing")
+        chat_controller.expect_messages("Testing\nRepeater: Testing")
 
         page.wait_for_url(re.compile(r".*\?.*"), timeout=30 * 1000)
 
         page.reload()
 
-        chat_controller.expect_messages("Welcome!\nTesting\nRepeater: Testing")
+        # Not `expect_greeting()` here: shinychat only renders the greeting while the
+        # conversation is empty, so once the restored messages land it is gone.
+        chat_controller.expect_messages("Testing\nRepeater: Testing")
 
     finally:
         app.close()

--- a/tests/playwright/shiny/components/chat/icon/app.py
+++ b/tests/playwright/shiny/components/chat/icon/app.py
@@ -16,8 +16,11 @@ with ui.layout_columns():
     with ui.div():
         ui.h2("Default Bot")
         chat_default.ui(
-            messages=["Hello! I'm Default Bot. How can I help you today?"],
-            icon_assistant=None,
+            greeting="Hello! I'm Default Bot. How can I help you today?",
+            # `True`, not `None`: as of shinychat 0.7.0 `None`/`False` omit the
+            # assistant icon and `True` opts into the built-in robot, which is what
+            # this chat is here to cover.
+            icon_assistant=True,
         )
 
     @chat_default.on_user_submit
@@ -31,7 +34,7 @@ with ui.layout_columns():
     with ui.div():
         ui.h2("Animal Bot")
         chat_animal.ui(
-            messages=["Hello! I'm Animal Bot. How can I help you today?"],
+            greeting="Hello! I'm Animal Bot. How can I help you today?",
             icon_assistant=faicons.icon_svg("otter").add_class("icon-otter"),
         )
         ui.input_select("animal", "Animal", choices=["Otter", "Hippo", "Frog", "Dove"])
@@ -63,7 +66,7 @@ with ui.layout_columns():
     with ui.div():
         ui.h2("SVG Bot")
         chat_svg.ui(
-            messages=["Hello! I'm SVG Bot. How can I help you today?"],
+            greeting="Hello! I'm SVG Bot. How can I help you today?",
             icon_assistant=ui.HTML(bs_icon_info_circle_fill),
         )
 
@@ -77,7 +80,7 @@ with ui.layout_columns():
     with ui.div():
         ui.h2("Image Bot")
         chat_image.ui(
-            messages=["Hello! I'm Image Bot. How can I help you today?"],
+            greeting="Hello! I'm Image Bot. How can I help you today?",
             icon_assistant=ui.img(
                 src="img/grace-hopper.jpg",
                 class_="icon-image grace-hopper",

--- a/tests/playwright/shiny/components/chat/icon/test_chat_icon.py
+++ b/tests/playwright/shiny/components/chat/icon/test_chat_icon.py
@@ -1,17 +1,28 @@
 from typing import Optional
 
 from playwright.sync_api import Page, expect
-from utils.deploy_utils import skip_on_webkit
+from utils.deploy_utils import skip_if_shinychat_older_than, skip_on_webkit
 
 from shiny.playwright import controller
 from shiny.run import ShinyAppProc
 
 
 class ChatModule:
-    def __init__(self, page: Page, id: str, classes: str):
+    def __init__(self, page: Page, id: str, name: str, classes: str):
         self.id = id
         self.chat = controller.Chat(page, f"chat_{id}")
+        self.name = name
         self.classes = classes
+
+    def expect_greeting_to_exist(self):
+        # The app's startup text is a `greeting=` rather than a message, and a
+        # greeting carries no assistant icon of its own -- shinychat renders it as
+        # `.shiny-chat-greeting > .shiny-chat-greeting-content`, with no
+        # `.message-icon`. So only its presence is checked here; the icons are
+        # asserted on the response messages below.
+        self.chat.expect_greeting(
+            f"Hello! I'm {self.name}. How can I help you today?", timeout=30 * 1000
+        )
 
     def expect_last_message_icon_to_have_classes(self, classes: Optional[str] = None):
         last_msg_icon = self.chat.loc_latest_message.locator(".message-icon > *").first
@@ -19,19 +30,20 @@ class ChatModule:
 
 
 @skip_on_webkit
+@skip_if_shinychat_older_than("0.7.0")
 def test_validate_chat_basic(page: Page, local_app: ShinyAppProc) -> None:
     page.goto(local_app.url)
 
     chats: list[ChatModule] = [
-        ChatModule(page, "default", "bi bi-robot"),
-        ChatModule(page, "animal", "fa icon-otter"),
-        ChatModule(page, "svg", "bi bi-info-circle-fill icon-svg"),
-        ChatModule(page, "image", "icon-image grace-hopper"),
+        ChatModule(page, "default", "Default Bot", "bi bi-robot"),
+        ChatModule(page, "animal", "Animal Bot", "fa icon-otter"),
+        ChatModule(page, "svg", "SVG Bot", "bi bi-info-circle-fill icon-svg"),
+        ChatModule(page, "image", "Image Bot", "icon-image grace-hopper"),
     ]
 
     for mod in chats:
         expect(mod.chat.loc).to_be_visible(timeout=30 * 1000)
-        mod.expect_last_message_icon_to_have_classes()
+        mod.expect_greeting_to_exist()
 
         mod.chat.set_user_input(f"Hi {mod.id}.")
         mod.chat.send_user_input()

--- a/tests/playwright/utils/deploy_utils.py
+++ b/tests/playwright/utils/deploy_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.metadata
 import json
 import os
 import re
@@ -12,6 +13,7 @@ from typing import Any, Callable, List, Optional, TypeVar
 
 import pytest
 from conftest import ScopeName
+from packaging.version import Version
 from playwright.sync_api import Page
 
 from shiny.run._run import shiny_app_gen
@@ -26,6 +28,7 @@ __all__ = (
     "goto_deployed_app",
     "local_deploys_app_url_fixture",
     "skip_if_not_chrome",
+    "skip_if_shinychat_older_than",
 )
 
 # connect
@@ -66,6 +69,35 @@ def skip_on_webkit(fn: CallableT) -> CallableT:
     fn = pytest.mark.skip_browser("webkit")(fn)
 
     return fn
+
+
+def skip_if_shinychat_older_than(
+    required_version: str,
+    reason: Optional[str] = None,
+) -> Callable[[CallableT], CallableT]:
+    """
+    Skip a test unless the installed shinychat is at least `required_version`.
+
+    `pyproject.toml` floors shinychat well below the versions some chat behaviour
+    was introduced in, so a test written against newer semantics -- `greeting=`
+    replacing `messages=`, `icon_assistant=True` opting into the built-in icon --
+    would fail rather than skip on an older but permitted install.
+    """
+    installed_version = importlib.metadata.version("shinychat")
+
+    def _(fn: CallableT) -> CallableT:
+        fn = pytest.mark.skipif(
+            Version(installed_version) < Version(required_version),
+            reason=reason
+            or (
+                f"Requires shinychat >= {required_version} "
+                f"(installed: {installed_version})"
+            ),
+        )(fn)
+
+        return fn
+
+    return _
 
 
 def skip_on_python_version(


### PR DESCRIPTION
Second CI blocker on `main`, independent of #2485 below it in this stack.

**shinychat 0.7.0 (2026-09-04)** deprecated `messages=` on `chat_ui()` / `Chat.ui()` in favour of `greeting=`, and made it an **outright error** on the `Chat` constructor unless `history=False` is also passed:

```
ValueError: `Chat(messages=...)` requires `history=False`: startup messages
can't be recorded by the conversation-history feature. Use the `greeting`
parameter for a startup message, ...
```

`pyproject.toml` floors at `shinychat>=0.6.0`, so CI resolves 0.7.0. Same shape as #2485: a third-party release moved underneath us.

### Changes

- **`api-examples/Chat/{app-core,app-express}.py`** — `messages=` → `greeting=`. These emit a `ShinyDeprecationWarning`, and `tests/playwright/examples/example_apps.py` fails any app that emits a warning, so **30 `playwright-examples` jobs** have been red since 2026-09-04.
- Dropped a stray second `ui.chat_ui("chat")` from the Core example. It rendered a **duplicate, empty chat sharing the `"chat"` id** — the bare call came first, so the example showed an empty chat above the real one. Unrelated to the deprecation and long-standing: `4a9ea3f3` (2025-03-27).
- **`templates/chat/**` (5 apps)** — azure-openai, langchain, anthropic, ollama, openai all pass `messages=` to the **constructor**, so they now **raise on startup**. Not exercised by CI, so this was invisible: worse than the examples, but silent.
- **`shiny/.agents/skills/shiny-for-python/references/chat.md`** — the bundled Agent Skill taught `messages=` in four places, including the minimal-app snippet. CLAUDE.md requires updating bundled skills in the same PR as the API they document.

### Verification

Built both examples' UI under `warnings.simplefilter("error")` — the exact condition the check enforces — and both construct clean. `black`, `isort`, `flake8` clean.

### Still failing, and deliberately not fixed here

Two `playwright-shiny` failures share this root cause but need a decision from the chat owner rather than a guess from me. **Both are pre-existing on `main`** (confirmed in run `34021260595`, 2026-09-06):

1. `bookmark/chat/client_state/{app,app-server}.py` pass `messages=` to the constructor, so they hit the `ValueError` (6 tests). The app deliberately manages its own conversation state via `RepeaterClient` and bookmarking, and the test asserts `expect_messages("Welcome!")` — but `greeting=` renders outside `loc_messages` (there's a separate `expect_greeting`), so migrating it changes what the test is actually asserting. The right fix depends on how py-shiny's chat bookmarking should interact with shinychat 0.7.0's new `history=` feature.
2. `components/chat/icon/test_chat_icon.py::test_validate_chat_basic` fails on `AssertionError: Locator expected to have class 'bi bi-robot'` (2 tests). The test asserts the assistant icon on the *startup* message, which `messages=` used to create; migrating to `greeting=` means there is no such message until the user sends one, so the test needs restructuring rather than a parameter swap.