### PR TITLE
fix(testserver): report a silenced output, and rename the never-rendered status

### DIFF
--- a/shiny/.agents/skills/shiny-for-python/references/test-server.md
+++ b/shiny/.agents/skills/shiny-for-python/references/test-server.md
@@ -168,6 +168,9 @@ and `await ts.set_inputs(...)` / `await ts.flush()`.
   `test_server_async()`.
 - Output is `"silent"` → an input it reads was never set, or a `req()` failed.
   Set the input, then read again.
+- Output is `"never-rendered"` → it has not run at all, usually because it is
+  hidden and so suspended. Make it visible (e.g. drop `output_hidden` from
+  `client_data=`).
 - `KeyError` for a module's output → the id is namespaced
   (`"counter-label"`), or use `make_scope("counter")`.
 - Tests interfere with each other → the fixture is module- or session-scoped;

--- a/shiny/.agents/skills/shiny-for-python/references/test-server.md
+++ b/shiny/.agents/skills/shiny-for-python/references/test-server.md
@@ -88,11 +88,16 @@ unwrapping. Each has `.status`, `.value`, `.error`, `.traceback`:
 |---|---|
 | `"ok"` | Rendered; `.value` is the JSON-round-tripped value the browser would receive |
 | `"error"` | The render function raised; see `.error` and `.traceback` |
-| `"silent"` | Never rendered — a dependency was unavailable (an unset input, or `req()` failed) |
+| `"silent"` | The latest render produced nothing, so the browser blanks it — a dependency was unavailable (an unset input, or `req()` failed) |
+| `"never-rendered"` | Has not run at all yet, so it has produced no value, error, or silent render |
 
 Comparing a non-`"ok"` value with `==` raises `ValueError` rather than
 returning `False`, so a broken output cannot pass a `!=` assertion by
 accident. Asking for an id that does not exist raises `KeyError`.
+
+`"silent"` describes the *latest* render: an output that rendered once and is
+then silenced by a failing `req()` reports `"silent"` with no value, matching
+the blank the browser shows rather than the stale value.
 
 `ts.get_export("name")` reads values registered with
 `shiny.testmode.export_test_values()` — internal reactives that have no output

--- a/shiny/session/_session.py
+++ b/shiny/session/_session.py
@@ -178,6 +178,16 @@ class OutBoundMessageQueues:
         is served over HTTP, and neither should carry a stack trace. Read
         in-process by `shiny.pytest.test_server`.
         """
+        self.test_silent: set[str] = set()
+        """
+        Outputs whose most recent render produced nothing (a `req()` failure), in
+        test mode only.
+
+        `test_values`/`test_errors` keep the *last* value an output computed, so
+        without this there is no way to tell that the latest render sent `None`
+        to the client and blanked the output. Cleared for an output as soon as it
+        computes a value or errors again.
+        """
 
     def reset(self) -> None:
         self.values.clear()
@@ -193,19 +203,23 @@ class OutBoundMessageQueues:
             self.test_values[id] = value
             self.test_errors.pop(id, None)
             self.test_tracebacks.pop(id, None)
+            self.test_silent.discard(id)
 
     def set_silent(self, id: str) -> None:
         """
         Record that computing `id`'s value was silently suppressed (e.g. via
-        `req()`), without touching the persistent test-mode record.
+        `req()`).
 
         Unlike `set_value(id, None)`, this leaves `test_values`/`test_errors`
         untouched, so the test-mode snapshot retains the output's last
         computed value or error (matching Shiny for R) instead of reporting
-        `None`.
+        `None`. The suppression itself is recorded in `test_silent`, which is
+        what tells a test that the latest render produced nothing.
         """
         self.values[id] = None
         self.errors.pop(id, None)
+        if self._record_test_values:
+            self.test_silent.add(id)
 
     def set_error(self, id: str, error: Any, traceback_text: str = "") -> None:
         self.errors[id] = error
@@ -216,6 +230,7 @@ class OutBoundMessageQueues:
             self.test_errors[id] = error
             self.test_tracebacks[id] = traceback_text
             self.test_values.pop(id, None)
+            self.test_silent.discard(id)
 
     def add_input_message(self, id: str, message: dict[str, Any]) -> None:
         self.input_messages.append({"id": id, "message": message})

--- a/shiny/testserver/_test_server.py
+++ b/shiny/testserver/_test_server.py
@@ -73,7 +73,7 @@ _TIMEOUT_HINT = (
 """Appended to every timeout message; the knob is not obvious from the error."""
 
 ValueKind = Literal["input", "output", "export"]
-ValueStatus = Literal["ok", "error", "silent"]
+ValueStatus = Literal["ok", "error", "silent", "never-rendered"]
 
 
 @dataclass(frozen=True, eq=False)
@@ -109,9 +109,15 @@ class TestServerValue:
     status
         * `"ok"` — produced a value, available as `value`.
         * `"error"` — raised; see `error` and `traceback`.
-        * `"silent"` — never rendered, because a dependency was unavailable. An
-          output reading an input that has not been set is silent, and so is a
-          `render.plot` until the client's width and height are supplied.
+        * `"silent"` — the most recent render produced nothing, because a
+          `req()` failed (any `SilentException`). The browser blanks such an
+          output, so it has no `value` here either, even if an earlier render
+          produced one. An output reading an input that has not been set is
+          silent, and so is a `render.plot` until the client's width and height
+          are supplied.
+        * `"never-rendered"` — has not run at all yet, so it has produced
+          neither a value, nor an error, nor a silent render. An output that is
+          hidden (and so suspended) is never-rendered until it becomes visible.
 
         There is no status for "does not exist": a `TestServerValue` always
         describes something real, and asking for a name that is not there raises
@@ -186,10 +192,18 @@ class TestServerValue:
         # would let `!=` pass while hiding why.
         if self.status == "silent":
             raise ValueError(
+                f"{self.kind.capitalize()} {self.name!r} rendered nothing, so"
+                " there is no value to compare against: a `req()` failed, which"
+                " blanks the output. A dependency was unavailable: an input that"
+                " was never set, or a size the client never reported. Set what it"
+                " needs first, or check `.status`."
+            )
+        if self.status == "never-rendered":
+            raise ValueError(
                 f"{self.kind.capitalize()} {self.name!r} never rendered, so there"
-                " is no value to compare against. A dependency was unavailable:"
-                " an input that was never set, or a size the client never"
-                " reported. Set what it needs first, or check `.status`."
+                " is no value to compare against. It has not run at all -- a"
+                " hidden output stays suspended until it becomes visible. Check"
+                " `.status`."
             )
         if self.status == "error":
             raise ValueError(
@@ -662,13 +676,17 @@ class AsyncTestServerSession:
             for name, value in snapshot.get("input", {}).items()
         }
 
-        # `set_silent()` deliberately records nothing, so a registered output with
-        # no recorded value and no recorded error never rendered.
+        # The snapshot keeps each output's last computed value even when the
+        # latest render was silenced (Shiny for R parity), so `test_silent` --
+        # which only holds outputs whose latest render produced nothing -- is
+        # what distinguishes "blank now" from "never ran".
         raw_outputs: Dict[str, Any] = snapshot.get("output", {})
         self._current_outputs = {}
         for name in self._session.output._outputs.keys():
             error = _snapshot_error(raw_outputs.get(name))
-            if error is not None:
+            if name in queues.test_silent:
+                self._current_outputs[name] = TestServerValue(name, "output", "silent")
+            elif error is not None:
                 self._current_outputs[name] = TestServerValue(
                     name,
                     "output",
@@ -681,7 +699,9 @@ class AsyncTestServerSession:
                     name, "output", "ok", raw_outputs[name]
                 )
             else:
-                self._current_outputs[name] = TestServerValue(name, "output", "silent")
+                self._current_outputs[name] = TestServerValue(
+                    name, "output", "never-rendered"
+                )
 
         self._current_exports = {}
         for name, value in snapshot.get("export", {}).items():
@@ -863,8 +883,8 @@ class AsyncTestServerSession:
         Returns
         -------
         :
-            A `TestServerValue`, with `status` `"silent"` if the output never
-            rendered. It compares equal to the value itself, so
+            A `TestServerValue`, with `status` `"silent"` if the output's latest
+            render produced nothing. It compares equal to the value itself, so
             `session.get_output("txt") == "hi"` works.
 
         Raises
@@ -1166,8 +1186,8 @@ class TestServerSession:
         Returns
         -------
         :
-            A `TestServerValue`, with `status` `"silent"` if the output never
-            rendered. It compares equal to the value itself, so
+            A `TestServerValue`, with `status` `"silent"` if the output's latest
+            render produced nothing. It compares equal to the value itself, so
             `session.get_output("txt") == "hi"` works.
 
         Raises

--- a/tests/pytest/test_test_mode.py
+++ b/tests/pytest/test_test_mode.py
@@ -88,8 +88,10 @@ def test_outbound_queue_no_record_when_off() -> None:
     omq = OutBoundMessageQueues(record_test_values=False)
     omq.set_value("out1", 42)
     omq.set_error("out2", {"message": "boom"})
+    omq.set_silent("out3")
     assert omq.test_values == {}
     assert omq.test_errors == {}
+    assert omq.test_silent == set()
 
 
 def test_outbound_queue_set_silent_retains_last_value() -> None:
@@ -104,6 +106,16 @@ def test_outbound_queue_set_silent_retains_last_value() -> None:
     # Persistent test-mode record: untouched, still reports the last value.
     assert omq.test_values == {"out1": 42}
     assert omq.test_errors == {}
+    # ...but the silencing itself is recorded, so a test can tell that the
+    # latest render produced nothing and the client went blank.
+    assert omq.test_silent == {"out1"}
+
+    # A later render supersedes the silence.
+    omq.set_value("out1", 43)
+    assert omq.test_silent == set()
+    omq.set_silent("out1")
+    omq.set_error("out1", {"message": "boom"})
+    assert omq.test_silent == set()
 
 
 def test_outbound_queue_set_silent_retains_last_error() -> None:
@@ -127,6 +139,7 @@ def test_outbound_queue_set_silent_on_first_run_leaves_absent() -> None:
     assert omq.values["out1"] is None
     assert "out1" not in omq.test_values
     assert "out1" not in omq.test_errors
+    assert omq.test_silent == {"out1"}
 
 
 def test_app_session_wires_record_flag(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/pytest/test_test_server.py
+++ b/tests/pytest/test_test_server.py
@@ -13,7 +13,7 @@ from typing import Callable
 
 import pytest
 
-from shiny import App, Inputs, Outputs, Session, module, reactive, render, ui
+from shiny import App, Inputs, Outputs, Session, module, reactive, render, req, ui
 from shiny.testmode import export_test_values
 from shiny.testserver import (
     AsyncTestServerScope,
@@ -864,7 +864,7 @@ def test_test_server_value_without_a_value_refuses_to_compare():
             lambda: silent != None,  # noqa: E711
             lambda: silent in [None],  # pyright: ignore[reportUnnecessaryContains]
         ):
-            with pytest.raises(ValueError, match="never rendered"):
+            with pytest.raises(ValueError, match="rendered nothing"):
                 comparison()
 
         with pytest.raises(ValueError, match="raised, so there is no value"):
@@ -902,7 +902,7 @@ def test_test_server_value_statuses():
 
     with test_server(server) as ts:
         assert ts.get_output("fine").status == "ok"
-        # Never rendered: `input.n()` is unset, so it raised a silent exception.
+        # Silent: `input.n()` is unset, so it raised a silent exception.
         assert ts.get_output("needs_input").status == "silent"
         assert ts.get_output("boom").status == "error"
         # There is no status for "does not exist"; the lookup fails instead, and
@@ -917,6 +917,52 @@ def test_test_server_value_statuses():
         ts.set_inputs(n=5)
         assert ts.get_output("needs_input") == "5"
         assert ts.get_output("needs_input").status == "ok"
+
+
+def test_test_server_reports_an_output_that_was_just_silenced():
+    def server(input: Inputs, output: Outputs, session: Session):
+        @render.text
+        def txt():
+            req(input.n() is not None and input.n() >= 0)
+            return f"ok: {input.n()}"
+
+    with test_server(server) as ts:
+        ts.set_inputs(n=1)
+        assert ts.get_output("txt") == "ok: 1"
+
+        # The browser blanks the output when `req()` fails, so reporting the
+        # previous render's value here would let a test assert something the
+        # user cannot see.
+        ts.set_inputs(n=-1)
+        silenced = ts.get_output("txt")
+        assert silenced.status == "silent"
+        assert silenced.value is MISSING
+        assert dict(silenced) == {"name": "txt", "kind": "output", "status": "silent"}
+
+        # And it recovers once the requirement is met again.
+        ts.set_inputs(n=2)
+        assert ts.get_output("txt") == "ok: 2"
+
+
+def test_test_server_output_that_never_ran_is_never_rendered():
+    def server(input: Inputs, output: Outputs, session: Session):
+        @render.text
+        def hidden():
+            return "never asked for"
+
+    # A hidden output's effect stays suspended, so it produces nothing at all --
+    # which is a different fact from a render that was silenced.
+    with test_server(server, client_data={"output_hidden": True}) as ts:
+        never = ts.get_output("hidden")
+        assert never.status == "never-rendered"
+        assert never.value is MISSING
+        assert repr(never) == (
+            "TestServerValue('hidden', kind='output', status='never-rendered')"
+        )
+        with pytest.raises(ValueError, match="never rendered"):
+            assert never == "never asked for"
+        # Not a failure: nothing went wrong, it simply was not shown.
+        assert ts.is_ok is True
 
 
 def test_test_server_value_records_a_per_item_traceback():


### PR DESCRIPTION
Fixes both `test_server()` status issues; they are coupled, since the second frees the name the first needs.

### #2492 — a silent `req()` failure is invisible

`set_silent()` left the test-mode record untouched, so `get_output()` kept reporting the *previous* render's value with `status="ok"` while the browser blanked the output. A test could pass while asserting a value the user cannot see.

`OutBoundMessageQueues` now records the suppression as its own fact in `test_silent`, discarded as soon as the output computes a value or errors again. `test_values`/`test_errors` still retain the last computed value (Shiny for R parity), so `_build_test_snapshot()` and the HTTP snapshot are unchanged — only `test_server` reads the new set, the same way it already reads `test_tracebacks`.

```python
ts.set_inputs(n=1)
assert ts.get_output("txt") == "ok: 1"
ts.set_inputs(n=-1)                                # fails req()
assert ts.get_output("txt").status == "silent"     # now true
assert ts.get_output("txt").value is MISSING       # no stale value
```

### #2493 — `"silent"` meant "never rendered"

With silence observable, `"silent"` now means what Shiny already taught: *this* render produced nothing. The state it used to name — an output that has not run at all — is `"never-rendered"`.

In practice most outputs that used to report `"silent"` still do, because reading an unset input raises a `SilentException`. `"never-rendered"` is the narrower state of an output whose effect never ran, e.g. a hidden (suspended) one.

`__eq__` now has a distinct message per state; `keys()`/`dict()`/`repr()` treat both the same as before (no `value`, no `error`).

No changelog entry: `test_server()` is itself unreleased (#2470), so its documented behavior is just what ships.

### Verification

`.venv/bin/python -m pytest tests/pytest -q` → 1208 passed, 1 skipped. `uv run make format check-lint check-types` and `make check-pyright` clean. New tests cover the silenced-after-ok transition, the `never-rendered` state, and the queue-level clearing rules; the bundled `shiny-for-python` skill's status table is updated.
