### PR TITLE
docs(skills): document test_server() in the bundled shiny-for-python skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Enhanced `playwright.controller.Offcanvas` to support `open()`, `loc_trigger`, `loc_title`, `loc_footer`, and expectation methods `expect_title()`, `expect_footer()`, and `expect_placement()`. (#2451)
 
+* The bundled `shiny-for-python` Agent Skill now documents `shiny.testserver.test_server()` in a new `test-server` topic, so coding agents reach for in-memory server tests instead of hand-built sessions or a browser when only server logic needs checking. (#PR_NUMBER)
+
 * Stub files for `folium`, `uvicorn`, and `seaborn` are now generated with Pyrefly instead of Pyright. (Thanks, @ChidiebereNjoku!) (#2478)
 
 * The README and the `shiny skills` CLI help now explain that [`library-skills`](https://library-skills.io) must be run from your own project directory, since it installs the bundled Agent Skills of the packages that project has installed. The previous wording left that precondition implicit, so running the command from an empty directory or from a clone of py-shiny silently installed nothing. (#2447)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Enhanced `playwright.controller.Offcanvas` to support `open()`, `loc_trigger`, `loc_title`, `loc_footer`, and expectation methods `expect_title()`, `expect_footer()`, and `expect_placement()`. (#2451)
 
-* The bundled `shiny-for-python` Agent Skill now documents `shiny.testserver.test_server()` in a new `test-server` topic, so coding agents reach for in-memory server tests instead of hand-built sessions or a browser when only server logic needs checking. (#PR_NUMBER)
+* The bundled `shiny-for-python` Agent Skill now documents `shiny.testserver.test_server()` in a new `test-server` topic, so coding agents reach for in-memory server tests instead of hand-built sessions or a browser when only server logic needs checking. (#2491)
 
 * Stub files for `folium`, `uvicorn`, and `seaborn` are now generated with Pyrefly instead of Pyright. (Thanks, @ChidiebereNjoku!) (#2478)
 

--- a/shiny/.agents/skills/shiny-for-python/SKILL.md
+++ b/shiny/.agents/skills/shiny-for-python/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shiny-for-python
-description: "Building, styling, testing, debugging, or observing a Shiny for Python (py-shiny) reactive web app - `from shiny import ...`, `shiny run app.py`. Index skill: read this, then open the linked reference for the task. Covers dashboard design and visual QA; card toolbars and accessible icons; interactive Plotly charts and maps; reactivity (calc/effect/value/event/req/isolate); Express vs Core; modules; layout, navigation, dynamic UI, and theming; plots, data frames, files, and custom renderers; LLM chat and Markdown streaming; notifications, modals, progress, and background tasks; bookmarking; custom JS components; session lifecycle; Playwright testing; debugging; and OpenTelemetry. Use when writing or changing any Shiny for Python app, especially an analytical dashboard, or when tempted to hand-roll what the framework provides - custom HTML tables, fake tabs, DOM manipulation, blocking reactive work, polling loops, or print-debugging server state."
+description: "Building, styling, testing, debugging, or observing a Shiny for Python (py-shiny) reactive web app - `from shiny import ...`, `shiny run app.py`. Index skill: read this, then open the linked reference for the task. Covers dashboard design and visual QA; card toolbars and accessible icons; interactive Plotly charts and maps; reactivity (calc/effect/value/event/req/isolate); Express vs Core; modules; layout, navigation, dynamic UI, and theming; plots, data frames, files, and custom renderers; LLM chat and Markdown streaming; notifications, modals, progress, and background tasks; bookmarking; custom JS components; session lifecycle; in-memory server testing (`test_server`) and Playwright testing; debugging; and OpenTelemetry. Use when writing or changing any Shiny for Python app, especially an analytical dashboard, or when tempted to hand-roll what the framework provides - custom HTML tables, fake tabs, DOM manipulation, blocking reactive work, polling loops, or print-debugging server state."
 ---
 
 # Shiny for Python
@@ -78,6 +78,7 @@ reference file before writing code** for that area.
 
 | Topic | Use when | Reference |
 |---|---|---|
+| Test server | Testing server logic in memory with `test_server()` — set inputs, assert on outputs/exports, module scopes; no browser | `references/test-server.md` |
 | Testing | End-to-end Playwright tests — launching an app under pytest, locating and asserting on UI | `references/testing.md` |
 | Debugging | Inspecting server-side reactive/input/output state; exposing values to a test harness | `references/debugging.md` |
 | OpenTelemetry | OTel tracing/profiling of reactive execution; exporting spans to a backend | `references/otel.md` |

--- a/shiny/.agents/skills/shiny-for-python/references/test-server.md
+++ b/shiny/.agents/skills/shiny-for-python/references/test-server.md
@@ -1,0 +1,174 @@
+# Testing server logic in memory with `test_server()`
+
+## Overview
+
+`shiny.testserver.test_server()` runs an app's server function against a mock
+connection — no browser, no network, no Playwright. Set inputs, let the
+reactive graph settle, assert on outputs, all in an ordinary (non-async) pytest
+test. It is the Python counterpart to R Shiny's `testServer()`.
+
+Use it for server logic: calcs, output values, error paths, modules. Use
+Playwright (`references/testing.md`) for anything the user sees or clicks —
+layout, widgets, client-side behavior. Do **not** call the server function
+directly with hand-built `Inputs`/`Session` objects, and do not launch a
+subprocess just to check an output's value.
+
+## Setup
+
+Nothing beyond `pytest`. `test_server` ships with shiny.
+
+## Write a test
+
+```python
+# app.py
+from shiny import App, Inputs, Outputs, Session, render, ui
+
+app_ui = ui.page_fluid(
+    ui.input_numeric("n", "N", 10),
+    ui.output_text("doubled"),
+)
+
+def server(input: Inputs, output: Outputs, session: Session):
+    @render.text
+    def doubled():
+        if input.n() < 0:
+            raise ValueError("n must be positive")
+        return str(input.n() * 2)
+
+app = App(app_ui, server)
+```
+
+```python
+# test_app.py
+from shiny.testserver import test_server
+
+def test_doubles():
+    with test_server() as ts:          # app.py beside this test file
+        ts.set_inputs(n=10)
+        assert ts.is_ok
+        assert ts.get_output("doubled") == "20"
+
+        ts.set_inputs(n=21)            # unnamed inputs keep their values
+        assert ts.get_output("doubled") == "42"
+
+def test_reports_error():
+    with test_server() as ts:
+        ts.set_inputs(n=-1)
+        assert ts.is_ok is False
+        failed = ts.get_output("doubled")
+        assert failed.status == "error"
+        assert "must be positive" in failed.error
+```
+
+The session **must** be used as a context manager; `with` tears the app down
+even when an assertion fails. `set_inputs()` flushes the reactive graph before
+returning, so outputs are already current — no waiting or retrying.
+
+## What `test_server()` accepts
+
+```python
+test_server()                 # "app.py" beside the test file (Core or Express)
+test_server("myapp.py")       # another file, relative to the test file
+test_server(Path("/abs/app.py"))
+test_server(app)              # a shiny.App instance
+test_server(server_fn)        # a bare server function, wrapped in an empty-UI app
+```
+
+Optional keywords: `client_data=` (see below) and `timeout_secs=5.0` (per
+flush, including the initial one — raise it for slow startups such as a cold
+matplotlib font cache).
+
+## Values and their status
+
+`get_input()`, `get_output()`, and `get_export()` return a `TestServerValue`
+that **compares equal to its underlying value**, so `== "20"` needs no
+unwrapping. Each has `.status`, `.value`, `.error`, `.traceback`:
+
+| `status` | Meaning |
+|---|---|
+| `"ok"` | Rendered; `.value` is the JSON-round-tripped value the browser would receive |
+| `"error"` | The render function raised; see `.error` and `.traceback` |
+| `"silent"` | Never rendered — a dependency was unavailable (an unset input, or `req()` failed) |
+
+Comparing a non-`"ok"` value with `==` raises `ValueError` rather than
+returning `False`, so a broken output cannot pass a `!=` assertion by
+accident. Asking for an id that does not exist raises `KeyError`.
+
+`ts.get_export("name")` reads values registered with
+`shiny.testmode.export_test_values()` — internal reactives that have no output
+(see `references/debugging.md`).
+
+## Modules
+
+Module ids are namespaced, so either use the full id or take a scope:
+
+```python
+def test_counter_module():
+    with test_server(app_server) as ts:
+        ts.set_inputs(**{"counter-n": 7})
+        assert ts.get_output("counter-label") == "n=7"
+
+        with ts.make_scope("counter") as counter:   # bare ids inside the module
+            counter.set_inputs(n=8)
+            assert counter.get_output("label") == "n=8"
+```
+
+Nested modules chain: `ts.make_scope("outer").make_scope("inner")`. Express
+modules use the same ids.
+
+## Client data (plots and URL readers)
+
+A browser normally reports output sizes, pixel ratio, and URL parts. Without
+them `render.plot` and `session.clientdata.url_*()` would be `"silent"`.
+`test_server` sends `DEFAULT_CLIENT_DATA` stand-ins automatically; override
+when a test cares:
+
+```python
+with test_server(client_data={"output_width": 300}) as ts:   # every output
+    assert ts.get_output("plot").status == "ok"
+
+with test_server() as ts:                                     # one output, mid-test
+    ts.set_inputs(**{".clientdata_output_plot_width": 300})
+```
+
+## Snapshots and fixtures
+
+```python
+import pytest
+from shiny.testserver import test_server
+
+@pytest.fixture            # keep function-scoped: a session remembers its inputs
+def ts():
+    with test_server("myapp.py") as session:
+        yield session
+
+def test_everything(ts):
+    ts.set_inputs(n=10)
+    values = ts.to_values()   # TestServerValues: .is_ok, .inputs, .outputs, .exports
+    as_dict = dict(ts)        # plain JSON-ready data
+    assert values.outputs["doubled"].value == "20"
+```
+
+Both forms are copies and stay valid after the `with` block closes.
+
+## Async tests
+
+`test_server()` drives its own event loop and cannot run inside a running one.
+In an `async def` test use `test_server_async()` — same API, but `async with`
+and `await ts.set_inputs(...)` / `await ts.flush()`.
+
+## Common mistakes
+
+- `RuntimeError` about a running event loop → the test is `async`; switch to
+  `test_server_async()`.
+- Output is `"silent"` → an input it reads was never set, or a `req()` failed.
+  Set the input, then read again.
+- Plot output is `"silent"` and you disabled client data → pass
+  `client_data=` with `output_width`/`output_height`.
+- `KeyError` for a module's output → the id is namespaced
+  (`"counter-label"`), or use `make_scope("counter")`.
+- Tests interfere with each other → the fixture is module- or session-scoped;
+  make it function-scoped.
+- `TimeoutError` on startup → the app is slow to import; raise `timeout_secs=`.
+- Forgot the `with` → the session never starts. `test_server()` returns an
+  unstarted session; always enter it.

--- a/shiny/.agents/skills/shiny-for-python/references/test-server.md
+++ b/shiny/.agents/skills/shiny-for-python/references/test-server.md
@@ -163,8 +163,6 @@ and `await ts.set_inputs(...)` / `await ts.flush()`.
   `test_server_async()`.
 - Output is `"silent"` → an input it reads was never set, or a `req()` failed.
   Set the input, then read again.
-- Plot output is `"silent"` and you disabled client data → pass
-  `client_data=` with `output_width`/`output_height`.
 - `KeyError` for a module's output → the id is namespaced
   (`"counter-label"`), or use `make_scope("counter")`.
 - Tests interfere with each other → the fixture is module- or session-scoped;

--- a/shiny/.agents/skills/shiny-for-python/references/testing.md
+++ b/shiny/.agents/skills/shiny-for-python/references/testing.md
@@ -8,6 +8,11 @@ app in a subprocess. Use them instead of hand-written CSS selectors, raw
 locators, or `time.sleep()` — controller `expect_*` methods auto-wait and
 auto-retry.
 
+Playwright tests what the user sees. To test server logic alone — output
+values, calcs, error paths, modules — without a browser, use
+`shiny.testserver.test_server()` instead (`references/test-server.md`); it is
+faster and needs no Playwright install.
+
 ## Setup
 
 ```bash


### PR DESCRIPTION
## Summary

#2470 added `shiny.testserver.test_server()` but the bundled `shiny-for-python` Agent Skill did not mention it, so coding agents using the skill still reach for Playwright (or hand-built sessions) when only server logic needs testing.

- New `references/test-server.md`: what `test_server()` accepts, `set_inputs`/`get_output`/`get_export`, `TestServerValue` statuses (`ok`/`error`/`silent`), module scopes, client data defaults, fixtures/snapshots, `test_server_async`, common mistakes.
- Index row in `SKILL.md` (Testing & observability) plus a mention in the umbrella description.
- Cross-link from `references/testing.md` pointing server-logic tests at `test_server()`.
- CHANGELOG entry.

## Validation

- `pytest tests/pytest/test_packaging.py` passes.
- `uvx --from skills-ref agentskills validate shiny/.agents/skills/shiny-for-python` reports a valid skill.