### PR TITLE
test: run session teardown in bookmark file-input restore test (#2482)

### DIFF
--- a/tests/pytest/test_test_mode.py
+++ b/tests/pytest/test_test_mode.py
@@ -906,7 +906,8 @@ async def test_snapshot_preprocess_output_namespaced(
     assert body["output"]["mod1-out1"] == "HELLO"
 
 
-def test_file_restore_handler_registers_snapshot_preprocess(
+@pytest.mark.asyncio
+async def test_file_restore_handler_registers_snapshot_preprocess(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -942,5 +943,8 @@ def test_file_restore_handler_registers_snapshot_preprocess(
     }
     restored = cast("list[Any]", handler(value, ResolvedId("file1"), session))
 
-    assert isinstance(restored, list) and len(restored) == 1
-    assert ResolvedId("file1") in session.input._snapshot_preprocessors
+    try:
+        assert isinstance(restored, list) and len(restored) == 1
+        assert ResolvedId("file1") in session.input._snapshot_preprocessors
+    finally:
+        await session._run_session_ended_tasks()


### PR DESCRIPTION
Closes #2482

### Description

In `tests/pytest/test_test_mode.py`, `test_file_restore_handler_registers_snapshot_preprocess` exercises the `shiny.file` bookmark restore handler. This handler instantiates a `tempfile.TemporaryDirectory` and registers cleanup via `session.on_ended(lambda: tempdir_root.cleanup())`.

Because the test previously exited without ending the session lifecycle, the cleanup callback never fired during the test execution. The directory was left to Python's cyclic garbage collector, intermittently emitting an unraisable `ResourceWarning: Implicitly cleaning up <TemporaryDirectory ...>` during test teardown.

### Solution

- Marked `test_file_restore_handler_registers_snapshot_preprocess` with `@pytest.mark.asyncio` and converted it to an `async def`.
- Wrapped the assertion block in a `try...finally` block that calls `await session._run_session_ended_tasks()`, ensuring the registered `on_ended` cleanup hook executes deterministically at test completion.

### Testing

- Verified that `pytest tests/pytest/test_test_mode.py -k test_file_restore_handler_registers_snapshot_preprocess` passes cleanly without unhandled warnings.
