### PR TITLE
docs(testserver): name reactive cycles in the flush timeout hint

### DIFF
--- a/shiny/testserver/_test_server.py
+++ b/shiny/testserver/_test_server.py
@@ -68,7 +68,9 @@ produces nothing, and `session.clientdata.url_pathname()` never resolves.
 
 _TIMEOUT_HINT = (
     " Raise `timeout_secs=` if the app is simply slow to start -- a cold"
-    " matplotlib font cache, say."
+    " matplotlib font cache, say. A flush that never finishes no matter how"
+    " long you wait is usually a reactive cycle: two effects that each write a"
+    " value the other reads keep re-queueing each other forever."
 )
 """Appended to every timeout message; the knob is not obvious from the error."""
 

--- a/tests/pytest/test_test_server.py
+++ b/tests/pytest/test_test_server.py
@@ -463,6 +463,33 @@ def test_test_server_set_inputs_timeout_when_awaiting():
             s.set_inputs(hang=1)
 
 
+def test_test_server_set_inputs_timeout_on_reactive_cycle():
+    """
+    Two effects that each write what the other reads re-queue each other forever,
+    so the flush never finishes. The effects yield the loop between runs, so this
+    times out rather than hanging the test process.
+    """
+
+    def server(input: Inputs, output: Outputs, session: Session):
+        a = reactive.value(0)
+        b = reactive.value(0)
+
+        @reactive.effect
+        def _():
+            val = input.go()
+            if val is not None and val > 0:
+                a.set(b() + 1)
+
+        @reactive.effect
+        def _():
+            if a() > 0:
+                b.set(a() + 1)
+
+    with test_server(server, timeout_secs=0.2) as s:
+        with pytest.raises(TimeoutError, match="reactive cycle"):
+            s.set_inputs(go=1)
+
+
 @pytest.mark.asyncio
 async def test_test_server_inside_running_loop_points_at_async_variant():
     def server(input: Inputs, output: Outputs, session: Session):

--- a/tests/pytest/test_test_server.py
+++ b/tests/pytest/test_test_server.py
@@ -485,7 +485,10 @@ def test_test_server_set_inputs_timeout_on_reactive_cycle():
             if a() > 0:
                 b.set(a() + 1)
 
-    with test_server(server, timeout_secs=0.2) as s:
+    # The cycle never terminates, so the timeout only decides how long the test
+    # waits, not whether it fails. Keep enough headroom that a loaded runner
+    # cannot trip the same timeout during session startup instead.
+    with test_server(server, timeout_secs=1.0) as s:
         with pytest.raises(TimeoutError, match="reactive cycle"):
             s.set_inputs(go=1)
 


### PR DESCRIPTION
## Problem

A `test_server()` flush that never finishes has two causes, but `_TIMEOUT_HINT` only named one:

> Raise `timeout_secs=` if the app is simply slow to start -- a cold matplotlib font cache, say.

The other cause is a reactive cycle: two effects that each write a value the other reads re-queue each other forever, so `ReactiveEnvironment._flush_sequential()` never drains and `on_flushed` never fires. For that case the hint's advice is exactly wrong — you bump `timeout_secs` to 30s and wait 30s for the same failure.

## Change

The hint now names the cycle case too. Plus a regression test covering it.

No behavior change. A cycle already fails with a `TimeoutError` rather than hanging the test process: the effects `await` between runs, so `wait_for` in `set_inputs()` can fire, and `_cleanup()` cancels the still-spinning session task on exit.

## Not done

No cycle detection in the reactive core. A browser session with the same app hangs identically, so capping flush iterations only in `test_server` would make tests disagree with production, and capping them in the core means picking a number that also caps legitimate cascades. The remaining gap is a cycle whose body blocks without awaiting — that holds the event loop and no timeout catches it — which is worth revisiting if anyone actually hits it.

## Verification

- `uv run make format check-lint check-types` — clean
- `uv run make check-pyright` — 0 errors
- `pytest tests/pytest/test_test_server.py -k timeout` — 3 passed