### PR TITLE
ci: skip jobs not needed for the PyPI release

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -73,6 +73,7 @@ jobs:
     # Pyrefly.
     name: "Pyright"
     runs-on: ubuntu-latest
+    if: github.event_name != 'release'
     steps:
       - uses: actions/checkout@v6
         with:
@@ -422,6 +423,7 @@ jobs:
 
   test-narwhals-integration:
     runs-on: ubuntu-latest
+    if: github.event_name != 'release'
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
`pyright` and `test-narwhals-integration` were the only jobs still running on a `release` event without feeding the `pypi` publish job, so both now carry `if: github.event_name != 'release'` like the other non-release jobs.

A release event now runs only:

- `check` — `pypi` depends on it
- `pypi` — the publish

`pytest.yaml` is the only workflow with a `release` trigger, so nothing else needed gating.

Left alone: `check`'s full 15-way OS/Python matrix on release. It is the gate `pypi` waits on; narrowing it is a separate call.