### PR TITLE
build(docs): require shinylive >= 0.8.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,7 +171,7 @@ doc = [
     "jupyter",
     "jupyter_client < 8.0.0",
     "tabulate",
-    "shinylive>=0.8.11",
+    "shinylive>=0.8.12",
     "pydantic>=2.7.4",
     "quartodoc>=0.8.1",
     "griffe>=1.3.2,<2.0.0",


### PR DESCRIPTION
Post-release docs bump: raises the `[doc]` extra's shinylive floor to [0.8.12](https://pypi.org/project/shinylive/0.8.12/), which ships shinylive web assets v0.10.15 (bundling shiny 1.8.0 and shinyswatch 0.13.0).

Verified on PyPI before opening: `shinylive-0.8.12-py3-none-any.whl` and `shinylive-0.8.12.tar.gz` are both present.